### PR TITLE
Fix comparison of `MiniSetup`.

### DIFF
--- a/incrementalcompiler/src/main/scala/sbt/internal/inc/IC.scala
+++ b/incrementalcompiler/src/main/scala/sbt/internal/inc/IC.scala
@@ -82,6 +82,7 @@ private[sbt] object IC {
 
     if (skip) new CompileResult(prev, setup, false)
     else {
+      import MiniSetupUtil.equivCompileSetup
       val (analysis, changed) = compileInternal(MixedAnalyzingCompiler(config)(log))
       new CompileResult(analysis, setup, changed)
     }


### PR DESCRIPTION
Previously `CompilationSetup`s were compared using an instance of
`Equiv[CompileSetup]` that was defined in `CompilationSetup`'s companion
object.

`CompilationSetup` has been renamed to `MiniSetup`, but there's no
longer a `MiniSetup` companion object because `MiniSetup` is created
using sbt-datatype. We now have to import the instance of
`Equiv[MiniSetup]` to use.
