### PR TITLE
Rework DefinesClass lookup.

### DIFF
--- a/internal/compiler-interface/src/main/datatype/incremental.json
+++ b/internal/compiler-interface/src/main/datatype/incremental.json
@@ -320,18 +320,10 @@
       ],
       "fields": [
         {
-          "name": "analysisMap",
-          "type": "xsbti.F1<java.io.File,xsbti.Maybe<xsbti.compile.CompileAnalysis>>",
+          "name": "perClasspathEntryLookup",
+          "type": "xsbti.compile.PerClasspathEntryLookup",
           "doc": [
-            "Provides the Analysis for the given classpath entry."
-          ]
-        },
-        {
-          "name": "definesClass",
-          "type": "xsbti.F1<java.io.File,xsbti.compile.DefinesClass>",
-          "doc": [
-            "Provides a function to determine if classpath entry `file` contains a given class.",
-            "The returned function should generally cache information about `file`, such as the list of entries in a jar."
+            "Provides a lookup of data structures and operations associated with a single classpath entry."
           ]
         },
         {

--- a/internal/compiler-interface/src/main/java/xsbti/compile/DefinesClass.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/DefinesClass.java
@@ -1,12 +1,14 @@
 package xsbti.compile;
 
 /**
-* Determines if an entry on a classpath contains a class.
-*/
-public interface DefinesClass
-{
- 	/**
-	* Returns true if the classpath entry contains the requested class.
-	*/
-	boolean apply(String className);
+ * Determines if a classpath entry contains a class.
+ *
+ * The corresponding classpath entry is not exposed by this interface. It's tied
+ * to it by a specific class that implements this interface.
+ */
+public interface DefinesClass {
+    /**
+     * Returns true if the classpath entry contains the requested class.
+     */
+    boolean apply(String className);
 }

--- a/internal/compiler-interface/src/main/java/xsbti/compile/PerClasspathEntryLookup.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/PerClasspathEntryLookup.java
@@ -1,0 +1,18 @@
+package xsbti.compile;
+
+import java.io.File;
+
+/**
+ * Defines lookup of data structures and operations zinc needs to perform on per classpath element basis.
+ */
+public interface PerClasspathEntryLookup {
+
+    /** Provides the Analysis for the given classpath entry. */
+    xsbti.Maybe<CompileAnalysis> analysis(File classpathEntry);
+
+    /**
+     * Provides a function to determine if classpath entry `file` contains a given class.
+     * The returned function should generally cache information about `file`, such as the list of entries in a jar.
+     */
+    DefinesClass definesClass(File classpathEntry);
+}

--- a/zinc/src/main/scala/sbt/internal/inc/CompileConfiguration.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/CompileConfiguration.scala
@@ -4,9 +4,8 @@ package inc
 
 import java.io.File
 
-import inc.Locate._
 import xsbti.Reporter
-import xsbti.compile.{ GlobalsCache, CompileProgress, IncOptions, MiniSetup, CompileAnalysis }
+import xsbti.compile.{ GlobalsCache, CompileProgress, IncOptions, MiniSetup, CompileAnalysis, PerClasspathEntryLookup }
 
 /**
  * Configuration used for running an analyzing compiler (a compiler which can extract dependencies between source files and JARs).
@@ -17,8 +16,7 @@ import xsbti.compile.{ GlobalsCache, CompileProgress, IncOptions, MiniSetup, Com
  * @param previousSetup
  * @param currentSetup
  * @param progress
- * @param getAnalysis
- * @param definesClass
+ * @param perClasspathEntryLookup
  * @param reporter
  * @param compiler
  * @param javac
@@ -32,8 +30,7 @@ final class CompileConfiguration(
   val previousSetup: Option[MiniSetup],
   val currentSetup: MiniSetup,
   val progress: Option[CompileProgress],
-  val getAnalysis: File => Option[CompileAnalysis],
-  val definesClass: DefinesClass,
+  val perClasspathEntryLookup: PerClasspathEntryLookup,
   val reporter: Reporter,
   val compiler: AnalyzingCompiler,
   val javac: xsbti.compile.JavaCompiler,

--- a/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
@@ -5,7 +5,7 @@ package inc
 import sbt.internal.inc.javac.{ IncrementalCompilerJavaTools, JavaTools }
 import xsbti.{ Position, Logger, Maybe, Reporter, F1, T2 }
 import xsbti.compile.{ CompileOrder, GlobalsCache, IncOptions, MiniSetup, CompileAnalysis, CompileResult, CompileOptions }
-import xsbti.compile.{ PreviousResult, Setup, Inputs, IncrementalCompiler, DefinesClass }
+import xsbti.compile.{ PreviousResult, Setup, Inputs, IncrementalCompiler, PerClasspathEntryLookup }
 import xsbti.compile.{ Compilers => XCompilers, CompileProgress, Output }
 import java.io.File
 import sbt.util.Logger.m2o
@@ -42,11 +42,7 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
       incrementalCompile(scalac, javacChosen, sources, classpath, CompileOutput(classesDirectory), cache, None, scalacOptions, javacOptions,
         m2o(in.previousResult.analysis),
         m2o(in.previousResult.setup),
-        { f => m2o(analysisMap()(f)) },
-        { f =>
-          val dc = definesClass()(f)
-          s => dc(s)
-        },
+        perClasspathEntryLookup,
         reporter, order, skip, incrementalCompilerOptions,
         extra.toList map { x => (x.get1, x.get2) })(log)
     }
@@ -65,8 +61,6 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
    * @param javacOptions  Options for the Java compiler
    * @param previousAnalysis  The previous dependency Analysis object/
    * @param previousSetup  The previous compilation setup (if any)
-   * @param analysisMap   A map of file to the dependency analysis of that file.
-   * @param definesClass  A mehcnaism of looking up whether or not a JAR defines a particular Class.
    * @param reporter  Where we sent all compilation error/warning events
    * @param compileOrder  The order we'd like to mix compilation.  JavaThenScala, ScalaThenJava or Mixed.
    * @param skip  IF true, we skip compilation and just return the previous analysis file.
@@ -87,8 +81,7 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
     javacOptions: Seq[String] = Nil,
     previousAnalysis: Option[CompileAnalysis],
     previousSetup: Option[MiniSetup],
-    analysisMap: File => Option[CompileAnalysis] = { _ => None },
-    definesClass: Locate.DefinesClass = Locate.definesClass _,
+    perClasspathEntryLookup: PerClasspathEntryLookup,
     reporter: Reporter,
     compileOrder: CompileOrder = Mixed,
     skip: Boolean = false,
@@ -100,7 +93,7 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
       case None           => Analysis.empty(incrementalCompilerOptions.nameHashing)
     }
     val config = MixedAnalyzingCompiler.makeConfig(scalac, javac, sources, classpath, output, cache,
-      progress, options, javacOptions, prev, previousSetup, analysisMap, definesClass, reporter,
+      progress, options, javacOptions, prev, previousSetup, perClasspathEntryLookup, reporter,
       compileOrder, skip, incrementalCompilerOptions, extra)
     if (skip) new CompileResult(prev, config.currentSetup, false)
     else {
@@ -118,7 +111,7 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
     override def lookupOnClasspath(binaryClassName: String): Option[File] =
       entry(binaryClassName)
     override def lookupAnalysis(classFile: File): Option[CompileAnalysis] =
-      compileConfiguration.getAnalysis(classFile)
+      m2o(compileConfiguration.perClasspathEntryLookup.analysis(classFile))
 
     override def lookupAnalysis(binaryDependency: File, binaryClassName: String): Option[CompileAnalysis] = {
       lookupOnClasspath(binaryClassName) flatMap { defines =>
@@ -162,9 +155,9 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
     IncrementalCompile(sourcesSet, lookup, mixedCompiler.compile, analysis, output, log, incOptions).swap
   }
 
-  def setup(analysisMap: F1[File, Maybe[CompileAnalysis]], definesClass: F1[File, DefinesClass], skip: Boolean, cacheFile: File, cache: GlobalsCache,
+  def setup(perClasspathEntryLookup: PerClasspathEntryLookup, skip: Boolean, cacheFile: File, cache: GlobalsCache,
     incrementalCompilerOptions: IncOptions, reporter: Reporter, extra: Array[T2[String, String]]): Setup =
-    new Setup(analysisMap, definesClass, skip, cacheFile, cache, incrementalCompilerOptions, reporter, extra)
+    new Setup(perClasspathEntryLookup, skip, cacheFile, cache, incrementalCompilerOptions, reporter, extra)
   def inputs(options: CompileOptions, compilers: XCompilers, setup: Setup, pr: PreviousResult): Inputs =
     new Inputs(compilers, options, setup, pr)
   def inputs(classpath: Array[File], sources: Array[File], classesDirectory: File, scalacOptions: Array[String],

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -6,7 +6,6 @@ import java.io.File
 import java.lang.ref.{ SoftReference, Reference }
 
 import inc.javac.AnalyzingJavaCompiler
-import Locate.DefinesClass
 import xsbti.{ AnalysisCallback => XAnalysisCallback, Reporter }
 import xsbti.compile.CompileOrder._
 import xsbti.compile._
@@ -108,8 +107,7 @@ object MixedAnalyzingCompiler {
     javacOptions: Seq[String] = Nil,
     previousAnalysis: CompileAnalysis,
     previousSetup: Option[MiniSetup],
-    analysisMap: File => Option[CompileAnalysis] = { _ => None },
-    definesClass: DefinesClass = Locate.definesClass _,
+    perClasspathEntryLookup: PerClasspathEntryLookup,
     reporter: Reporter,
     compileOrder: CompileOrder = Mixed,
     skip: Boolean = false,
@@ -127,8 +125,7 @@ object MixedAnalyzingCompiler {
         progress,
         previousAnalysis,
         previousSetup,
-        analysisMap,
-        definesClass,
+        perClasspathEntryLookup,
         scalac,
         javac,
         reporter,
@@ -145,8 +142,7 @@ object MixedAnalyzingCompiler {
     progress: Option[CompileProgress],
     previousAnalysis: CompileAnalysis,
     previousSetup: Option[MiniSetup],
-    analysis: File => Option[CompileAnalysis],
-    definesClass: DefinesClass,
+    perClasspathEntryLookup: PerClasspathEntryLookup,
     compiler: AnalyzingCompiler,
     javac: xsbti.compile.JavaCompiler,
     reporter: Reporter,
@@ -156,7 +152,7 @@ object MixedAnalyzingCompiler {
   ): CompileConfiguration = {
     import MiniSetupUtil._
     new CompileConfiguration(sources, classpath, previousAnalysis, previousSetup, setup,
-      progress, analysis, definesClass, reporter, compiler, javac, cache, incrementalCompilerOptions)
+      progress, perClasspathEntryLookup: PerClasspathEntryLookup, reporter, compiler, javac, cache, incrementalCompilerOptions)
   }
 
   /** Returns the search classpath (for dependencies) and a function which can also do so. */
@@ -166,7 +162,7 @@ object MixedAnalyzingCompiler {
     val absClasspath = classpath.map(_.getAbsoluteFile)
     val cArgs = new CompilerArguments(compiler.scalaInstance, compiler.cp)
     val searchClasspath = explicitBootClasspath(options.scalacOptions) ++ withBootclasspath(cArgs, absClasspath)
-    (searchClasspath, Locate.entry(searchClasspath, definesClass))
+    (searchClasspath, Locate.entry(searchClasspath, perClasspathEntryLookup))
   }
 
   /** Returns a "lookup file for a given class name" function. */

--- a/zinc/src/test/scala/sbt/inc/IncrementalCompilerSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/IncrementalCompilerSpec.scala
@@ -6,11 +6,10 @@ import java.io.File
 import sbt.internal.inc._
 import sbt.io.IO
 import sbt.io.syntax._
-import sbt.util.{ Logger, InterfaceUtil, Level }
-import sbt.util.InterfaceUtil.f1
+import sbt.util.{ Logger, InterfaceUtil }
 import sbt.internal.util.ConsoleLogger
-import xsbti.{ F1, Maybe }
-import xsbti.compile.{ CompileAnalysis, CompileOrder, DefinesClass, IncOptionsUtil, PreviousResult }
+import xsbti.Maybe
+import xsbti.compile.{ CompileAnalysis, CompileOrder, DefinesClass, IncOptionsUtil, PreviousResult, PerClasspathEntryLookup }
 
 class IncrementalCompilerSpec extends BridgeProviderSpecification {
 
@@ -21,11 +20,13 @@ class IncrementalCompilerSpec extends BridgeProviderSpecification {
     new File(classOf[IncrementalCompilerSpec].getResource("Good.scala").toURI)
   val fooSampleFile0 =
     new File(classOf[IncrementalCompilerSpec].getResource("Foo.scala").toURI)
-  val dc = f1[File, DefinesClass] { f =>
-    val x = Locate.definesClass(f)
-    new DefinesClass {
-      override def apply(className: String): Boolean = x(className)
-    }
+
+  class Lookup(am: File => Maybe[CompileAnalysis]) extends PerClasspathEntryLookup {
+    override def analysis(classpathEntry: File): Maybe[CompileAnalysis] =
+      am(classpathEntry)
+
+    override def definesClass(classpathEntry: File): DefinesClass =
+      Locate.definesClass(classpathEntry)
   }
 
   "incremental compiler" should "compile" in {
@@ -36,11 +37,11 @@ class IncrementalCompilerSpec extends BridgeProviderSpecification {
       val si = scalaInstance(scalaVersion)
       val sc = scalaCompiler(si, compilerBridge)
       val cs = compiler.compilers(si, ClasspathOptions.boot, None, sc)
-      val analysisMap = f1((f: File) => Maybe.nothing[CompileAnalysis])
+      val lookup = new Lookup(Function.const(Maybe.nothing[CompileAnalysis]))
       val incOptions = IncOptionsUtil.defaultIncOptions()
       val reporter = new LoggerReporter(maxErrors, log, identity)
       val extra = Array(InterfaceUtil.t2(("key", "value")))
-      val setup = compiler.setup(analysisMap, dc, skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
+      val setup = compiler.setup(lookup, skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
       val prev = compiler.emptyPreviousResult
       val classesDir = tempDir / "classes"
       val in = compiler.inputs(si.allJars, Array(knownSampleGoodFile), classesDir, Array(), Array(), maxErrors, Array(),
@@ -68,18 +69,18 @@ class IncrementalCompilerSpec extends BridgeProviderSpecification {
       val sc = scalaCompiler(si, compilerBridge)
       val cs = compiler.compilers(si, ClasspathOptions.boot, None, sc)
       val prev0 = compiler.emptyPreviousResult
-      val analysisMap = f1((f: File) => prev0.analysis)
+      val lookup = new Lookup(_ => prev0.analysis)
       val incOptions = IncOptionsUtil.defaultIncOptions()
       val reporter = new LoggerReporter(maxErrors, log, identity)
       val extra = Array(InterfaceUtil.t2(("key", "value")))
-      val setup = compiler.setup(analysisMap, dc, skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
+      val setup = compiler.setup(lookup, skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
       val classesDir = tempDir / "classes"
       val in = compiler.inputs(si.allJars, sources, classesDir, Array(), Array(), maxErrors, Array(),
         CompileOrder.Mixed, cs, setup, prev0)
       val result = compiler.compile(in, log)
       val prev = compiler.previousResult(result)
-      val analysisMap2 = f1((f: File) => prev.analysis)
-      val setup2 = compiler.setup(analysisMap2, dc, skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
+      val lookup2 = new Lookup(_ => prev.analysis)
+      val setup2 = compiler.setup(lookup2, skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
       val in2 = compiler.inputs(si.allJars, sources, classesDir, Array(), Array(), maxErrors, Array(),
         CompileOrder.Mixed, cs, setup2, prev)
       val result2 = compiler.compile(in2, log)
@@ -105,11 +106,11 @@ class IncrementalCompilerSpec extends BridgeProviderSpecification {
       val sc = scalaCompiler(si, compilerBridge)
       val cs = compiler.compilers(si, ClasspathOptions.boot, None, sc)
       val prev0 = compiler.emptyPreviousResult
-      val analysisMap = f1((f: File) => prev0.analysis)
+      val lookup = new Lookup(_ => prev0.analysis)
       val incOptions = IncOptionsUtil.defaultIncOptions()
       val reporter = new LoggerReporter(maxErrors, log, identity)
       val extra = Array(InterfaceUtil.t2(("key", "value")))
-      val setup = compiler.setup(analysisMap, dc, skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
+      val setup = compiler.setup(lookup, skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
       val classesDir = tempDir / "classes"
       val in = compiler.inputs(si.allJars, sources, classesDir, Array(), Array(), maxErrors, Array(),
         CompileOrder.Mixed, cs, setup, prev0)
@@ -120,9 +121,9 @@ class IncrementalCompilerSpec extends BridgeProviderSpecification {
         case Some((a, s)) => new PreviousResult(Maybe.just(a), Maybe.just(s))
         case _            => sys.error("previous is not found")
       }
-      val analysisMap2 = f1((f: File) => prev.analysis)
+      val lookup2 = new Lookup(_ => prev.analysis)
       val extra2 = Array(InterfaceUtil.t2(("key", "value2")))
-      val setup2 = compiler.setup(analysisMap2, dc, skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra2)
+      val setup2 = compiler.setup(lookup2, skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra2)
       val in2 = compiler.inputs(si.allJars, sources, classesDir, Array(), Array(), maxErrors, Array(),
         CompileOrder.Mixed, cs, setup2, prev)
       val result2 = compiler.compile(in2, log)
@@ -132,9 +133,4 @@ class IncrementalCompilerSpec extends BridgeProviderSpecification {
 
   def scalaCompiler(instance: ScalaInstance, bridgeJar: File): AnalyzingCompiler =
     new AnalyzingCompiler(instance, CompilerInterfaceProvider.constant(bridgeJar), ClasspathOptions.boot)
-
-  def f1[A, B](f: A => B): F1[A, B] =
-    new F1[A, B] {
-      def apply(a: A): B = f(a)
-    }
 }


### PR DESCRIPTION
Before this commit, DefinesClass meant two things:
1. Function String => Boolean that determined whether a class with
    a given binary name is defined by a classpath entry the function
    instance is associated with
2. A function File => (String => Boolean) that created function from 1.
    for a given classpath entry

After this commit, `DefinesClass` means only the function from 1.

The operation from 2. is moved to newly introduced PerClasspathEntryLookup
interface. That interface also includes lookup of Analysis that corresponds
to a given classpath entry.

Thanks to this change, conversions between Java-defined function-like
objects and Scala functions is largely removed. These conversions were
error prone as shown by #100. As a bonus, the refactoring from this commit
makes it a bit easier to implement sbt/sbt#2525.
