### PR TITLE
FPORT: Make sbt aware of Dotty

### DIFF
--- a/internal/incrementalcompiler-classpath/src/main/scala/sbt/internal/inc/ScalaInstance.scala
+++ b/internal/incrementalcompiler-classpath/src/main/scala/sbt/internal/inc/ScalaInstance.scala
@@ -42,6 +42,11 @@ object ScalaInstance {
   val ScalaOrg = ScalaOrganization
   val VersionPrefix = "version "
 
+  def isDotty(version: String): Boolean =
+    // We rely on the fact that the first public version of Scala was 1.0 and
+    // that Dotty will keep being version 0.x for a long time.
+    version.startsWith("0.")
+
   def apply(org: String, version: String, launcher: xsbti.Launcher): ScalaInstance =
     // Due to incompatibility with previous launchers if scalaOrg has default value revert to an existing method
     if (org == ScalaOrg)

--- a/internal/incrementalcompiler-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala
+++ b/internal/incrementalcompiler-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala
@@ -32,7 +32,11 @@ final class CompilerArguments(scalaInstance: xsbti.compile.ScalaInstance, cp: xs
     }
   def finishClasspath(classpath: Seq[File]): Seq[File] =
     filterLibrary(classpath) ++ include(cp.compiler, scalaInstance.compilerJar) ++ include(cp.extra, scalaInstance.otherJars: _*)
-  private[this] def include(flag: Boolean, jars: File*) = if (flag) jars else Nil
+  private[this] def include(flag: Boolean, jars: File*) =
+    if (flag || ScalaInstance.isDotty(scalaInstance.version))
+      jars
+    else
+      Nil
   private[this] def abs(files: Seq[File]) = files.map(_.getAbsolutePath).sortWith(_ < _)
   private[this] def checkScalaHomeUnset(): Unit = {
     val scalaHome = System.getProperty("scala.home")

--- a/internal/incrementalcompiler-compile-core/src/main/scala/sbt/internal/inc/RawCompiler.scala
+++ b/internal/incrementalcompiler-compile-core/src/main/scala/sbt/internal/inc/RawCompiler.scala
@@ -23,16 +23,29 @@ class RawCompiler(val scalaInstance: xsbti.compile.ScalaInstance, cp: ClasspathO
 
     val arguments = compilerArguments(sources, classpath, Some(outputDirectory), options)
     log.debug("Plain interface to Scala compiler " + scalaInstance.actualVersion + "  with arguments: " + arguments.mkString("\n\t", "\n\t", ""))
-    val mainClass = Class.forName("scala.tools.nsc.Main", true, scalaInstance.loader)
-    val process = mainClass.getMethod("process", classOf[Array[String]])
-    process.invoke(null, arguments.toArray)
-    checkForFailure(mainClass, arguments.toArray)
+    val args = arguments.toArray
+    val reporter =
+      if (ScalaInstance.isDotty(scalaInstance.version)) {
+        val mainClass = Class.forName("dotty.tools.dotc.Main", true, scalaInstance.loader)
+        val process = mainClass.getMethod("process", classOf[Array[String]])
+        process.invoke(null, args)
+      } else {
+        val mainClass = Class.forName("scala.tools.nsc.Main", true, scalaInstance.loader)
+        val process = mainClass.getMethod("process", classOf[Array[String]])
+        process.invoke(null, arguments.toArray)
+        mainClass.getMethod("reporter").invoke(null)
+      }
+    checkForFailure(reporter, arguments.toArray)
   }
   def compilerArguments = new CompilerArguments(scalaInstance, cp)
-  protected def checkForFailure(mainClass: Class[_], args: Array[String]): Unit = {
-    val reporter = mainClass.getMethod("reporter").invoke(null)
+  protected def checkForFailure(reporter: AnyRef, args: Array[String]): Unit = {
     val failed = reporter.getClass.getMethod("hasErrors").invoke(reporter).asInstanceOf[Boolean]
     if (failed) throw new CompileFailed(args, "Plain compile failed", Array())
+  }
+  @deprecated("Use `checkForFailure(AnyRef, Array[String])`", "0.13.10")
+  protected def checkForFailure(mainClass: Class[_], args: Array[String]): Unit = {
+    val reporter = mainClass.getMethod("reporter").invoke(null)
+    checkForFailure(reporter, args)
   }
 }
 class CompileFailed(val arguments: Array[String], override val toString: String, val problems: Array[xsbti.Problem]) extends xsbti.CompileFailed with FeedbackProvidedException


### PR DESCRIPTION
This small set of changes, together with the compiler-bridge I wrote
(https://github.com/smarter/dotty-bridge) enables us to compile code
using Dotty in sbt, see https://github.com/smarter/dotty-example-project
for an example.

Partial forward port of sbt/sbt#2344.
