### PR TITLE
Configure classfile manager

### DIFF
--- a/incrementalcompiler/src/main/scala/sbt/internal/inc/IncrementalCompiler.scala
+++ b/incrementalcompiler/src/main/scala/sbt/internal/inc/IncrementalCompiler.scala
@@ -33,7 +33,7 @@ object IC extends IncrementalCompiler[Analysis, AnalyzingCompiler] {
       val compilers = in.compilers; import compilers._
       val aMap = (f: File) => m2o(analysisMap(f))
       val defClass = (f: File) => { val dc = definesClass(f); (name: String) => dc.apply(name) }
-      val incOptions = IncOptions.fromStringMap(incrementalCompilerOptions)
+      val incOptions = IncOptions.fromStringMap(incrementalCompilerOptions).withNewClassfileManager(newClassfileManager.apply _)
       val (previousAnalysis, previousSetup) = {
         MixedAnalyzingCompiler.staticCachedStore(setup.cacheFile()).get().map {
           case (a, s) => (a, Some(s))

--- a/internal/compiler-interface/src/main/java/xsbti/compile/ClassfileManager.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/ClassfileManager.java
@@ -1,0 +1,18 @@
+package xsbti.compile;
+
+import java.io.File;
+
+public interface ClassfileManager {
+  /**
+   * Called once per compilation step with the class files to delete prior to that step's compilation.
+   * The files in `classes` must not exist if this method returns normally.
+   * Any empty ancestor directories of deleted files must not exist either.
+   */
+  void delete(File[] classes);
+
+  /** Called once per compilation step with the class files generated during that step.*/
+  void generated(File[] classes);
+
+  /** Called once at the end of the whole compilation run, with `success` indicating whether compilation succeeded (true) or not (false).*/
+  void complete(boolean success);
+}

--- a/internal/compiler-interface/src/main/java/xsbti/compile/Options.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/Options.java
@@ -1,6 +1,7 @@
 package xsbti.compile;
 
 import java.io.File;
+import xsbti.F0;
 
 /** Standard compilation options.*/
 public interface Options
@@ -26,5 +27,5 @@ public interface Options
 	CompileOrder order();
 
 	/** Configures the classfile manager. */
-	ClassfileManager classFileManager();
+	F0<ClassfileManager> newClassfileManager();
 }

--- a/internal/compiler-interface/src/main/java/xsbti/compile/Options.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/Options.java
@@ -24,4 +24,7 @@ public interface Options
 
 	/** Controls the order in which Java and Scala sources are compiled.*/
 	CompileOrder order();
+
+	/** Configures the classfile manager. */
+	ClassfileManager classFileManager();
 }

--- a/internal/incrementalcompiler-core/src/main/scala/sbt/internal/inc/IncOptions.scala
+++ b/internal/incrementalcompiler-core/src/main/scala/sbt/internal/inc/IncOptions.scala
@@ -4,6 +4,8 @@ package inc
 
 import java.io.File
 
+import xsbti.compile.ClassfileManager
+
 /**
  * Represents all configuration options for the incremental compiler itself and
  * not the underlying Java/Scala compiler.
@@ -206,7 +208,7 @@ object IncOptions extends Serializable {
     apiDebug = false,
     apiDiffContextSize = 5,
     apiDumpDirectory = None,
-    newClassfileManager = ClassfileManager.deleteImmediately,
+    newClassfileManager = DefaultClassfileManager.deleteImmediately,
     recompileOnMacroDef = recompileOnMacroDefDefault,
     nameHashing = nameHashingDefault
   )
@@ -277,7 +279,7 @@ object IncOptions extends Serializable {
     }
 
     new IncOptions(getTransitiveStep, getRecompileAllFraction, getRelationsDebug, getApiDebug, getApiDiffContextSize,
-      getApiDumpDirectory, ClassfileManager.deleteImmediately, getRecompileOnMacroDef, getNameHashing, getAntStyle)
+      getApiDumpDirectory, DefaultClassfileManager.deleteImmediately, getRecompileOnMacroDef, getNameHashing, getAntStyle)
   }
 
   def toStringMap(o: IncOptions): java.util.Map[String, String] = {

--- a/internal/incrementalcompiler-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/incrementalcompiler-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -8,7 +8,7 @@ package inc
 import xsbt.api.{ NameChanges, SameAPI, TopLevel }
 import annotation.tailrec
 import xsbti.api.{ Compilation, Source }
-import xsbti.compile.DependencyChanges
+import xsbti.compile.{ ClassfileManager, DependencyChanges }
 import java.io.File
 
 /**
@@ -78,11 +78,11 @@ object Incremental {
   private[inc] def apiDebug(options: IncOptions): Boolean = options.apiDebug || java.lang.Boolean.getBoolean(apiDebugProp)
 
   private[sbt] def prune(invalidatedSrcs: Set[File], previous: Analysis): Analysis =
-    prune(invalidatedSrcs, previous, ClassfileManager.deleteImmediately())
+    prune(invalidatedSrcs, previous, DefaultClassfileManager.deleteImmediately())
 
   private[sbt] def prune(invalidatedSrcs: Set[File], previous: Analysis, classfileManager: ClassfileManager): Analysis =
     {
-      classfileManager.delete(invalidatedSrcs.flatMap(previous.relations.products))
+      classfileManager.delete(invalidatedSrcs.flatMap(previous.relations.products).toArray)
       previous -- invalidatedSrcs
     }
 
@@ -91,10 +91,10 @@ object Incremental {
       val classfileManager = options.newClassfileManager()
       val result = try run(classfileManager) catch {
         case e: Exception =>
-          classfileManager.complete(success = false)
+          classfileManager.complete( /*success = */ false)
           throw e
       }
-      classfileManager.complete(success = true)
+      classfileManager.complete( /*success = */ true)
       result
     }
 

--- a/internal/incrementalcompiler-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
+++ b/internal/incrementalcompiler-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
@@ -3,7 +3,7 @@ package internal
 package inc
 
 import scala.annotation.tailrec
-import xsbti.compile.DependencyChanges
+import xsbti.compile.{ ClassfileManager, DependencyChanges }
 import xsbti.api.{ Compilation, Source }
 import java.io.File
 
@@ -28,7 +28,7 @@ private[inc] abstract class IncrementalCommon(log: sbt.util.Logger, options: Inc
       debug("********* Pruned: \n" + pruned.relations + "\n*********")
 
       val fresh = doCompile(invalidated, binaryChanges)
-      classfileManager.generated(fresh.relations.allProducts)
+      classfileManager.generated(fresh.relations.allProducts.toArray)
       debug("********* Fresh: \n" + fresh.relations + "\n*********")
       val merged = pruned ++ fresh //.copy(relations = pruned.relations ++ fresh.relations, apis = pruned.apis ++ fresh.apis)
       debug("********* Merged: \n" + merged.relations + "\n*********")


### PR DESCRIPTION
`ClassfileManager` is now an interface, and `xsbti.compile.Options` must provide a way to create a new `ClassfileManager`. This will allow users of the API provided by `sbt.internal.inc.IC` to specify the class file manager that they want to use.

`object ClassfileManager` is renamed to `DefaultClassfileManager`.

This change will help to port Scala IDE to this API (see https://github.com/scala-ide/scala-ide/blob/master/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/EclipseSbtBuildManager.scala#L199-L207).
