### PR TITLE
SafeLazy: explicitly turn by-name parameter into Function0

### DIFF
--- a/internal/zinc-apiinfo/src/main/scala/xsbti/SafeLazy.scala
+++ b/internal/zinc-apiinfo/src/main/scala/xsbti/SafeLazy.scala
@@ -6,7 +6,7 @@ object SafeLazy {
   def apply[T <: AnyRef](eval: xsbti.F0[T]): xsbti.api.Lazy[T] =
     apply(eval())
   def apply[T <: AnyRef](eval: => T): xsbti.api.Lazy[T] =
-    fromFunction0(eval _)
+    fromFunction0(() => eval)
   def fromFunction0[T <: AnyRef](eval: () => T): xsbti.api.Lazy[T] =
     new Impl(eval)
 


### PR DESCRIPTION
Dotty does not support eta-expanding lazy vals, it's clearer to do it by hand.
