### PR TITLE
FPORT: Fixes incremental compiler missing member ref from macro expansion  

### DIFF
--- a/internal/compiler-bridge/src-2.10/main/scala/xsbt/Dependency.scala
+++ b/internal/compiler-bridge/src-2.10/main/scala/xsbt/Dependency.scala
@@ -245,8 +245,9 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile with 
       // In some cases (eg. macro annotations), `typeTree.tpe` may be null. See sbt/sbt#1593 and sbt/sbt#1655.
       case typeTree: TypeTree if typeTree.tpe != null =>
         symbolsInType(typeTree.tpe) foreach addDependency
-      case MacroExpansionOf(original) if inspectedOriginalTrees.add(original) =>
+      case m @ MacroExpansionOf(original) if inspectedOriginalTrees.add(original) =>
         traverse(original)
+        super.traverse(m)
       case _: ClassDef | _: ModuleDef if tree.symbol != null && tree.symbol != NoSymbol =>
         // make sure we cache lookups for all classes declared in the compilation unit; the recorded information
         // will be used in Analyzer phase

--- a/internal/compiler-bridge/src/main/scala/xsbt/Dependency.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/Dependency.scala
@@ -245,8 +245,9 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile with 
       // In some cases (eg. macro annotations), `typeTree.tpe` may be null. See sbt/sbt#1593 and sbt/sbt#1655.
       case typeTree: TypeTree if typeTree.tpe != null =>
         symbolsInType(typeTree.tpe) foreach addDependency
-      case MacroExpansionOf(original) if inspectedOriginalTrees.add(original) =>
+      case m @ MacroExpansionOf(original) if inspectedOriginalTrees.add(original) =>
         traverse(original)
+        super.traverse(m)
       case _: ClassDef | _: ModuleDef if tree.symbol != null && tree.symbol != NoSymbol =>
         // make sure we cache lookups for all classes declared in the compilation unit; the recorded information
         // will be used in Analyzer phase


### PR DESCRIPTION
This is forward porting of https://github.com/sbt/sbt/pull/2563
Fix sbt/sbt#2560

traverse(tree: Tree) used to call super.traverse(tree) at the end.
sbt/sbt@0f616294c4e713dc415f5dc3ae7aef257decb228 brought the traversing
call to inside of the pattern matching.
For the case of MacroExpansionOf(original), it amounts to not traveling
the macro-expanded code. See
sbt/src/sbt-test/source-dependencies/macro-nonarg-dep for the repro.
