### PR TITLE
Include private members in API hash of traits. (sbt/sbt#2160)

### DIFF
--- a/internal/apiinfo/src/main/scala/xsbt/api/HashAPI.scala
+++ b/internal/apiinfo/src/main/scala/xsbt/api/HashAPI.scala
@@ -60,6 +60,8 @@ final class HashAPI(includePrivate: Boolean, includeParamNames: Boolean, include
     }
   }
 
+  private[this] def isTrait(cl: ClassLike) = cl.definitionType == DefinitionType.Trait
+
   private[this] final val ValHash = 1
   private[this] final val VarHash = 2
   private[this] final val DefHash = 3
@@ -184,7 +186,7 @@ final class HashAPI(includePrivate: Boolean, includeParamNames: Boolean, include
     extend(ClassHash)
     hashParameterizedDefinition(c)
     hashType(c.selfType)
-    hashStructure(c.structure, includeDefinitions)
+    hashStructure(c.structure, includeDefinitions, isTrait(c))
   }
   def hashField(f: FieldLike): Unit = {
     f match {
@@ -343,14 +345,14 @@ final class HashAPI(includePrivate: Boolean, includeParamNames: Boolean, include
     hashType(a.baseType)
     hashAnnotations(a.annotations)
   }
-  final def hashStructure(structure: Structure, includeDefinitions: Boolean) =
-    visit(visitedStructures, structure)(structure => hashStructure0(structure, includeDefinitions))
-  def hashStructure0(structure: Structure, includeDefinitions: Boolean): Unit = {
+  final def hashStructure(structure: Structure, includeDefinitions: Boolean, isTrait: Boolean = false) =
+    visit(visitedStructures, structure)(structure => hashStructure0(structure, includeDefinitions, isTrait))
+  def hashStructure0(structure: Structure, includeDefinitions: Boolean, isTrait: Boolean = false): Unit = {
     extend(StructureHash)
     hashTypes(structure.parents, includeDefinitions)
-    if (includeDefinitions) {
-      hashDefinitions(structure.declared, false)
-      hashDefinitions(structure.inherited, false)
+    if (includeDefinitions || isTrait) {
+      hashDefinitions(structure.declared, isTrait)
+      hashDefinitions(structure.inherited, isTrait)
     }
   }
   def hashParameters(parameters: Seq[TypeParameter], base: Type): Unit =

--- a/internal/apiinfo/src/main/scala/xsbt/api/HashAPI.scala
+++ b/internal/apiinfo/src/main/scala/xsbt/api/HashAPI.scala
@@ -278,7 +278,7 @@ final class HashAPI(includePrivate: Boolean, includeParamNames: Boolean, include
     hashSeq(ts, (t: Type) => hashType(t, includeDefinitions))
   def hashType(t: Type, includeDefinitions: Boolean = true): Unit =
     t match {
-      case s: Structure     => hashStructure(s, includeDefinitions)
+      case s: Structure     => hashStructure(s, includeDefinitions, isTrait = false)
       case e: Existential   => hashExistential(e)
       case c: Constant      => hashConstant(c)
       case p: Polymorphic   => hashPolymorphic(p)
@@ -345,8 +345,14 @@ final class HashAPI(includePrivate: Boolean, includeParamNames: Boolean, include
     hashType(a.baseType)
     hashAnnotations(a.annotations)
   }
-  final def hashStructure(structure: Structure, includeDefinitions: Boolean, isTrait: Boolean = false) =
+  @deprecated("Use the overload that indicates if the definition is a trait.", "0.14")
+  final def hashStructure(structure: Structure, includeDefinitions: Boolean): Unit =
+    hashStructure(structure, includeDefinitions, isTrait = false)
+  final def hashStructure(structure: Structure, includeDefinitions: Boolean, isTrait: Boolean = false): Unit =
     visit(visitedStructures, structure)(structure => hashStructure0(structure, includeDefinitions, isTrait))
+  @deprecated("Use the overload that indicates if the definition is a trait.", "0.14")
+  def hashStructure0(structure: Structure, includeDefinitions: Boolean): Unit =
+    hashStructure0(structure, includeDefinitions, isTrait = false)
   def hashStructure0(structure: Structure, includeDefinitions: Boolean, isTrait: Boolean = false): Unit = {
     extend(StructureHash)
     hashTypes(structure.parents, includeDefinitions)


### PR DESCRIPTION
This is a port of sbt/sbt#2160.

I've included both commits, particularly the second that simply added back overloads to restore the binary compatibility. It's not required here, should I remove it?
