### PR TITLE
Improvements to `IvyComponentCompiler`, test compiling all versions of the compiler bridge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ scala:
    - 2.11.7
 
 script:
-   - sbt "plz $TRAVIS_SCALA_VERSION test"
+   - sbt "plz $TRAVIS_SCALA_VERSION publishBridgesAndTest"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ scala:
    - 2.11.7
 
 script:
-   - sbt "plz $TRAVIS_SCALA_VERSION publishBridgesAndTest"
+   - sbt "publishBridgesAndTest $TRAVIS_SCALA_VERSION"

--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,7 @@ lazy val incrementalcompilerRoot: Project = (project in file(".")).
 
 lazy val incrementalcompiler = (project in file("incrementalcompiler")).
   dependsOn(incrementalcompilerCore, incrementalcompilerPersist, incrementalcompilerCompileCore,
-    incrementalcompilerClassfile, incrementalcompilerIvyIntegration).
+    incrementalcompilerClassfile, incrementalcompilerIvyIntegration % "compile->compile;test->test").
   settings(
     testedBaseSettings,
     name := "incrementalcompiler",
@@ -127,7 +127,7 @@ lazy val incrementalcompilerIvyIntegration = (project in internalPath / "increme
   dependsOn(incrementalcompilerCompileCore).
   settings(
     baseSettings,
-    libraryDependencies += libraryManagement,
+    libraryDependencies ++= Seq(libraryManagement, libraryManagement % Test classifier "tests", utilTesting % Test),
     name := "Incrementalcompiler Ivy Integration"
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -168,6 +168,7 @@ lazy val compilerBridge: Project = (project in internalPath / "compiler-bridge")
   dependsOn(compilerInterface % "compile;test->test", /*launchProj % "test->test",*/ incrementalcompilerApiInfo % "test->test").
   settings(
     baseSettings,
+    libraryDependencies += scalaCompiler.value % "provided",
     autoScalaLibrary := false,
     // precompiledSettings,
     name := "Compiler Bridge",
@@ -223,8 +224,10 @@ lazy val incrementalcompilerClassfile = (project in internalPath / "incrementalc
     name := "Incrementalcompiler Classfile"
   )
 
-lazy val publishBridgesAndTest = Command.command("publishBridgesAndTest") { state =>
-  val test = "test" :: state
+lazy val publishBridgesAndTest = Command.args("publishBridgesAndTest", "<version>") { (state, args) =>
+  val version = args mkString ""
+  val compilerInterfaceID = compilerInterface.id
   val compilerBridgeID = compilerBridge.id
+  val test = s"$compilerInterfaceID/publishM2" :: s"plz $version test" :: state
   (scalaVersions map (v => s"plz $v $compilerBridgeID/publishM2") foldRight test) { _ :: _ }
 }

--- a/incrementalcompiler/src/test/scala/sbt/inc/IncrementalCompilerSpec.scala
+++ b/incrementalcompiler/src/test/scala/sbt/inc/IncrementalCompilerSpec.scala
@@ -21,7 +21,7 @@ class IncrementalCompilerSpec extends BridgeProviderSpecification {
   "incremental compiler" should "compile" in {
     IO.withTemporaryDirectory { tempDir =>
       val compilerBridge = getCompilerBridge(tempDir, Logger.Null, scalaVersion)
-      val si = scalaInstanceFromFile(scalaVersion)
+      val si = scalaInstance(scalaVersion)
       val sc = scalaCompiler(si, compilerBridge)
       val cs = compiler.compilers(si, ClasspathOptions.boot, None, sc)
       val analysisMap = f1((f: File) => Maybe.nothing[CompileAnalysis])

--- a/incrementalcompiler/src/test/scala/sbt/inc/IncrementalCompilerSpec.scala
+++ b/incrementalcompiler/src/test/scala/sbt/inc/IncrementalCompilerSpec.scala
@@ -3,134 +3,47 @@ package inc
 
 import java.io.File
 
+import sbt.internal.inc._
 import sbt.io.IO
-import sbt.util.Logger
-import sbt.internal.util.UnitSpec
-import sbt.internal.inc.{ AnalyzingCompiler, IncrementalCompilerImpl, ScalaInstance, RawCompiler, ClasspathOptions, ComponentCompiler }
-import sbt.internal.inc.{ CompilerInterfaceProvider, CompilerCache, LoggerReporter }
-import sbt.internal.librarymanagement.{ BaseIvySpecification, IvySbt, InlineIvyConfiguration }
-import sbt.librarymanagement.{ ModuleID, UpdateOptions, Resolver }
-import java.net.URLClassLoader
-import sbt.internal.inc.classpath.ClasspathUtilities
-import xsbti.Maybe
-import xsbti.compile.{ F1, CompileAnalysis, DefinesClass, IncOptionsUtil, PreviousResult, MiniSetup, CompileOrder }
 import sbt.io.Path._
+import sbt.util.Logger
+import xsbti.Maybe
+import xsbti.compile.{ CompileAnalysis, CompileOrder, DefinesClass, F1, IncOptionsUtil }
 
-class IncrementalCompilerSpec extends BaseIvySpecification {
-  override def resolvers: Seq[Resolver] = super.resolvers ++ Seq(Resolver.mavenLocal, Resolver.jcenterRepo)
-  val ivyConfiguration = mkIvyConfiguration(UpdateOptions())
-  val ivySbt = new IvySbt(ivyConfiguration)
+class IncrementalCompilerSpec extends BridgeProviderSpecification {
 
-  val home = new File(sys.props("user.home"))
   val scalaVersion = scala.util.Properties.versionNumberString
-  val ivyCache = home / ".ivy2" / "cache"
   val compiler = new IncrementalCompilerImpl // IncrementalCompilerUtil.defaultIncrementalCompiler
-  val CompilerBridgeId =
-    scalaVersion match {
-      case sc if sc startsWith "2.11" => "compiler-bridge_2.11"
-      case sc if sc startsWith "2.10" => "compiler-bridge_2.10"
-    }
-  val JavaClassVersion = System.getProperty("java.class.version")
   val maxErrors = 100
   val knownSampleGoodFile =
     new File(classOf[IncrementalCompilerSpec].getResource("Good.scala").toURI)
 
   "incremental compiler" should "compile" in {
     IO.withTemporaryDirectory { tempDir =>
+      val compilerBridge = getCompilerBridge(tempDir, Logger.Null, scalaVersion)
       val si = scalaInstanceFromFile(scalaVersion)
-      val sc = scalaCompiler(si, compilerBridge(si, tempDir, log))
+      val sc = scalaCompiler(si, compilerBridge)
       val cs = compiler.compilers(si, ClasspathOptions.boot, None, sc)
-      val analysisMap = f1[File, Maybe[CompileAnalysis]](f => Maybe.nothing[CompileAnalysis])
+      val analysisMap = f1((f: File) => Maybe.nothing[CompileAnalysis])
       val dc = f1[File, DefinesClass](f => new DefinesClass {
         override def apply(className: String): Boolean = false
       })
       val incOptions = IncOptionsUtil.defaultIncOptions()
       val reporter = new LoggerReporter(maxErrors, log, identity)
-      val setup = compiler.setup(analysisMap, dc, false, tempDir / "inc_compile", CompilerCache.fresh,
-        incOptions, reporter)
+      val setup = compiler.setup(analysisMap, dc, skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter)
       val prev = compiler.emptyPreviousResult
       val classesDir = tempDir / "classes"
-      val in = compiler.inputs(si.allJars, Array(knownSampleGoodFile), classesDir, Array(), Array(), 100, Array(), CompileOrder.Mixed,
-        cs, setup, prev)
+      val in = compiler.inputs(si.allJars, Array(knownSampleGoodFile), classesDir, Array(), Array(), maxErrors, Array(),
+        CompileOrder.Mixed, cs, setup, prev)
       compiler.compile(in, log)
       val expectedOuts = List(classesDir / "test" / "pkg" / "Good$.class")
-      expectedOuts foreach { f => assert(f.exists) }
+      expectedOuts foreach { f => assert(f.exists, s"$f does not exist.") }
     }
   }
 
   def scalaCompiler(instance: ScalaInstance, bridgeJar: File): AnalyzingCompiler =
     new AnalyzingCompiler(instance, CompilerInterfaceProvider.constant(bridgeJar), ClasspathOptions.boot)
 
-  def compilerBridge(scalaInstance: ScalaInstance, cacheDir: File, log: Logger): File = {
-
-    val dir = cacheDir / bridgeId(scalaInstance.actualVersion)
-    val bridgeJar = dir / (CompilerBridgeId + ".jar")
-
-    if (!bridgeJar.exists) {
-      dir.mkdirs()
-
-      val sourceModule = {
-        val dummyModule = ModuleID(xsbti.ArtifactInfo.SbtOrganization + "-tmp", "tmp-module", ComponentCompiler.incrementalVersion, Some("compile"))
-        val source = ModuleID(xsbti.ArtifactInfo.SbtOrganization, CompilerBridgeId, ComponentCompiler.incrementalVersion, Some("compile")).sources()
-        module(dummyModule, Seq(source), None)
-      }
-
-      val compilerBridgeArtifacts =
-        for {
-          conf <- ivyUpdate(sourceModule).configurations
-          m <- conf.modules
-          (_, f) <- m.artifacts
-        } yield f
-
-      val compilerBridgeSource = compilerBridgeArtifacts find (_.getName endsWith "-sources.jar") getOrElse ???
-      val compilerInterfaceJar = compilerBridgeArtifacts find (_.getName startsWith "compiler-interface") getOrElse ???
-      val utilInterfaceJar = compilerBridgeArtifacts find (_.getName startsWith "util-interface") getOrElse ???
-
-      compileBridgeJar(CompilerBridgeId, compilerBridgeSource, bridgeJar, compilerInterfaceJar :: utilInterfaceJar :: Nil, scalaInstance, log)
-    }
-    bridgeJar
-  }
-  def bridgeId(scalaVersion: String) = CompilerBridgeId + "-" + scalaVersion + "-" + JavaClassVersion
-  def compileBridgeJar(label: String, sourceJar: File, targetJar: File, xsbtiJars: Iterable[File], instance: ScalaInstance, log: Logger): Unit = {
-    val raw = new RawCompiler(instance, ClasspathOptions.auto, log)
-    AnalyzingCompiler.compileSources(sourceJar :: Nil, targetJar, xsbtiJars, label, raw, log)
-  }
-
-  def scalaInstanceFromFile(v: String): ScalaInstance =
-    scalaInstance(
-      ivyCache / "org.scala-lang" / "scala-compiler" / "jars" / s"scala-compiler-$v.jar",
-      ivyCache / "org.scala-lang" / "scala-library" / "jars" / s"scala-library-$v.jar",
-      Seq(ivyCache / "org.scala-lang" / "scala-reflect" / "jars" / s"scala-reflect-$v.jar")
-    )
-  def scalaInstance(scalaCompiler: File, scalaLibrary: File, scalaExtra: Seq[File]): ScalaInstance =
-    {
-      val loader = scalaLoader(scalaLibrary +: scalaCompiler +: scalaExtra)
-      val version = scalaVersion(loader)
-      val allJars = (scalaLibrary +: scalaCompiler +: scalaExtra).toArray
-      new ScalaInstance(version.getOrElse("unknown"), loader, scalaLibrary, scalaCompiler, allJars, version)
-    }
-  def scalaLoader(jars: Seq[File]) = new URLClassLoader(toURLs(jars), ClasspathUtilities.rootLoader)
-  def scalaVersion(scalaLoader: ClassLoader): Option[String] = {
-    propertyFromResource("compiler.properties", "version.number", scalaLoader)
-  }
-  /**
-   * Get a property from a properties file resource in the classloader.
-   */
-  def propertyFromResource(resource: String, property: String, classLoader: ClassLoader): Option[String] = {
-    val props = propertiesFromResource(resource, classLoader)
-    Option(props.getProperty(property))
-  }
-  /**
-   * Get all properties from a properties file resource in the classloader.
-   */
-  def propertiesFromResource(resource: String, classLoader: ClassLoader): java.util.Properties = {
-    val props = new java.util.Properties
-    val stream = classLoader.getResourceAsStream(resource)
-    try { props.load(stream) }
-    catch { case e: Exception => }
-    finally { if (stream ne null) stream.close }
-    props
-  }
   def f1[A, B](f: A => B): F1[A, B] =
     new F1[A, B] {
       def apply(a: A): B = f(a)

--- a/internal/incrementalcompiler-ivy-integration/src/test/scala/sbt/internal/inc/BridgeProviderSpecification.scala
+++ b/internal/incrementalcompiler-ivy-integration/src/test/scala/sbt/internal/inc/BridgeProviderSpecification.scala
@@ -1,0 +1,106 @@
+package sbt.internal.inc
+
+import java.io.File
+import java.net.URLClassLoader
+import java.util.Properties
+import java.util.concurrent.Callable
+
+import sbt.internal.inc.classpath.ClasspathUtilities
+import sbt.internal.librarymanagement.{ ComponentManager, IvySbt, BaseIvySpecification }
+import sbt.io.IO
+import sbt.io.Path._
+import sbt.librarymanagement.{ ModuleID, UpdateOptions, Resolver }
+import sbt.util.Logger
+import xsbti.{ ComponentProvider, GlobalLock }
+
+abstract class BridgeProviderSpecification extends BaseIvySpecification {
+
+  override def resolvers: Seq[Resolver] = Seq(Resolver.mavenLocal, Resolver.jcenterRepo)
+  val ivyConfiguration = mkIvyConfiguration(UpdateOptions())
+  val ivySbt = new IvySbt(ivyConfiguration)
+
+  val home = new File(sys.props("user.home"))
+  val ivyCache = home / ".ivy2" / "cache"
+
+  def getCompilerBridge(tempDir: File, log: Logger, scalaVersion: String): File = {
+    val instance = scalaInstanceFromFile(scalaVersion)
+    val bridgeId = compilerBridgeId(scalaVersion)
+    val sourceModule = ModuleID(xsbti.ArtifactInfo.SbtOrganization, bridgeId, ComponentCompiler.incrementalVersion, Some("component")).sources()
+
+    val raw = new RawCompiler(instance, ClasspathOptions.auto, log)
+    val manager = new ComponentManager(lock, provider(tempDir), None, log)
+    val componentCompiler = new IvyComponentCompiler(raw, manager, ivyConfiguration, sourceModule, log)
+
+    val bridge = componentCompiler.apply()
+    val target = tempDir / s"target-bridge-$scalaVersion.jar"
+    IO.copyFile(bridge, target)
+    target
+  }
+
+  def scalaInstanceFromFile(scalaVersion: String): ScalaInstance =
+    scalaInstance(
+      ivyCache / "org.scala-lang" / "scala-compiler" / "jars" / s"scala-compiler-$scalaVersion.jar",
+      ivyCache / "org.scala-lang" / "scala-library" / "jars" / s"scala-library-$scalaVersion.jar",
+      Seq(ivyCache / "org.scala-lang" / "scala-reflect" / "jars" / s"scala-reflect-$scalaVersion.jar")
+    )
+
+  def scalaInstance(scalaCompiler: File, scalaLibrary: File, scalaExtra: Seq[File]): ScalaInstance = {
+    val loader = scalaLoader(scalaLibrary +: scalaCompiler +: scalaExtra)
+    val version = scalaVersion(loader)
+    val allJars = (scalaLibrary +: scalaCompiler +: scalaExtra).toArray
+    new ScalaInstance(version.getOrElse("unknown"), loader, scalaLibrary, scalaCompiler, allJars, version)
+  }
+
+  def compilerBridgeId(scalaVersion: String) =
+    scalaVersion match {
+      case sc if sc startsWith "2.11" => "compiler-bridge_2.11"
+      case _                          => "compiler-bridge_2.10"
+    }
+
+  def scalaLoader(jars: Seq[File]) = new URLClassLoader(sbt.io.Path.toURLs(jars), ClasspathUtilities.rootLoader)
+  def scalaVersion(scalaLoader: ClassLoader): Option[String] =
+    propertyFromResource("compiler.properties", "version.number", scalaLoader)
+
+  /**
+   * Get a property from a properties file resource in the classloader.
+   */
+  def propertyFromResource(resource: String, property: String, classLoader: ClassLoader): Option[String] = {
+    val props = propertiesFromResource(resource, classLoader)
+    Option(props.getProperty(property))
+  }
+
+  /**
+   * Get all properties from a properties file resource in the classloader.
+   */
+  def propertiesFromResource(resource: String, classLoader: ClassLoader): Properties = {
+    val props = new Properties
+    val stream = classLoader.getResourceAsStream(resource)
+    try { props.load(stream) }
+    catch { case _: Exception => }
+    finally { if (stream ne null) stream.close() }
+    props
+  }
+
+  private val lock: GlobalLock = new GlobalLock {
+    override def apply[T](file: File, callable: Callable[T]): T = callable.call()
+  }
+
+  private def provider(targetDir: File): ComponentProvider = new ComponentProvider {
+
+    override def lockFile(): File = targetDir / "lock"
+
+    override def defineComponent(componentID: String, files: Array[File]): Unit =
+      files foreach { f => IO.copyFile(f, targetDir / componentID / f.getName) }
+
+    override def addToComponent(componentID: String, files: Array[File]): Boolean = {
+      defineComponent(componentID, files)
+      true
+    }
+
+    override def component(componentID: String): Array[File] =
+      IO.listFiles(targetDir / componentID)
+
+    override def componentLocation(id: String): File = throw new UnsupportedOperationException
+  }
+
+}

--- a/internal/incrementalcompiler-ivy-integration/src/test/scala/sbt/internal/inc/IvyComponentCompilerSpec.scala
+++ b/internal/incrementalcompiler-ivy-integration/src/test/scala/sbt/internal/inc/IvyComponentCompilerSpec.scala
@@ -1,7 +1,7 @@
 package sbt.internal.inc
 
 import sbt.io.IO
-import sbt.util.{ Level, Logger }
+import sbt.util.Logger
 
 class IvyComponentCompilerSpec extends BridgeProviderSpecification {
 

--- a/internal/incrementalcompiler-ivy-integration/src/test/scala/sbt/internal/inc/IvyComponentCompilerSpec.scala
+++ b/internal/incrementalcompiler-ivy-integration/src/test/scala/sbt/internal/inc/IvyComponentCompilerSpec.scala
@@ -1,7 +1,7 @@
 package sbt.internal.inc
 
 import sbt.io.IO
-import sbt.util.Logger
+import sbt.util.{ Level, Logger }
 
 class IvyComponentCompilerSpec extends BridgeProviderSpecification {
 
@@ -10,19 +10,19 @@ class IvyComponentCompilerSpec extends BridgeProviderSpecification {
   val scala210 = "2.10.5"
   val scala211 = "2.11.7"
 
-  "IvyComponentCompiler" should "compile the bridge for Scala 2.8" in pendingUntilFixed {
+  "IvyComponentCompiler" should "compile the bridge for Scala 2.8" in {
     IO.withTemporaryDirectory { tempDir =>
       getCompilerBridge(tempDir, Logger.Null, scala282) should exist
     }
   }
 
-  it should "compile the bridge for Scala 2.9" in pendingUntilFixed {
+  it should "compile the bridge for Scala 2.9" in {
     IO.withTemporaryDirectory { tempDir =>
       getCompilerBridge(tempDir, Logger.Null, scala292) should exist
     }
   }
 
-  it should "compile the bridge for Scala 2.10" in pendingUntilFixed {
+  it should "compile the bridge for Scala 2.10" in {
     IO.withTemporaryDirectory { tempDir =>
       getCompilerBridge(tempDir, Logger.Null, scala210) should exist
     }

--- a/internal/incrementalcompiler-ivy-integration/src/test/scala/sbt/internal/inc/IvyComponentCompilerSpec.scala
+++ b/internal/incrementalcompiler-ivy-integration/src/test/scala/sbt/internal/inc/IvyComponentCompilerSpec.scala
@@ -1,0 +1,37 @@
+package sbt.internal.inc
+
+import sbt.io.IO
+import sbt.util.Logger
+
+class IvyComponentCompilerSpec extends BridgeProviderSpecification {
+
+  val scala282 = "2.8.2"
+  val scala292 = "2.9.2"
+  val scala210 = "2.10.5"
+  val scala211 = "2.11.7"
+
+  "IvyComponentCompiler" should "compile the bridge for Scala 2.8" in pendingUntilFixed {
+    IO.withTemporaryDirectory { tempDir =>
+      getCompilerBridge(tempDir, Logger.Null, scala282) should exist
+    }
+  }
+
+  it should "compile the bridge for Scala 2.9" in pendingUntilFixed {
+    IO.withTemporaryDirectory { tempDir =>
+      getCompilerBridge(tempDir, Logger.Null, scala292) should exist
+    }
+  }
+
+  it should "compile the bridge for Scala 2.10" in pendingUntilFixed {
+    IO.withTemporaryDirectory { tempDir =>
+      getCompilerBridge(tempDir, Logger.Null, scala210) should exist
+    }
+  }
+
+  it should "compile the bridge for Scala 2.11" in {
+    IO.withTemporaryDirectory { tempDir =>
+      getCompilerBridge(tempDir, Logger.Null, scala211) should exist
+    }
+  }
+
+}


### PR DESCRIPTION
- A new command `publishBridgesAndTests` now publishes the bridge for all versions of Scala used in the build definition and then runs the tests.
- The `IvyComponentCompiler` works better now. It doesn't try to resolve artefacts multiple times, but gets all the dependencies of the compiler bridge at once.
- `compilerBridge` now has a `provided` dependency on `scale-compiler`. Otherwise, the `IvyComponentCompiler` will get it along with the compiler bridge's sources and this will be problematic when compiling them.
- I wrote tests that try to compile the compiler bridge for Scala 2.8, 2.9, 2.10, and 2.11.
