### PR TITLE
NPE fix

### DIFF
--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
@@ -108,10 +108,8 @@ object ClassToAPI {
   }
 
   /** TODO: over time, ClassToAPI should switch the majority of access to the classfile parser */
-  private[this] def classFileForClass(c: Class[_]): ClassFile = {
-    val file = new java.io.File(IO.classLocationFile(c), s"${c.getName.replace('.', '/')}.class")
-    classfile.Parser.apply(file)
-  }
+  private[this] def classFileForClass(c: Class[_]): ClassFile =
+    classfile.Parser.apply(IO.classfileLocation(c))
 
   private[this] def lzyS[T <: AnyRef](t: T): xsbti.api.Lazy[T] = lzy(t)
   def lzy[T <: AnyRef](t: => T): xsbti.api.Lazy[T] = xsbti.SafeLazy(t)

--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
@@ -61,8 +61,10 @@ object ClassToAPI {
   def emptyClassMap: ClassMap = new ClassMap(new mutable.HashMap, new mutable.HashSet, new mutable.ListBuffer,
     new mutable.HashSet)
 
+  def classCanonicalName(c: Class[_]): String =
+    Option(c.getCanonicalName) getOrElse { c.getName }
   def toDefinitions(cmap: ClassMap)(c: Class[_]): Seq[api.ClassLikeDef] =
-    cmap.memo.getOrElseUpdate(c.getCanonicalName, toDefinitions0(c, cmap))
+    cmap.memo.getOrElseUpdate(classCanonicalName(c), toDefinitions0(c, cmap))
   def toDefinitions0(c: Class[_], cmap: ClassMap): Seq[api.ClassLikeDef] =
     {
       import api.DefinitionType.{ ClassDef, Module, Trait }
@@ -72,7 +74,7 @@ object ClassToAPI {
       val annots = annotations(c.getAnnotations)
       val children = childrenOfSealedClass(c)
       val topLevel = c.getEnclosingClass == null
-      val name = c.getCanonicalName
+      val name = classCanonicalName(c)
       val tpe = if (Modifier.isInterface(c.getModifiers)) Trait else ClassDef
       lazy val (static, instance) = structure(c, enclPkg, cmap)
       val cls = new api.ClassLike(tpe, strict(Empty), lzy(instance, cmap), emptyStringArray, children.toArray,
@@ -273,7 +275,7 @@ object ClassToAPI {
 
   def name(gd: GenericDeclaration): String =
     gd match {
-      case c: Class[_]       => c.getCanonicalName
+      case c: Class[_]       => classCanonicalName(c)
       case m: Method         => m.getName
       case c: Constructor[_] => c.getName
     }
@@ -311,7 +313,9 @@ object ClassToAPI {
 
   def array(tpe: api.Type): api.SimpleType = new api.Parameterized(ArrayRef, Array(tpe))
   def reference(c: Class[_]): api.SimpleType =
-    if (c.isArray) array(reference(c.getComponentType)) else if (c.isPrimitive) primitive(c.getName) else reference(c.getCanonicalName)
+    if (c.isArray) array(reference(c.getComponentType))
+    else if (c.isPrimitive) primitive(c.getName)
+    else reference(classCanonicalName(c))
 
   // does not handle primitives
   def reference(s: String): api.SimpleType =

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/ClassFile.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/ClassFile.scala
@@ -12,7 +12,6 @@ import java.io.File
 private[sbt] trait ClassFile {
   val majorVersion: Int
   val minorVersion: Int
-  val fileName: String
   val className: String
   val superClassName: String
   val interfaceNames: Array[String]

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Parser.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Parser.scala
@@ -6,6 +6,7 @@ package internal
 package inc
 package classfile
 
+import java.net.URL
 import java.io.{ DataInputStream, File, InputStream }
 import scala.annotation.switch
 import sbt.io.Using
@@ -18,15 +19,19 @@ import sbt.io.Using
 import Constants._
 
 private[sbt] object Parser {
-  def apply(file: File): ClassFile = Using.fileInputStream(file)(parse(file.getAbsolutePath)).right.get
-  private def parse(fileName: String)(is: InputStream): Either[String, ClassFile] = Right(parseImpl(fileName, is))
-  private def parseImpl(filename: String, is: InputStream): ClassFile =
+  def apply(file: File): ClassFile =
+    Using.fileInputStream(file)(parse(file.toString)).right.get
+
+  def apply(url: URL): ClassFile =
+    Using.urlInputStream(url)(parse(url.toString)).right.get
+
+  private def parse(readableName: String)(is: InputStream): Either[String, ClassFile] = Right(parseImpl(readableName, is))
+  private def parseImpl(readableName: String, is: InputStream): ClassFile =
     {
       val in = new DataInputStream(is)
-      new ClassFile {
-        assume(in.readInt() == JavaMagic, "Invalid class file: " + fileName)
+      assume(in.readInt() == JavaMagic, "Invalid class file: " + readableName)
 
-        val fileName = filename
+      new ClassFile {
         val minorVersion: Int = in.readUnsignedShort()
         val majorVersion: Int = in.readUnsignedShort()
 

--- a/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/ParserSpecification.scala
+++ b/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/ParserSpecification.scala
@@ -1,0 +1,24 @@
+package sbt
+package classfile
+
+import util.Try
+
+import org.scalacheck._
+import Prop._
+
+object ParserSpecification extends Properties("Parser") {
+  property("able to parse all relevant classes") =
+    Prop.forAll(classes) { (c: Class[_]) =>
+      Parser(IO.classfileLocation(c)) ne null
+    }
+
+  implicit def classes: Gen[Class[_]] =
+    Gen.oneOf(
+      this.getClass,
+      classOf[java.lang.Integer],
+      classOf[java.util.AbstractMap.SimpleEntry[String, String]],
+      classOf[String],
+      classOf[Thread],
+      classOf[Properties]
+    )
+}

--- a/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/ParserSpecification.scala
+++ b/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/ParserSpecification.scala
@@ -1,7 +1,9 @@
 package sbt
+package internal
+package inc
 package classfile
 
-import util.Try
+import scala.util.Try
 
 import org.scalacheck._
 import Prop._
@@ -9,7 +11,7 @@ import Prop._
 object ParserSpecification extends Properties("Parser") {
   property("able to parse all relevant classes") =
     Prop.forAll(classes) { (c: Class[_]) =>
-      Parser(IO.classfileLocation(c)) ne null
+      Parser(sbt.io.IO.classfileLocation(c)) ne null
     }
 
   implicit def classes: Gen[Class[_]] =


### PR DESCRIPTION
Fixes #129  (see https://github.com/eed3si9n/zinc-bug-repro for the repro)

Classname will now fall back to `class.getName` when `getCanonicalName` returns `null`.
Also this PR forward ports https://github.com/sbt/sbt/pull/2268 to fix https://github.com/sbt/sbt/issues/2263 equivalent on zinc.

/review @dwijnand, @Duhemm 
