### PR TITLE
FPORT: Avoid CCE when scalac internally uses compileLate

### DIFF
--- a/incrementalcompiler/src/sbt-test/apiinfo/source-path/build.sbt
+++ b/incrementalcompiler/src/sbt-test/apiinfo/source-path/build.sbt
@@ -1,0 +1,3 @@
+scalaVersion := "2.11.7"
+
+scalacOptions in Compile ++= "-sourcepath" :: (baseDirectory.value / "srcpath").toString :: Nil

--- a/incrementalcompiler/src/sbt-test/apiinfo/source-path/src/main/scala/test.scala
+++ b/incrementalcompiler/src/sbt-test/apiinfo/source-path/src/main/scala/test.scala
@@ -1,0 +1,17 @@
+object Test {
+  // When the refchecks compiler phase checks if Tuple2 has the
+  // @deprecated annotation, it forces the info for the
+  // `@deprecatedInheritance` annotation (the only annotation on
+  // class Tuple2.
+  //
+  // Because we are compiling with `-sourcpath` that contains a
+  // source file for `deprecatedInheritance`, this triggers a
+  // `compileLate` of that file (which basically runs all previous
+  // compiler phases on that file.)
+  //
+  // `compileLate` assumes that all of the phases are subclasses
+  // of `GlobalPhase`, rather than just `Phase`. This triggers a
+  // `ClassCastException` when it encounters SBT's custom
+  // API phase.
+  new Tuple2("", "")
+}

--- a/incrementalcompiler/src/sbt-test/apiinfo/source-path/srcpath/scala/deprecatedInheritance.scala
+++ b/incrementalcompiler/src/sbt-test/apiinfo/source-path/srcpath/scala/deprecatedInheritance.scala
@@ -1,0 +1,4 @@
+package scala
+
+private[scala] // for now, this needs to be generalized to communicate other modifier deltas
+class deprecatedInheritance(message: String = "", since: String = "") extends scala.annotation.StaticAnnotation

--- a/incrementalcompiler/src/sbt-test/apiinfo/source-path/test
+++ b/incrementalcompiler/src/sbt-test/apiinfo/source-path/test
@@ -1,0 +1,1 @@
+> compile


### PR DESCRIPTION
Scripted test half of forward porting sbt/sbt#2453.

Porting to here rather than in sbt/sbt (sbt/sbt#2487).
