### PR TITLE
Rework DefinesClass lookup.

### DIFF
--- a/internal/compiler-interface/src/main/datatype/incremental.json
+++ b/internal/compiler-interface/src/main/datatype/incremental.json
@@ -320,18 +320,10 @@
       ],
       "fields": [
         {
-          "name": "analysisMap",
-          "type": "xsbti.F1<java.io.File,xsbti.Maybe<xsbti.compile.CompileAnalysis>>",
+          "name": "perClasspathEntryLookup",
+          "type": "xsbti.compile.PerClasspathEntryLookup",
           "doc": [
-            "Provides the Analysis for the given classpath entry."
-          ]
-        },
-        {
-          "name": "definesClass",
-          "type": "xsbti.F1<java.io.File,xsbti.compile.DefinesClass>",
-          "doc": [
-            "Provides a function to determine if classpath entry `file` contains a given class.",
-            "The returned function should generally cache information about `file`, such as the list of entries in a jar."
+            "Provides a lookup of data structures and operations associated with a single classpath entry."
           ]
         },
         {

--- a/internal/compiler-interface/src/main/java/xsbti/compile/DefinesClass.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/DefinesClass.java
@@ -1,12 +1,14 @@
 package xsbti.compile;
 
 /**
-* Determines if an entry on a classpath contains a class.
-*/
-public interface DefinesClass
-{
- 	/**
-	* Returns true if the classpath entry contains the requested class.
-	*/
-	boolean apply(String className);
+ * Determines if a classpath entry contains a class.
+ *
+ * The corresponding classpath entry is not exposed by this interface. It's tied
+ * to it by a specific class that implements this interface.
+ */
+public interface DefinesClass {
+    /**
+     * Returns true if the classpath entry contains the requested class.
+     */
+    boolean apply(String className);
 }

--- a/internal/compiler-interface/src/main/java/xsbti/compile/PerClasspathEntryLookup.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/PerClasspathEntryLookup.java
@@ -1,0 +1,18 @@
+package xsbti.compile;
+
+import java.io.File;
+
+/**
+ * Defines lookup of data structures and operations zinc needs to perform on per classpath element basis.
+ */
+public interface PerClasspathEntryLookup {
+
+    /** Provides the Analysis for the given classpath entry. */
+    xsbti.Maybe<CompileAnalysis> analysis(File classpathEntry);
+
+    /**
+     * Provides a function to determine if classpath entry `file` contains a given class.
+     * The returned function should generally cache information about `file`, such as the list of entries in a jar.
+     */
+    DefinesClass definesClass(File classpathEntry);
+}

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Locate.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Locate.scala
@@ -65,12 +65,17 @@ object Locate {
 
   private class JarDefinesClass(entry: File) extends DefinesClass {
     import collection.JavaConversions._
-    private val jar = try { new ZipFile(entry, ZipFile.OPEN_READ) } catch {
-      // ZipException doesn't include the file name :(
-      case e: ZipException => throw new RuntimeException("Error opening zip file: " + entry.getName, e)
+    private val entries = {
+      val jar = try { new ZipFile(entry, ZipFile.OPEN_READ) } catch {
+        // ZipException doesn't include the file name :(
+        case e: ZipException => throw new RuntimeException("Error opening zip file: " + entry.getName, e)
+      }
+      try {
+        jar.entries.map(e => toClassName(e.getName)).toSet
+      } finally {
+        jar.close()
+      }
     }
-    private val entries = try { jar.entries.map(e => toClassName(e.getName)).toSet } finally { jar.close() }
-
     override def apply(binaryClassName: String): Boolean =
       entries.contains(binaryClassName)
   }

--- a/zinc/src/main/scala/sbt/internal/inc/CompileConfiguration.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/CompileConfiguration.scala
@@ -4,9 +4,8 @@ package inc
 
 import java.io.File
 
-import inc.Locate._
 import xsbti.Reporter
-import xsbti.compile.{ GlobalsCache, CompileProgress, IncOptions, MiniSetup, CompileAnalysis }
+import xsbti.compile.{ GlobalsCache, CompileProgress, IncOptions, MiniSetup, CompileAnalysis, PerClasspathEntryLookup }
 
 /**
  * Configuration used for running an analyzing compiler (a compiler which can extract dependencies between source files and JARs).
@@ -17,8 +16,7 @@ import xsbti.compile.{ GlobalsCache, CompileProgress, IncOptions, MiniSetup, Com
  * @param previousSetup
  * @param currentSetup
  * @param progress
- * @param getAnalysis
- * @param definesClass
+ * @param perClasspathEntryLookup
  * @param reporter
  * @param compiler
  * @param javac
@@ -32,8 +30,7 @@ final class CompileConfiguration(
   val previousSetup: Option[MiniSetup],
   val currentSetup: MiniSetup,
   val progress: Option[CompileProgress],
-  val getAnalysis: File => Option[CompileAnalysis],
-  val definesClass: DefinesClass,
+  val perClasspathEntryLookup: PerClasspathEntryLookup,
   val reporter: Reporter,
   val compiler: xsbti.compile.ScalaCompiler,
   val javac: xsbti.compile.JavaCompiler,


### PR DESCRIPTION
This is a continuation of #120. It's rebased against 1.0, and added a minor refactoring.

Before this commit, DefinesClass meant two things:
1. Function String => Boolean that determined whether a class with
    a given binary name is defined by a classpath entry the function
    instance is associated with
2. A function File => (String => Boolean) that created function from 1.
    for a given classpath entry

After this commit, `DefinesClass` means only the function from 1.

The operation from 2. is moved to newly introduced PerClasspathEntryLookup
interface. That interface also includes lookup of Analysis that corresponds
to a given classpath entry.

Thanks to this change, conversions between Java-defined function-like
objects and Scala functions is largely removed. These conversions were
error prone as shown by #100. As a bonus, the refactoring from this commit
makes it a bit easier to implement sbt/sbt#2525.

/cc @gkossakowski 
