### PR TITLE
Handle source, docs artifacts correctly for Ivy [follow-up]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import Scripted._
 // import StringUtilities.normalize
 import com.typesafe.tools.mima.core._, ProblemFilters._
 
-def baseVersion = "0.1.0-M2"
+def baseVersion = "0.1.0-M3"
 def internalPath   = file("internal")
 
 lazy val scalaVersions = Seq(scala210, scala211)

--- a/internal/incrementalcompiler-ivy-integration/src/main/scala/sbt/internal/inc/ComponentCompiler.scala
+++ b/internal/incrementalcompiler-ivy-integration/src/main/scala/sbt/internal/inc/ComponentCompiler.scala
@@ -9,7 +9,7 @@ import java.io.File
 import scala.util.Try
 import sbt.io.{ Hash, IO }
 import sbt.internal.librarymanagement._
-import sbt.librarymanagement.{ Configurations, ModuleID, ModuleInfo, Resolver, UpdateOptions, VersionNumber }
+import sbt.librarymanagement._
 import sbt.util.Logger
 import sbt.internal.util.{ BufferedLogger, FullLogger }
 
@@ -127,7 +127,7 @@ private[inc] class IvyComponentCompiler(compiler: RawCompiler, manager: Componen
   private def update(module: ivySbt.Module, retrieveDirectory: File): Seq[File] = {
 
     val retrieveConfiguration = new RetrieveConfiguration(retrieveDirectory, Resolver.defaultRetrievePattern, false)
-    val updateConfiguration = new UpdateConfiguration(Some(retrieveConfiguration), true, UpdateLogging.DownloadOnly)
+    val updateConfiguration = new UpdateConfiguration(Some(retrieveConfiguration), true, UpdateLogging.DownloadOnly, ArtifactTypeFilter.forbid(Set("src", "doc", "javadoc")))
 
     buffered.info(s"Attempting to fetch ${dependenciesNames(module)}. This operation may fail.")
     IvyActions.updateEither(module, updateConfiguration, UnresolvedWarningConfiguration(), LogicalClock.unknown, None, buffered) match {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   lazy val utilTesting = "org.scala-sbt" %% "util-testing" % utilVersion
   lazy val utilTracking = "org.scala-sbt" %% "util-tracking" % utilVersion
   lazy val utilInterface = "org.scala-sbt" % "util-interface" % utilVersion
-  lazy val libraryManagement = "org.scala-sbt" %% "librarymanagement" % "0.1.0-M6"
+  lazy val libraryManagement = "org.scala-sbt" %% "librarymanagement" % "0.1.0-M7"
   lazy val utilScripted = "org.scala-sbt" %% "util-scripted" % utilVersion
 
   lazy val launcherInterface = "org.scala-sbt" % "launcher-interface" % "1.0.0-M1"


### PR DESCRIPTION
This is a follow-up to https://github.com/sbt/librarymanagement/pull/25, making this project depend on the newer `librarymanagement-0.1.0-M7` which contains that change (and is binary incompatible with `0.1.0-M6`), and a pre-requisite to https://github.com/sbt/sbt/pull/2475.
