### PR TITLE
Fix DependencySpecification test.

### DIFF
--- a/internal/compiler-bridge/src/test/scala/xsbt/DependencySpecification.scala
+++ b/internal/compiler-bridge/src/test/scala/xsbt/DependencySpecification.scala
@@ -24,7 +24,7 @@ class DependencySpecification extends UnitSpec {
     assert(inheritance('D) === Set.empty)
     assert(memberRef('E) === Set.empty)
     assert(inheritance('E) === Set.empty)
-    assert(memberRef('F) === Set('A, 'B, 'C, 'D, 'E))
+    assert(memberRef('F) === Set('A, 'B, 'D, 'E))
     assert(inheritance('F) === Set('A, 'E))
     assert(memberRef('H) === Set('B, 'E, 'G))
     // aliases and applied type constructors are expanded so we have inheritance dependency on B


### PR DESCRIPTION
Forward port of sbt/sbt#2358.

This is a fixup of 0f616294c4e713dc415f5dc3ae7aef257decb228.
That commit assumed that dealiasing is being done for types referred in
self type. It was changed to not do that but the test wasn't updated.
Unfortunately, that mistake slipped by during PR review because unit tests
of compileInterface were not ran (see #2358).
