### PR TITLE
Upgrade to latest sbt/librarymanagement

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   lazy val utilTesting = "org.scala-sbt" %% "util-testing" % utilVersion
   lazy val utilTracking = "org.scala-sbt" %% "util-tracking" % utilVersion
   lazy val utilInterface = "org.scala-sbt" % "util-interface" % utilVersion
-  lazy val libraryManagement = "org.scala-sbt" %% "librarymanagement" % "0.1.0-M2"
+  lazy val libraryManagement = "org.scala-sbt" %% "librarymanagement" % "0.1.0-M6"
 
   lazy val launcherInterface = "org.scala-sbt" % "launcher-interface" % "1.0.0-M1"
 


### PR DESCRIPTION
Brings in among other things:
- sbt/librarymanagement#17 FPORT: Make JCenter opt in
- sbt/librarymanagement#18 FPORT: Make sbt aware of Dotty 
- sbt/librarymanagement#19 FPORT: Maven compatibility changes (intransitive warnings and "configuration not public") 
- sbt/librarymanagement#20 FPORT: Refix snapshots
