### PR TITLE
(WIP) Adds FileWatch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 jdk:
-  - openjdk7
+   - openjdk7
 scala:
    - 2.11.7
 

--- a/build.sbt
+++ b/build.sbt
@@ -160,7 +160,7 @@ lazy val zincCore = (project in internalPath / "zinc-core").
   dependsOn(zincApiInfo, zincClasspath, compilerBridge % Test).
   settings(
     testedBaseSettings,
-    libraryDependencies ++= Seq(sbtIO, utilLogging, utilRelation),
+    libraryDependencies ++= Seq(sbtIO, utilLogging, utilRelation, barbaryWatchService),
     // we need to fork because in unit tests we set usejavacp = true which means
     // we are expecting all of our dependencies to be on classpath so Scala compiler
     // can use them while constructing its own classpath for compilation

--- a/internal/compiler-interface/src/main/datatype/incremental.json
+++ b/internal/compiler-interface/src/main/datatype/incremental.json
@@ -327,6 +327,13 @@
           ]
         },
         {
+          "name": "fileWatch",
+          "type": "xsbti.compile.FileWatch",
+          "doc": [
+            "Detects change in file system."
+          ]
+        },
+        {
           "name": "skip",
           "type": "boolean",
           "doc": [
@@ -396,6 +403,52 @@
         {
           "name": "previousResult",
           "type": "xsbti.compile.PreviousResult"
+        }
+      ]
+    },
+    {
+      "name": "FileChanges",
+      "namespace": "xsbti.compile",
+      "target": "Java",
+      "type": "record",
+      "doc": [
+        "Changes detected to the file system since a given time."
+      ],
+      "fields": [
+        {
+          "name": "beginTime",
+          "type": "Long",
+          "doc": [
+            "The begin time for the range monitoring the change, given in millisecond."
+          ]
+        },
+        {
+          "name": "endTime",
+          "type": "Long",
+          "doc": [
+            "The end time for the range monitoring the change, given in millisecond."
+          ]
+        },
+        {
+          "name": "added",
+          "type": "java.util.Set<java.io.File>",
+          "doc": [
+            "Added files."
+          ]
+        },
+        {
+          "name": "removed",
+          "type": "java.util.Set<java.io.File>",
+          "doc": [
+            "Removed files."
+          ]
+        },
+        {
+          "name": "changed",
+          "type": "java.util.Set<java.io.File>",
+          "doc": [
+            "Files that were modified."
+          ]
         }
       ]
     },

--- a/internal/compiler-interface/src/main/java/xsbti/compile/FileWatch.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/FileWatch.java
@@ -1,0 +1,26 @@
+package xsbti.compile;
+
+import java.io.File;
+
+/**
+ * Defines extension point to proactively detect file changes.
+ */
+public interface FileWatch {
+    /** Changes to class files. "since" parameter is used to indicate
+     * the start time for the change.
+     * When detection is not possible it returns nothing().
+     */
+    xsbti.Maybe<FileChanges> productChanges(long since);
+
+    /** Changes to source files. "since" parameter is used to indicate
+     * the start time for the change.
+     * When detection is not possible it returns nothing().
+     */
+    xsbti.Maybe<FileChanges> sourceChanges(long since);
+
+    /** Changes to binary files. "since" parameter is used to indicate
+     * the start time for the change.
+     * When detection is not possible it returns nothing().
+     */
+    xsbti.Maybe<FileChanges> binaryChanges(long since);
+}

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Changes.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Changes.scala
@@ -9,7 +9,8 @@ import java.io.File
 import xsbti.api.NameHashes
 import xsbti.api.NameHash
 
