### PR TITLE
FPORT: Avoid CCE when scalac internally uses compileLate. Fixes #2452

### DIFF
--- a/internal/compiler-bridge/src-2.10/main/scala/xsbt/API.scala
+++ b/internal/compiler-bridge/src-2.10/main/scala/xsbt/API.scala
@@ -66,7 +66,7 @@ final class API(val global: CallbackGlobal) extends Compat {
   }
 
   private abstract class TopLevelTraverser extends Traverser {
-    def `class`(s: Symbol)
+    def `class`(s: Symbol): Unit
     override def traverse(tree: Tree): Unit = {
       tree match {
         case (_: ClassDef | _: ModuleDef) if isTopLevel(tree.symbol) => `class`(tree.symbol)

--- a/internal/compiler-bridge/src-2.10/main/scala/xsbt/Dependency.scala
+++ b/internal/compiler-bridge/src-2.10/main/scala/xsbt/Dependency.scala
@@ -33,11 +33,11 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile with 
   import global._
 
   def newPhase(prev: Phase): Phase = new DependencyPhase(prev)
-  private class DependencyPhase(prev: Phase) extends Phase(prev) {
+  private class DependencyPhase(prev: Phase) extends GlobalPhase(prev) {
     override def description = "Extracts dependency information"
     def name = Dependency.name
-    def run: Unit = {
-      for (unit <- currentRun.units if !unit.isJava) {
+    def apply(unit: CompilationUnit): Unit = {
+      if (!unit.isJava) {
         // build dependencies structure
         val sourceFile = unit.source.file.file
         if (global.callback.nameHashing) {

--- a/internal/compiler-bridge/src/main/scala/xsbt/Dependency.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/Dependency.scala
@@ -33,11 +33,11 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile with 
   import global._
 
   def newPhase(prev: Phase): Phase = new DependencyPhase(prev)
-  private class DependencyPhase(prev: Phase) extends Phase(prev) {
+  private class DependencyPhase(prev: Phase) extends GlobalPhase(prev) {
     override def description = "Extracts dependency information"
     def name = Dependency.name
-    def run: Unit = {
-      for (unit <- currentRun.units if !unit.isJava) {
+    def apply(unit: CompilationUnit): Unit = {
+      if (!unit.isJava) {
         // build dependencies structure
         val sourceFile = unit.source.file.file
         if (global.callback.nameHashing) {


### PR DESCRIPTION
This is forward port of https://github.com/sbt/sbt/pull/2453.

For example, when the `--sourcepath` option is provided
and the refchecks phase compiles an annotation found
on a referenced symbol from the sourcepath.

`compileLate` assumes that all non-sentinel compiler
phases can be down cast to `GlobalPhase`.

This commit changes the two phases in SBT to extend
this instead of `Phase`. This has the knock on benefit
of simplifying the phases by letting the `GlobalPhase.run`
iterator over the list of compilation units and feed them
to us one by one.

I checked that the test case failed before making each
change.
