### PR TITLE
Overhaul ClassfileManager to pessimistically clone

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Compile.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Compile.scala
@@ -58,7 +58,7 @@ object IncrementalCompile {
       try {
         Incremental.compile(sources, lookup, previous, current,
           doCompile(compile, internalBinaryToSourceClassName, internalSourceToClassNamesMap, externalAPI, current, output, options),
-          log, options)
+          output, log, options)
       } catch {
         case e: xsbti.CompileCancelled =>
           log.info("Compilation has been cancelled")

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -53,7 +53,7 @@ object Incremental {
     log: sbt.util.Logger,
     options: IncOptions
   )(implicit equivS: Equiv[Stamp]): (Boolean, Analysis) =
-    {
+    ClassfileManager.manageClassfiles(output, options) {
       val previous = previous0 match { case a: Analysis => a }
       val incremental: IncrementalCommon =
         if (options.nameHashing)
@@ -71,9 +71,7 @@ object Incremental {
       val (initialInvClasses, initialInvSources) = incremental.invalidateInitial(previous.relations, initialChanges)
       log.debug("All initially invalidated classes: " + initialInvClasses + "\n" +
         "All initially invalidated sources:" + initialInvSources + "\n")
-      val analysis = ClassfileManager.manageClassfiles(output, options) {
-        incremental.cycle(initialInvClasses, initialInvSources, sources, binaryChanges, previous, doCompile, 1)
-      }
+      val analysis = incremental.cycle(initialInvClasses, initialInvSources, sources, binaryChanges, previous, doCompile, 1)
       (initialInvClasses.nonEmpty || initialInvSources.nonEmpty, analysis)
     }
 

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -6,9 +6,10 @@ package internal
 package inc
 
 import java.io.File
+import sbt.io.IO
 import sbt.util.Logger
 import scala.annotation.tailrec
-import xsbti.compile.{ DependencyChanges, IncOptions, CompileAnalysis }
+import xsbti.compile.{ DependencyChanges, IncOptions, CompileAnalysis, Output }
 
 /**
  * Helper class to run incremental compilation algorithm.
@@ -37,6 +38,7 @@ object Incremental {
    * @param doCompile  The function which can run one level of compile.
    * @param log  The log where we write debugging information
    * @param options  Incremental compilation options
+   * @param output  The final output location for the compile.
    * @param equivS  The means of testing whether two "Stamps" are the same.
    * @return
    *         A flag of whether or not compilation completed succesfully, and the resulting dependency analysis object.
@@ -47,6 +49,7 @@ object Incremental {
     previous0: CompileAnalysis,
     current: ReadStamps,
     doCompile: (Set[File], DependencyChanges) => Analysis,
+    output: Output,
     log: sbt.util.Logger,
     options: IncOptions
   )(implicit equivS: Equiv[Stamp]): (Boolean, Analysis) =
@@ -68,9 +71,8 @@ object Incremental {
       val (initialInvClasses, initialInvSources) = incremental.invalidateInitial(previous.relations, initialChanges)
       log.debug("All initially invalidated classes: " + initialInvClasses + "\n" +
         "All initially invalidated sources:" + initialInvSources + "\n")
-      val analysis = manageClassfiles(options) { classfileManager =>
-
-        incremental.cycle(initialInvClasses, initialInvSources, sources, binaryChanges, previous, doCompile, classfileManager, 1)
+      val analysis = ClassfileManager.manageClassfiles(output, options) {
+        incremental.cycle(initialInvClasses, initialInvSources, sources, binaryChanges, previous, doCompile, 1)
       }
       (initialInvClasses.nonEmpty || initialInvSources.nonEmpty, analysis)
     }
@@ -85,26 +87,9 @@ object Incremental {
   private[inc] val apiDebugProp = "xsbt.api.debug"
   private[inc] def apiDebug(options: IncOptions): Boolean = options.apiDebug || java.lang.Boolean.getBoolean(apiDebugProp)
 
-  private[sbt] def prune(invalidatedSrcs: Set[File], previous: CompileAnalysis): Analysis =
-    prune(invalidatedSrcs, previous, ClassfileManager.deleteImmediately())
-
-  private[sbt] def prune(invalidatedSrcs: Set[File], previous0: CompileAnalysis, classfileManager: ClassfileManager): Analysis =
-    {
-      val previous = previous0 match { case a: Analysis => a }
-      classfileManager.delete(invalidatedSrcs.flatMap(previous.relations.products))
-      previous -- invalidatedSrcs
-    }
-
-  private[this] def manageClassfiles[T](options: IncOptions)(run: ClassfileManager => T): T =
-    {
-      val classfileManager = ClassfileManager.getClassfileManager(options)
-      val result = try run(classfileManager) catch {
-        case e: Exception =>
-          classfileManager.complete(success = false)
-          throw e
-      }
-      classfileManager.complete(success = true)
-      result
-    }
-
+  private[sbt] def prune(invalidatedSrcs: Set[File], previous0: CompileAnalysis): Analysis = {
+    val previous = previous0 match { case a: Analysis => a }
+    IO.deleteFilesEmptyDirs(invalidatedSrcs.flatMap(previous.relations.products))
+    previous -- invalidatedSrcs
+  }
 }

--- a/zinc/src/test/resources/sbt/inc/Bad.scala
+++ b/zinc/src/test/resources/sbt/inc/Bad.scala
@@ -1,0 +1,5 @@
+package test.pkg
+
+object Bad extends App {
+  thisIsAnUnknownSymbol
+}

--- a/zinc/src/test/scala/sbt/inc/IncrementalCompilerSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/IncrementalCompilerSpec.scala
@@ -4,15 +4,16 @@ package inc
 import java.io.File
 
 import sbt.internal.inc._
-import sbt.io.IO
+import sbt.io.{ IO, PathFinder }
 import sbt.io.Path._
 import sbt.util.{ Logger, InterfaceUtil, Level }
 import sbt.util.InterfaceUtil.f1
-import sbt.internal.util.ConsoleLogger
 import xsbti.{ F1, Maybe }
-import xsbti.compile.{ CompileAnalysis, CompileOrder, DefinesClass, IncOptionsUtil, PreviousResult }
+import xsbti.compile.{ Compilers, CompileAnalysis, CompileOrder, DefinesClass, IncOptions, IncOptionsUtil, PreviousResult, TransactionalManagerType }
 
 class IncrementalCompilerSpec extends BridgeProviderSpecification {
+  // uncomment this to see the debug log
+  // log.setLevel(Level.Debug)
 
   val scalaVersion = scala.util.Properties.versionNumberString
   val compiler = new IncrementalCompilerImpl // IncrementalCompilerUtil.defaultIncrementalCompiler
@@ -21,32 +22,46 @@ class IncrementalCompilerSpec extends BridgeProviderSpecification {
     new File(classOf[IncrementalCompilerSpec].getResource("Good.scala").toURI)
   val fooSampleFile0 =
     new File(classOf[IncrementalCompilerSpec].getResource("Foo.scala").toURI)
+  val badSampleFile0 =
+    new File(classOf[IncrementalCompilerSpec].getResource("Bad.scala").toURI)
   val dc = f1[File, DefinesClass] { f =>
     val x = Locate.definesClass(f)
     new DefinesClass {
       override def apply(className: String): Boolean = x(className)
     }
   }
+  val reporter = new LoggerReporter(maxErrors, log, identity)
 
-  "incremental compiler" should "compile" in {
+  case class Harness(
+    tempDir: File,
+    si: ScalaInstance,
+    cs: Compilers
+  ) {
+    def classesDir: File = tempDir / "classes"
+  }
+
+  def withHarness(body: Harness => Unit): Unit =
     IO.withTemporaryDirectory { tempDir =>
-      val knownSampleGoodFile = tempDir / "src" / "Good.scala"
-      IO.copyFile(knownSampleGoodFile0, knownSampleGoodFile, false)
       val compilerBridge = getCompilerBridge(tempDir, Logger.Null, scalaVersion)
       val si = scalaInstance(scalaVersion)
-      val sc = scalaCompiler(si, compilerBridge)
+      val sc = new AnalyzingCompiler(si, CompilerInterfaceProvider.constant(compilerBridge), ClasspathOptions.boot)
       val cs = compiler.compilers(si, ClasspathOptions.boot, None, sc)
-      val analysisMap = f1((f: File) => Maybe.nothing[CompileAnalysis])
+      body(Harness(tempDir, si, cs))
+    }
+
+  "incremental compiler" should "compile" in {
+    withHarness { h =>
       val incOptions = IncOptionsUtil.defaultIncOptions()
-      val reporter = new LoggerReporter(maxErrors, log, identity)
+      val knownSampleGoodFile = h.tempDir / "src" / "Good.scala"
+      IO.copyFile(knownSampleGoodFile0, knownSampleGoodFile, false)
+      val analysisMap = f1((f: File) => Maybe.nothing[CompileAnalysis])
       val extra = Array(InterfaceUtil.t2(("key", "value")))
-      val setup = compiler.setup(analysisMap, dc, skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
+      val setup = compiler.setup(analysisMap, dc, skip = false, h.tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
       val prev = compiler.emptyPreviousResult
-      val classesDir = tempDir / "classes"
-      val in = compiler.inputs(si.allJars, Array(knownSampleGoodFile), classesDir, Array(), Array(), maxErrors, Array(),
-        CompileOrder.Mixed, cs, setup, prev)
+      val in = compiler.inputs(h.si.allJars, Array(knownSampleGoodFile), h.classesDir, Array(), Array(), maxErrors, Array(),
+        CompileOrder.Mixed, h.cs, setup, prev)
       val result = compiler.compile(in, log)
-      val expectedOuts = List(classesDir / "test" / "pkg" / "Good$.class")
+      val expectedOuts = List(h.classesDir / "test" / "pkg" / "Good$.class")
       expectedOuts foreach { f => assert(f.exists, s"$f does not exist.") }
       val a = result.analysis match { case a: Analysis => a }
       assert(a.stamps.allInternalSources.nonEmpty)
@@ -54,65 +69,47 @@ class IncrementalCompilerSpec extends BridgeProviderSpecification {
   }
 
   it should "not compile anything if source has not changed" in {
-    IO.withTemporaryDirectory { tempDir =>
-      val knownSampleGoodFile = tempDir / "src" / "Good.scala"
+    withHarness { h =>
+      val incOptions = IncOptionsUtil.defaultIncOptions()
+      val knownSampleGoodFile = h.tempDir / "src" / "Good.scala"
       IO.copyFile(knownSampleGoodFile0, knownSampleGoodFile, false)
-      val fooSampleFile = tempDir / "src" / "Foo.scala"
+      val fooSampleFile = h.tempDir / "src" / "Foo.scala"
       IO.copyFile(fooSampleFile0, fooSampleFile, false)
       val sources = Array(knownSampleGoodFile, fooSampleFile)
-      val log = ConsoleLogger()
-      // uncomment this to see the debug log
-      // log.setLevel(Level.Debug)
-      val compilerBridge = getCompilerBridge(tempDir, Logger.Null, scalaVersion)
-      val si = scalaInstance(scalaVersion)
-      val sc = scalaCompiler(si, compilerBridge)
-      val cs = compiler.compilers(si, ClasspathOptions.boot, None, sc)
       val prev0 = compiler.emptyPreviousResult
       val analysisMap = f1((f: File) => prev0.analysis)
-      val incOptions = IncOptionsUtil.defaultIncOptions()
-      val reporter = new LoggerReporter(maxErrors, log, identity)
       val extra = Array(InterfaceUtil.t2(("key", "value")))
-      val setup = compiler.setup(analysisMap, dc, skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
-      val classesDir = tempDir / "classes"
-      val in = compiler.inputs(si.allJars, sources, classesDir, Array(), Array(), maxErrors, Array(),
-        CompileOrder.Mixed, cs, setup, prev0)
+      val setup = compiler.setup(analysisMap, dc, skip = false, h.tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
+      val in = compiler.inputs(h.si.allJars, sources, h.classesDir, Array(), Array(), maxErrors, Array(),
+        CompileOrder.Mixed, h.cs, setup, prev0)
       val result = compiler.compile(in, log)
       val prev = compiler.previousResult(result)
       val analysisMap2 = f1((f: File) => prev.analysis)
-      val setup2 = compiler.setup(analysisMap2, dc, skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
-      val in2 = compiler.inputs(si.allJars, sources, classesDir, Array(), Array(), maxErrors, Array(),
-        CompileOrder.Mixed, cs, setup2, prev)
+      val setup2 = compiler.setup(analysisMap2, dc, skip = false, h.tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
+      val in2 = compiler.inputs(h.si.allJars, sources, h.classesDir, Array(), Array(), maxErrors, Array(),
+        CompileOrder.Mixed, h.cs, setup2, prev)
       val result2 = compiler.compile(in2, log)
       assert(!result2.hasModified)
     }
   }
 
   it should "trigger full compilation if extra changes" in {
-    IO.withTemporaryDirectory { tempDir =>
-      val cacheFile = tempDir / "target" / "inc_compile"
+    withHarness { h =>
+      val incOptions = IncOptionsUtil.defaultIncOptions()
+      val cacheFile = h.tempDir / "target" / "inc_compile"
       val fileStore = AnalysisStore.cached(FileBasedStore(cacheFile))
 
-      val knownSampleGoodFile = tempDir / "src" / "Good.scala"
+      val knownSampleGoodFile = h.tempDir / "src" / "Good.scala"
       IO.copyFile(knownSampleGoodFile0, knownSampleGoodFile, false)
-      val fooSampleFile = tempDir / "src" / "Foo.scala"
+      val fooSampleFile = h.tempDir / "src" / "Foo.scala"
       IO.copyFile(fooSampleFile0, fooSampleFile, false)
       val sources = Array(knownSampleGoodFile, fooSampleFile)
-      val log = ConsoleLogger()
-      // uncomment this to see the debug log
-      // log.setLevel(Level.Debug)
-      val compilerBridge = getCompilerBridge(tempDir, Logger.Null, scalaVersion)
-      val si = scalaInstance(scalaVersion)
-      val sc = scalaCompiler(si, compilerBridge)
-      val cs = compiler.compilers(si, ClasspathOptions.boot, None, sc)
       val prev0 = compiler.emptyPreviousResult
       val analysisMap = f1((f: File) => prev0.analysis)
-      val incOptions = IncOptionsUtil.defaultIncOptions()
-      val reporter = new LoggerReporter(maxErrors, log, identity)
       val extra = Array(InterfaceUtil.t2(("key", "value")))
-      val setup = compiler.setup(analysisMap, dc, skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
-      val classesDir = tempDir / "classes"
-      val in = compiler.inputs(si.allJars, sources, classesDir, Array(), Array(), maxErrors, Array(),
-        CompileOrder.Mixed, cs, setup, prev0)
+      val setup = compiler.setup(analysisMap, dc, skip = false, h.tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
+      val in = compiler.inputs(h.si.allJars, sources, h.classesDir, Array(), Array(), maxErrors, Array(),
+        CompileOrder.Mixed, h.cs, setup, prev0)
       val result = compiler.compile(in, log)
       //val prev = compiler.previousResult(result)
       fileStore.set(result.analysis match { case a: Analysis => a }, result.setup)
@@ -122,19 +119,62 @@ class IncrementalCompilerSpec extends BridgeProviderSpecification {
       }
       val analysisMap2 = f1((f: File) => prev.analysis)
       val extra2 = Array(InterfaceUtil.t2(("key", "value2")))
-      val setup2 = compiler.setup(analysisMap2, dc, skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra2)
-      val in2 = compiler.inputs(si.allJars, sources, classesDir, Array(), Array(), maxErrors, Array(),
-        CompileOrder.Mixed, cs, setup2, prev)
+      val setup2 = compiler.setup(analysisMap2, dc, skip = false, h.tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra2)
+      val in2 = compiler.inputs(h.si.allJars, sources, h.classesDir, Array(), Array(), maxErrors, Array(),
+        CompileOrder.Mixed, h.cs, setup2, prev)
       val result2 = compiler.compile(in2, log)
       assert(result2.hasModified)
     }
   }
 
-  def scalaCompiler(instance: ScalaInstance, bridgeJar: File): AnalyzingCompiler =
-    new AnalyzingCompiler(instance, CompilerInterfaceProvider.constant(bridgeJar), ClasspathOptions.boot)
+  it should "restore existing classfiles on failure" in {
+    withHarness { h =>
+      def currentClasses() = (PathFinder(h.classesDir) ** "*.class").get.toSet
+      val incOptions =
+        IncOptionsUtil.defaultIncOptions()
+          .withClassfileManagerType(
+            Maybe.just(new TransactionalManagerType(h.tempDir / "backup", log))
+          )
+      val knownSampleGoodFile = h.tempDir / "src" / "Good.scala"
+      IO.copyFile(knownSampleGoodFile0, knownSampleGoodFile, false)
+      val sources = Array(knownSampleGoodFile)
+      val prev0 = compiler.emptyPreviousResult
+      val analysisMap = f1((f: File) => prev0.analysis)
+      val extra = Array(InterfaceUtil.t2(("key", "value")))
+      val setup = compiler.setup(analysisMap, dc, skip = false, h.tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
+      val in = compiler.inputs(h.si.allJars, sources, h.classesDir, Array(), Array(), maxErrors, Array(),
+        CompileOrder.Mixed, h.cs, setup, prev0)
+      val result = compiler.compile(in, log)
+      val prev = compiler.previousResult(result)
+      val expectedClasses = currentClasses()
 
-  def f1[A, B](f: A => B): F1[A, B] =
-    new F1[A, B] {
-      def apply(a: A): B = f(a)
+      // Compile again with an analysis function that has a sideeffect of destroying
+      // classes, and ensure that the classes directory is restored afterward.
+      val exception = new Exception("Expected exception")
+      val analysisMap2 =
+        f1[File, Maybe[CompileAnalysis]] { f =>
+          expectedClasses.foreach(_.delete())
+          throw exception
+        }
+
+      val badSampleFile = h.tempDir / "src" / "Foo.scala"
+      IO.copyFile(badSampleFile0, badSampleFile, false)
+      val sources2 = Array(knownSampleGoodFile)
+      val setup2 = compiler.setup(analysisMap2, dc, skip = false, h.tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
+      val in2 = compiler.inputs(h.si.allJars, sources2, h.classesDir, Array(), Array(), maxErrors, Array(),
+        CompileOrder.Mixed, h.cs, setup2, prev)
+
+      // Expect the compile to have been poisoned.
+      try {
+        val result = compiler.compile(in2, log)
+        assert(false, s"Expected to fail while compiling $badSampleFile")
+      } catch {
+        case e if e == exception =>
+        // pass
+      }
+
+      // Confirm that the original classfiles are still in place.
+      assert(expectedClasses == currentClasses())
     }
+  }
 }


### PR DESCRIPTION
ClassfileManager is supposed to protect against errors occurring during compilation which would prevent analysis from being written.

But with its current API, it is only able to do that job with the explicit cooperation of all tools involved. For example, if javac or scalac decided to overwrite a file before raising an exception, or analysis of classfiles fails in `sbt.internal.inc.classfile.Analyze`, then the post-facto call to `generated` is too late to back things up. This is not just a theoretical concern: the Analyze object can _currently_ fail when partial classpaths are in play. Will post a separate patch to improve that, but it's certainly not going to be the last time we see an exception.

Instead, this review changes the API of ClassfileManager to allow for pessimistically cloning the class directory into the configured backup directory, and restoring it in case of failure.