-final case class InitialChanges(internalSrc: Changes[File], removedProducts: Set[File], binaryDeps: Set[File], external: APIChanges)
+final case class InitialChanges(changeBeginTime: Option[Long], changeEndTime: Option[Long],
+  internalSrc: Changes[File], removedProducts: Set[File], binaryDeps: Set[File], external: APIChanges)
 final class APIChanges(val apiChanges: Iterable[APIChange]) {
   override def toString = "API Changes: " + apiChanges
   def allModified: Iterable[String] = apiChanges.map(_.modifiedClass)

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/FileWatch.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/FileWatch.scala
@@ -8,8 +8,7 @@ import sbt.util.Logger
 import Logger.o2m
 import xsbti.Maybe
 import xsbti.compile.{ FileWatch, FileChanges }
-import com.barbarysoftware.watchservice.{ WatchService, WatchKey, WatchEvent, WatchableFile, StandardWatchEventKind }
-import com.barbarysoftware.watchservice.StandardWatchEventKind._
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
@@ -19,7 +18,7 @@ private[sbt] object NoFileWatch extends FileWatch {
   override def binaryChanges(since: Long): Maybe[FileChanges] = o2m(None)
 }
 
-class BarbaryFileWatch(sourcesToWatch: List[File], log: Logger) extends FileWatch with AutoCloseable {
+abstract class NativeFileWatch(sourcesToWatch: List[File], log: Logger) extends FileWatch with AutoCloseable {
   override def productChanges(since: Long): Maybe[FileChanges] = o2m(None)
   override def sourceChanges(since: Long): Maybe[FileChanges] =
     synchronized {
@@ -29,18 +28,24 @@ class BarbaryFileWatch(sourcesToWatch: List[File], log: Logger) extends FileWatc
       else {
         val xs = sourceEvents.toList filter { case (_, t, _) => t >= since }
         Some(new FileChanges(since, t,
-          (xs collect { case (f, _, ENTRY_CREATE) => f }).toSet.asJava,
-          (xs collect { case (f, _, ENTRY_DELETE) => f }).toSet.asJava,
-          (xs collect { case (f, _, ENTRY_MODIFY) => f }).toSet.asJava))
+          (xs collect { case (f, _, FileChangeType.Create) => f }).toSet.asJava,
+          (xs collect { case (f, _, FileChangeType.Delete) => f }).toSet.asJava,
+          (xs collect { case (f, _, FileChangeType.Modify) => f }).toSet.asJava))
       }
-      sourceEvents.clear()
-      trackTime = t
+
+      setTrackTime(t)
       o2m(result)
     }
 
   override def binaryChanges(since: Long): Maybe[FileChanges] = o2m(None)
-  private val sourceEvents: mutable.ListBuffer[(File, Long, WatchEvent.Kind[_])] = mutable.ListBuffer.empty
-  private def addSourceEvent(file0: File, t: Long, kind: WatchEvent.Kind[_]): Unit =
+  private var trackTime: Long = System.currentTimeMillis
+  protected def setTrackTime(value: Long): Unit =
+    {
+      sourceEvents.clear()
+      trackTime = value
+    }
+  private val sourceEvents: mutable.ListBuffer[(File, Long, FileChangeType)] = mutable.ListBuffer.empty
+  protected def addSourceEvent(file0: File, t: Long, kind: FileChangeType): Unit =
     synchronized {
       // On Mac /var/folders are reported out to /private/var/folders/
       val file =
@@ -48,17 +53,30 @@ class BarbaryFileWatch(sourcesToWatch: List[File], log: Logger) extends FileWatc
         else file0
       sourceEvents.append((file, t, kind))
     }
-  private val watcher = WatchService.newWatchService
+}
+
+/**
+ * File watcher using JDK7. For Linux and Windows, there's a native implemation.
+ * For OS X it will use polling.
+ */
+class JDK7FileWatch(sourcesToWatch: List[File], log: Logger) extends NativeFileWatch(sourcesToWatch, log) {
+  import java.nio.file._
+  import StandardWatchEventKinds._
+
+  private val watcher = FileSystems.getDefault.newWatchService()
   sourcesToWatch foreach { x =>
     if (x.isDirectory) {
-      val f = new WatchableFile(x)
-      f.register(watcher, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY)
+      x.toPath.register(watcher, Array[WatchEvent.Kind[_]](ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY),
+        // This custom modifier exists just for polling implementations of the watch service, and means poll every 2 seconds.
+        // For non polling event based watchers, it has no effect.
+        com.sun.nio.file.SensitivityWatchEventModifier.HIGH)
     }
   }
-  private var trackTime: Long = System.currentTimeMillis
-  private val consumer = new Thread(makeRunnable)
-  consumer.start()
-  def makeRunnable: Runnable = new Runnable {
+  def init(): Unit = {
+    val consumer = new Thread(makeRunnable)
+    consumer.start()
+  }
+  private def makeRunnable: Runnable = new Runnable {
     def run: Unit = {
       var done = false
       while (!done) {
@@ -69,8 +87,8 @@ class BarbaryFileWatch(sourcesToWatch: List[File], log: Logger) extends FileWatc
               case OVERFLOW => ()
               case _ =>
                 event0 match {
-                  case ev: WatchEvent[File] @unchecked =>
-                    addSourceEvent(ev.context, t, ev.kind)
+                  case ev: WatchEvent[Path] @unchecked =>
+                    addSourceEvent(ev.context.toFile, t, FileChangeType(ev.kind))
                     log.debug("[filewatch] detected file system event: " + ev.context() + " " + ev.kind)
                 }
             }
@@ -82,8 +100,77 @@ class BarbaryFileWatch(sourcesToWatch: List[File], log: Logger) extends FileWatc
       }
     }
   }
-
-  def close: Unit = {
+  init()
+  override def close: Unit = {
     watcher.close
   }
+}
+
+/** File watcher for OS X. */
+class BarbaryFileWatch(sourcesToWatch: List[File], log: Logger) extends NativeFileWatch(sourcesToWatch, log) {
+  import com.barbarysoftware.watchservice.{ WatchService, WatchKey, WatchEvent, WatchableFile, StandardWatchEventKind }
+  import com.barbarysoftware.watchservice.StandardWatchEventKind._
+
+  private val watcher = WatchService.newWatchService
+  sourcesToWatch foreach { x =>
+    if (x.isDirectory) {
+      val f = new WatchableFile(x)
+      f.register(watcher, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY)
+    }
+  }
+  def init(): Unit = {
+    val consumer = new Thread(makeBarbaryRunnable)
+    consumer.start()
+  }
+  private def makeBarbaryRunnable: Runnable = new Runnable {
+    def run: Unit = {
+      var done = false
+      while (!done) {
+        Try { watcher.take() } map { key =>
+          key.pollEvents.asScala foreach { event0 =>
+            val t = System.currentTimeMillis
+            event0.kind match {
+              case OVERFLOW => ()
+              case _ =>
+                event0 match {
+                  case ev: WatchEvent[File] @unchecked =>
+                    addSourceEvent(ev.context, t, FileChangeType(ev.kind))
+                    log.debug("[filewatch] detected file system event: " + ev.context() + " " + ev.kind)
+                }
+            }
+          }
+          done = !key.reset
+        } recover {
+          case e => done = true
+        }
+      }
+    }
+  }
+  init()
+  override def close: Unit = {
+    watcher.close
+  }
+}
+
+sealed trait FileChangeType
+object FileChangeType {
+  import com.barbarysoftware.watchservice.{ WatchEvent => BWatchEvent }
+  import com.barbarysoftware.watchservice.{ StandardWatchEventKind => BStandard }
+  import java.nio.file.WatchEvent
+  import com.barbarysoftware.watchservice.{ StandardWatchEventKind => Standard }
+  def apply(value: BWatchEvent.Kind[_]): FileChangeType =
+    value match {
+      case BStandard.ENTRY_CREATE => Create
+      case BStandard.ENTRY_DELETE => Delete
+      case BStandard.ENTRY_MODIFY => Modify
+    }
+  def apply(value: WatchEvent.Kind[_]): FileChangeType =
+    value match {
+      case Standard.ENTRY_CREATE => Create
+      case Standard.ENTRY_DELETE => Delete
+      case Standard.ENTRY_MODIFY => Modify
+    }
+  case object Create extends FileChangeType
+  case object Delete extends FileChangeType
+  case object Modify extends FileChangeType
 }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/FileWatch.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/FileWatch.scala
@@ -1,0 +1,89 @@
+package sbt
+package internal
+package inc
+
+import scala.util.Try
+import java.io.File
+import sbt.util.Logger
+import Logger.o2m
+import xsbti.Maybe
+import xsbti.compile.{ FileWatch, FileChanges }
+import com.barbarysoftware.watchservice.{ WatchService, WatchKey, WatchEvent, WatchableFile, StandardWatchEventKind }
+import com.barbarysoftware.watchservice.StandardWatchEventKind._
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+private[sbt] object NoFileWatch extends FileWatch {
+  override def productChanges(since: Long): Maybe[FileChanges] = o2m(None)
+  override def sourceChanges(since: Long): Maybe[FileChanges] = o2m(None)
+  override def binaryChanges(since: Long): Maybe[FileChanges] = o2m(None)
+}
+
+class BarbaryFileWatch(sourcesToWatch: List[File], log: Logger) extends FileWatch with AutoCloseable {
+  override def productChanges(since: Long): Maybe[FileChanges] = o2m(None)
+  override def sourceChanges(since: Long): Maybe[FileChanges] =
+    synchronized {
+      log.debug(s"[filewatch] sourceChanges - since: $since")
+      val t = System.currentTimeMillis
+      val result = if (since < trackTime) None
+      else {
+        val xs = sourceEvents.toList filter { case (_, t, _) => t >= since }
+        Some(new FileChanges(since, t,
+          (xs collect { case (f, _, ENTRY_CREATE) => f }).toSet.asJava,
+          (xs collect { case (f, _, ENTRY_DELETE) => f }).toSet.asJava,
+          (xs collect { case (f, _, ENTRY_MODIFY) => f }).toSet.asJava))
+      }
+      sourceEvents.clear()
+      trackTime = t
+      o2m(result)
+    }
+
+  override def binaryChanges(since: Long): Maybe[FileChanges] = o2m(None)
+  private val sourceEvents: mutable.ListBuffer[(File, Long, WatchEvent.Kind[_])] = mutable.ListBuffer.empty
+  private def addSourceEvent(file0: File, t: Long, kind: WatchEvent.Kind[_]): Unit =
+    synchronized {
+      // On Mac /var/folders are reported out to /private/var/folders/
+      val file =
+        if (file0.toString startsWith "/private/var/folders/") new File(file0.toString.replaceAll("""^\/private\/""", "/"))
+        else file0
+      sourceEvents.append((file, t, kind))
+    }
+  private val watcher = WatchService.newWatchService
+  sourcesToWatch foreach { x =>
+    if (x.isDirectory) {
+      val f = new WatchableFile(x)
+      f.register(watcher, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY)
+    }
+  }
+  private var trackTime: Long = System.currentTimeMillis
+  private val consumer = new Thread(makeRunnable)
+  consumer.start()
+  def makeRunnable: Runnable = new Runnable {
+    def run: Unit = {
+      var done = false
+      while (!done) {
+        Try { watcher.take() } map { key =>
+          key.pollEvents.asScala foreach { event0 =>
+            val t = System.currentTimeMillis
+            event0.kind match {
+              case OVERFLOW => ()
+              case _ =>
+                event0 match {
+                  case ev: WatchEvent[File] @unchecked =>
+                    addSourceEvent(ev.context, t, ev.kind)
+                    log.debug("[filewatch] detected file system event: " + ev.context() + " " + ev.kind)
+                }
+            }
+          }
+          done = !key.reset
+        } recover {
+          case e => done = true
+        }
+      }
+    }
+  }
+
+  def close: Unit = {
+    watcher.close
+  }
+}

--- a/internal/zinc-core/src/test/scala/sbt/inc/TestCaseGenerators.scala
+++ b/internal/zinc-core/src/test/scala/sbt/inc/TestCaseGenerators.scala
@@ -70,7 +70,7 @@ object TestCaseGenerators {
       srcStamps <- listOfN(src.length, genStamp)
       binStamps <- listOfN(bin.length, genStamp)
       binClassNames <- listOfN(bin.length, unique(identifier))
-    } yield Stamps(zipMap(prod, prodStamps), zipMap(src, srcStamps), zipMap(bin, binStamps), zipMap(bin, binClassNames))
+    } yield Stamps(None, None, zipMap(prod, prodStamps), zipMap(src, srcStamps), zipMap(bin, binStamps), zipMap(bin, binClassNames))
   }
 
   private[this] val emptyStructure = new Structure(lzy(Array()), lzy(Array()), lzy(Array()))

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/TextAnalysisFormat.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/TextAnalysisFormat.scala
@@ -214,6 +214,8 @@ object TextAnalysisFormat {
 
   private[this] object StampsF {
     object Headers {
+      val changeBeginTime = "change begin time"
+      val changeEndTime = "change end time"
       val products = "product stamps"
       val sources = "source stamps"
       val binaries = "binary stamps"
@@ -223,6 +225,8 @@ object TextAnalysisFormat {
     def write(out: Writer, stamps: Stamps): Unit = {
       def doWriteMap[V](header: String, m: Map[File, V]) = writeMap(out)(header, m, fileToString, { v: V => v.toString })
 
+      writeSeq(out)(Headers.changeBeginTime, stamps.changeBeginTime.toList, (_: Long).toString)
+      writeSeq(out)(Headers.changeEndTime, stamps.changeEndTime.toList, (_: Long).toString)
       doWriteMap(Headers.products, stamps.products)
       doWriteMap(Headers.sources, stamps.sources)
       doWriteMap(Headers.binaries, stamps.binaries)
@@ -231,12 +235,15 @@ object TextAnalysisFormat {
 
     def read(in: BufferedReader): Stamps = {
       def doReadMap[V](expectedHeader: String, s2v: String => V) = readMap(in)(expectedHeader, stringToFile, s2v)
+
+      val changeBeginTime = readSeq(in)(Headers.changeBeginTime, _.toLong).headOption
+      val changeEndTime = readSeq(in)(Headers.changeEndTime, _.toLong).headOption
       val products = doReadMap(Headers.products, Stamp.fromString)
       val sources = doReadMap(Headers.sources, Stamp.fromString)
       val binaries = doReadMap(Headers.binaries, Stamp.fromString)
       val classNames = doReadMap(Headers.classNames, identity[String])
 
-      Stamps(products, sources, binaries, classNames)
+      Stamps(changeBeginTime, changeEndTime, products, sources, binaries, classNames)
     }
   }
 

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -11,12 +11,11 @@ import xsbti.compile.{ CompileAnalysis, CompileOrder, DefinesClass, IncOptionsUt
 import xsbti.compile.PerClasspathEntryLookup
 import sbt.io.IO
 import sbt.io.syntax._
-
+import sbt.inc.IncrementalCompilerUtil
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier.{ isPublic, isStatic }
 import java.util.Properties
 import sbt.internal.inc.classpath.ClasspathUtilities
-
 import sbt.internal.scripted.{ StatementHandler, TestFailed }
 
 final case class IncInstance(si: ScalaInstance, cs: XCompilers)
@@ -198,7 +197,8 @@ final class IncHandler(directory: File, scriptedLog: Logger) extends BridgeProvi
       val incOptions = loadIncOptions(directory / "incOptions.properties").withClassfileManagerType(transactional)
       val reporter = new LoggerReporter(maxErrors, scriptedLog, identity)
       val extra = Array(t2(("key", "value")))
-      val setup = compiler.setup(lookup, skip = false, cacheFile, CompilerCache.fresh, incOptions, reporter, extra)
+      val setup = compiler.setup(lookup, IncrementalCompilerUtil.noFileWatch,
+        skip = false, cacheFile, CompilerCache.fresh, incOptions, reporter, extra)
       val classpath = (i.si.allJars.toList ++ unmanagedJars :+ classesDir).toArray
       val in = compiler.inputs(classpath, sources.toArray, classesDir, Array(), Array(), maxErrors, Array(),
         CompileOrder.Mixed, cs, setup, prev)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,6 +29,7 @@ object Dependencies {
   lazy val scalaReflect = Def.setting { "org.scala-lang" % "scala-reflect" % scalaVersion.value }
 
   lazy val sbinary = "org.scala-sbt" %% "sbinary" % "0.4.3"
+  lazy val barbaryWatchService = "net.incongru.watchservice" % "barbary-watchservice" % "1.0"
   lazy val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.13.1"
   lazy val scalatest = "org.scalatest" %% "scalatest" % "2.2.6"
   lazy val junit = "junit" % "junit" % "4.11"

--- a/zinc/src/main/scala/sbt/inc/IncrementalCompilerUtil.scala
+++ b/zinc/src/main/scala/sbt/inc/IncrementalCompilerUtil.scala
@@ -3,15 +3,38 @@ package inc
 
 import java.io.File
 import sbt.util.Logger
+import scala.util.Properties
+import java.util.Locale
 import xsbti.Maybe
 import xsbti.compile.{ IncrementalCompiler, FileWatch }
-import sbt.internal.inc.{ IncrementalCompilerImpl, NoFileWatch, BarbaryFileWatch }
+import sbt.internal.inc.{ IncrementalCompilerImpl, NoFileWatch, BarbaryFileWatch, JDK7FileWatch }
 
 object IncrementalCompilerUtil {
   def defaultIncrementalCompiler: IncrementalCompiler =
     new IncrementalCompilerImpl
 
   val noFileWatch: FileWatch = NoFileWatch
-  def barbaryFileWatch(sourcesToWatch: List[File], log: Logger): FileWatch =
-    new BarbaryFileWatch(sourcesToWatch, log)
+  def fileWatch(sourcesToWatch: List[File], log: Logger): FileWatch =
+    os match {
+      case (Windows | Linux) if Properties.isJavaAtLeast("1.7") => new JDK7FileWatch(sourcesToWatch, log)
+      case OSX if Properties.isJavaAtLeast("1.7") => new BarbaryFileWatch(sourcesToWatch, log)
+      case _ => noFileWatch
+    }
+
+  private sealed trait OS
+  private case object Windows extends OS
+  private case object Linux extends OS
+  private case object OSX extends OS
+  private case object Other extends OS
+
+  private val os: OS = {
+    sys.props.get("os.name").map { name =>
+      name.toLowerCase(Locale.ENGLISH) match {
+        case osx if osx.contains("darwin") || osx.contains("mac") => OSX
+        case windows if windows.contains("windows") => Windows
+        case linux if linux.contains("linux") => Linux
+        case _ => Other
+      }
+    }.getOrElse(Other)
+  }
 }

--- a/zinc/src/main/scala/sbt/inc/IncrementalCompilerUtil.scala
+++ b/zinc/src/main/scala/sbt/inc/IncrementalCompilerUtil.scala
@@ -1,10 +1,17 @@
 package sbt
 package inc
 
-import xsbti.compile.IncrementalCompiler
-import sbt.internal.inc.IncrementalCompilerImpl
+import java.io.File
+import sbt.util.Logger
+import xsbti.Maybe
+import xsbti.compile.{ IncrementalCompiler, FileWatch }
+import sbt.internal.inc.{ IncrementalCompilerImpl, NoFileWatch, BarbaryFileWatch }
 
 object IncrementalCompilerUtil {
   def defaultIncrementalCompiler: IncrementalCompiler =
     new IncrementalCompilerImpl
+
+  val noFileWatch: FileWatch = NoFileWatch
+  def barbaryFileWatch(sourcesToWatch: List[File], log: Logger): FileWatch =
+    new BarbaryFileWatch(sourcesToWatch, log)
 }

--- a/zinc/src/main/scala/sbt/internal/inc/CompileConfiguration.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/CompileConfiguration.scala
@@ -5,7 +5,7 @@ package inc
 import java.io.File
 
 import xsbti.Reporter
-import xsbti.compile.{ GlobalsCache, CompileProgress, IncOptions, MiniSetup, CompileAnalysis, PerClasspathEntryLookup }
+import xsbti.compile.{ GlobalsCache, CompileProgress, IncOptions, MiniSetup, CompileAnalysis, PerClasspathEntryLookup, FileWatch }
 
 /**
  * Configuration used for running an analyzing compiler (a compiler which can extract dependencies between source files and JARs).
@@ -31,6 +31,7 @@ final class CompileConfiguration(
   val currentSetup: MiniSetup,
   val progress: Option[CompileProgress],
   val perClasspathEntryLookup: PerClasspathEntryLookup,
+  val fileWatch: FileWatch,
   val reporter: Reporter,
   val compiler: xsbti.compile.ScalaCompiler,
   val javac: xsbti.compile.JavaCompiler,

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -108,6 +108,7 @@ object MixedAnalyzingCompiler {
     previousAnalysis: CompileAnalysis,
     previousSetup: Option[MiniSetup],
     perClasspathEntryLookup: PerClasspathEntryLookup,
+    fileWatch: FileWatch,
     reporter: Reporter,
     compileOrder: CompileOrder = Mixed,
     skip: Boolean = false,
@@ -126,6 +127,7 @@ object MixedAnalyzingCompiler {
         previousAnalysis,
         previousSetup,
         perClasspathEntryLookup,
+        fileWatch,
         scalac,
         javac,
         reporter,
@@ -143,6 +145,7 @@ object MixedAnalyzingCompiler {
     previousAnalysis: CompileAnalysis,
     previousSetup: Option[MiniSetup],
     perClasspathEntryLookup: PerClasspathEntryLookup,
+    fileWatch: FileWatch,
     compiler: xsbti.compile.ScalaCompiler,
     javac: xsbti.compile.JavaCompiler,
     reporter: Reporter,
@@ -152,7 +155,7 @@ object MixedAnalyzingCompiler {
   ): CompileConfiguration = {
     import MiniSetupUtil._
     new CompileConfiguration(sources, classpath, previousAnalysis, previousSetup, setup,
-      progress, perClasspathEntryLookup: PerClasspathEntryLookup, reporter, compiler, javac, cache, incrementalCompilerOptions)
+      progress, perClasspathEntryLookup: PerClasspathEntryLookup, fileWatch, reporter, compiler, javac, cache, incrementalCompilerOptions)
   }
 
   /** Returns the search classpath (for dependencies) and a function which can also do so. */

--- a/zinc/src/test/resources/sbt/inc/Foo2.scala
+++ b/zinc/src/test/resources/sbt/inc/Foo2.scala
@@ -1,0 +1,5 @@
+package test.pkg
+
+object Foo {
+  val x = 2
+}

--- a/zinc/src/test/scala/sbt/inc/IncrementalCompilerSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/IncrementalCompilerSpec.scala
@@ -41,7 +41,7 @@ class IncrementalCompilerSpec extends BridgeProviderSpecification {
       val incOptions = IncOptionsUtil.defaultIncOptions()
       val reporter = new LoggerReporter(maxErrors, log, identity)
       val extra = Array(InterfaceUtil.t2(("key", "value")))
-      val setup = compiler.setup(lookup, skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
+      val setup = compiler.setup(lookup, IncrementalCompilerUtil.noFileWatch, skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
       val prev = compiler.emptyPreviousResult
       val classesDir = tempDir / "classes"
       val in = compiler.inputs(si.allJars, Array(knownSampleGoodFile), classesDir, Array(), Array(), maxErrors, Array(),
@@ -73,14 +73,14 @@ class IncrementalCompilerSpec extends BridgeProviderSpecification {
       val incOptions = IncOptionsUtil.defaultIncOptions()
       val reporter = new LoggerReporter(maxErrors, log, identity)
       val extra = Array(InterfaceUtil.t2(("key", "value")))
-      val setup = compiler.setup(lookup, skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
+      val setup = compiler.setup(lookup, IncrementalCompilerUtil.noFileWatch, skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
       val classesDir = tempDir / "classes"
       val in = compiler.inputs(si.allJars, sources, classesDir, Array(), Array(), maxErrors, Array(),
         CompileOrder.Mixed, cs, setup, prev0)
       val result = compiler.compile(in, log)
       val prev = compiler.previousResult(result)
       val lookup2 = new Lookup(_ => prev.analysis)
-      val setup2 = compiler.setup(lookup2, skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
+      val setup2 = compiler.setup(lookup2, IncrementalCompilerUtil.noFileWatch, skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
       val in2 = compiler.inputs(si.allJars, sources, classesDir, Array(), Array(), maxErrors, Array(),
         CompileOrder.Mixed, cs, setup2, prev)
       val result2 = compiler.compile(in2, log)
@@ -110,7 +110,7 @@ class IncrementalCompilerSpec extends BridgeProviderSpecification {
       val incOptions = IncOptionsUtil.defaultIncOptions()
       val reporter = new LoggerReporter(maxErrors, log, identity)
       val extra = Array(InterfaceUtil.t2(("key", "value")))
-      val setup = compiler.setup(lookup, skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
+      val setup = compiler.setup(lookup, IncrementalCompilerUtil.noFileWatch, skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
       val classesDir = tempDir / "classes"
       val in = compiler.inputs(si.allJars, sources, classesDir, Array(), Array(), maxErrors, Array(),
         CompileOrder.Mixed, cs, setup, prev0)
@@ -123,7 +123,7 @@ class IncrementalCompilerSpec extends BridgeProviderSpecification {
       }
       val lookup2 = new Lookup(_ => prev.analysis)
       val extra2 = Array(InterfaceUtil.t2(("key", "value2")))
-      val setup2 = compiler.setup(lookup2, skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra2)
+      val setup2 = compiler.setup(lookup2, IncrementalCompilerUtil.noFileWatch, skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra2)
       val in2 = compiler.inputs(si.allJars, sources, classesDir, Array(), Array(), maxErrors, Array(),
         CompileOrder.Mixed, cs, setup2, prev)
       val result2 = compiler.compile(in2, log)

--- a/zinc/src/test/scala/sbt/inc/WatcherSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/WatcherSpec.scala
@@ -37,7 +37,7 @@ class WatcherSpec extends BridgeProviderSpecification {
       // log.setLevel(Level.Debug)
       val sourceDirectory = tempDir / "src"
       IO.createDirectory(sourceDirectory)
-      val fileWatch = IncrementalCompilerUtil.barbaryFileWatch(List(sourceDirectory), log)
+      val fileWatch = IncrementalCompilerUtil.fileWatch(List(sourceDirectory), log)
       Thread.sleep(100)
       val fooSampleFile = tempDir / "src" / "Foo.scala"
       IO.copyFile(fooSampleFile0, fooSampleFile, false)

--- a/zinc/src/test/scala/sbt/inc/WatcherSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/WatcherSpec.scala
@@ -6,7 +6,7 @@ import java.io.File
 import sbt.internal.inc._
 import sbt.io.IO
 import sbt.io.syntax._
-import sbt.util.{ Logger, InterfaceUtil }
+import sbt.util.{ Logger, InterfaceUtil, Level }
 import sbt.internal.util.ConsoleLogger
 import xsbti.Maybe
 import xsbti.compile.{ CompileAnalysis, CompileOrder, DefinesClass, IncOptionsUtil, PreviousResult, PerClasspathEntryLookup }

--- a/zinc/src/test/scala/sbt/inc/WatcherSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/WatcherSpec.scala
@@ -34,7 +34,7 @@ class WatcherSpec extends BridgeProviderSpecification {
     IO.withTemporaryDirectory { tempDir =>
       val log = ConsoleLogger()
       // uncomment this to see the debug log
-      // log.setLevel(Level.Debug)
+      log.setLevel(Level.Debug)
       val sourceDirectory = tempDir / "src"
       IO.createDirectory(sourceDirectory)
       val fileWatch = IncrementalCompilerUtil.fileWatch(List(sourceDirectory), log)
@@ -74,7 +74,7 @@ class WatcherSpec extends BridgeProviderSpecification {
         skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
       val in2 = compiler.inputs(si.allJars, sources2, classesDir, Array(), Array(), maxErrors, Array(),
         CompileOrder.Mixed, cs, setup2, prev2)
-      Thread.sleep(100)
+      Thread.sleep(1000)
       log.info("---- compile 2 ----")
       val result2 = compiler.compile(in2, log)
       assert(result2.hasModified)

--- a/zinc/src/test/scala/sbt/inc/WatcherSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/WatcherSpec.scala
@@ -1,0 +1,99 @@
+package sbt
+package inc
+
+import java.io.File
+
+import sbt.internal.inc._
+import sbt.io.IO
+import sbt.io.syntax._
+import sbt.util.{ Logger, InterfaceUtil }
+import sbt.internal.util.ConsoleLogger
+import xsbti.Maybe
+import xsbti.compile.{ CompileAnalysis, CompileOrder, DefinesClass, IncOptionsUtil, PreviousResult, PerClasspathEntryLookup }
+
+class WatcherSpec extends BridgeProviderSpecification {
+  val scalaVersion = scala.util.Properties.versionNumberString
+  val compiler = new IncrementalCompilerImpl // IncrementalCompilerUtil.defaultIncrementalCompiler
+  val maxErrors = 100
+  val knownSampleGoodFile0 =
+    new File(classOf[IncrementalCompilerSpec].getResource("Good.scala").toURI)
+  val fooSampleFile0 =
+    new File(classOf[IncrementalCompilerSpec].getResource("Foo.scala").toURI)
+  val fooSampleFile2 =
+    new File(classOf[IncrementalCompilerSpec].getResource("Foo2.scala").toURI)
+
+  class Lookup(am: File => Maybe[CompileAnalysis]) extends PerClasspathEntryLookup {
+    override def analysis(classpathEntry: File): Maybe[CompileAnalysis] =
+      am(classpathEntry)
+
+    override def definesClass(classpathEntry: File): DefinesClass =
+      Locate.definesClass(classpathEntry)
+  }
+
+  it should "use native file watcher to detect modified files" in {
+    IO.withTemporaryDirectory { tempDir =>
+      val log = ConsoleLogger()
+      // uncomment this to see the debug log
+      // log.setLevel(Level.Debug)
+      val sourceDirectory = tempDir / "src"
+      IO.createDirectory(sourceDirectory)
+      val fileWatch = IncrementalCompilerUtil.barbaryFileWatch(List(sourceDirectory), log)
+      Thread.sleep(100)
+      val fooSampleFile = tempDir / "src" / "Foo.scala"
+      IO.copyFile(fooSampleFile0, fooSampleFile, false)
+      val knownSampleGoodFile = tempDir / "src" / "subdir" / "Good.scala"
+      IO.copyFile(knownSampleGoodFile0, knownSampleGoodFile, false)
+      val sources = Array(fooSampleFile, knownSampleGoodFile)
+      val compilerBridge = getCompilerBridge(tempDir, Logger.Null, scalaVersion)
+      val si = scalaInstance(scalaVersion)
+      val sc = scalaCompiler(si, compilerBridge)
+      val cs = compiler.compilers(si, ClasspathOptionsUtil.boot, None, sc)
+      val prev0 = compiler.emptyPreviousResult
+      val lookup = new Lookup(_ => prev0.analysis)
+      val incOptions = IncOptionsUtil.defaultIncOptions()
+      val reporter = new LoggerReporter(maxErrors, log, identity)
+      val extra = Array(InterfaceUtil.t2(("key", "value")))
+      val setup = compiler.setup(lookup, fileWatch,
+        skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
+      val classesDir = tempDir / "classes"
+      val in = compiler.inputs(si.allJars, sources, classesDir, Array(), Array(), maxErrors, Array(),
+        CompileOrder.Mixed, cs, setup, prev0)
+      // This is the baseline compilation using two files
+      // At this point there's no good previous end change time,
+      // so the watcher will return None, and fallback to checking last modified dates
+      log.info("---- compile 1 ----")
+      val result1 = compiler.compile(in, log)
+
+      // Here we introduce a change trackable by the native OS
+      IO.copyFile(fooSampleFile2, fooSampleFile, false)
+      Thread.sleep(100)
+      val sources2 = Array(knownSampleGoodFile, fooSampleFile)
+      val prev2 = compiler.previousResult(result1)
+      val lookup2 = new Lookup(_ => prev2.analysis)
+      val setup2 = compiler.setup(lookup2, fileWatch,
+        skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
+      val in2 = compiler.inputs(si.allJars, sources2, classesDir, Array(), Array(), maxErrors, Array(),
+        CompileOrder.Mixed, cs, setup2, prev2)
+      Thread.sleep(100)
+      log.info("---- compile 2 ----")
+      val result2 = compiler.compile(in2, log)
+      assert(result2.hasModified)
+
+      // This is for no-op compilation
+      // it should not detect anything
+      val prev3 = compiler.previousResult(result2)
+      val lookup3 = new Lookup(_ => prev3.analysis)
+      val setup3 = compiler.setup(lookup3, fileWatch,
+        skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, extra)
+      val in3 = compiler.inputs(si.allJars, sources2, classesDir, Array(), Array(), maxErrors, Array(),
+        CompileOrder.Mixed, cs, setup3, prev3)
+      Thread.sleep(100)
+      log.info("---- compile 3 ----")
+      val result3 = compiler.compile(in3, log)
+      assert(!result3.hasModified)
+    }
+  }
+
+  def scalaCompiler(instance: ScalaInstance, bridgeJar: File): AnalyzingCompiler =
+    new AnalyzingCompiler(instance, CompilerInterfaceProvider.constant(bridgeJar), ClasspathOptionsUtil.boot)
+}


### PR DESCRIPTION
Source: https://github.com/eed3si9n/zinc/tree/wip/watcher

This adds new Java interfaces `xsbti.compile.FileWatch` and
`xsbt.compile.FileChanges`, which are intended for proactive file
change detection using native OS hooks or other means such as IDEs.
### motivation

On Windows, especially it seems, there is a large overhead for running
compile task without changing any sources. From profiling we discovered
that 60% of the time is taken up by
`sbt.inc.IncrementalCommon.changedInitial`. This further breaks down to
[line 134 -
137](https://github.com/sbt/sbt/blob/v0.13.11/compile/inc/src/main/scala
/sbt/inc/IncrementalCommon.scala#L134-L137) spending 7%, 38%, 20%, and
34% respectively.
