### PR TITLE
Fix sigle output deserialization on windows

### DIFF
--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/TextAnalysisFormat.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/TextAnalysisFormat.scala
@@ -308,11 +308,13 @@ object TextAnalysisFormat {
 
     private[this] val singleOutputMode = "single"
     private[this] val multipleOutputMode = "multiple"
-    private[this] val singleOutputKey = new File("/output_dir")
 
     def write(out: Writer, setup: MiniSetup): Unit = {
       val (mode, outputAsMap) = setup.output match {
-        case s: SingleOutput   => (singleOutputMode, Map(singleOutputKey -> s.outputDirectory))
+        case s: SingleOutput =>
+          // just to be compatible with multipleOutputMode
+          val ignored = s.outputDirectory
+          (singleOutputMode, Map(ignored -> s.outputDirectory))
         case m: MultipleOutput => (multipleOutputMode, m.outputGroups.map(x => x.sourceDirectory -> x.outputDirectory).toMap)
       }
 
@@ -340,7 +342,7 @@ object TextAnalysisFormat {
       val output = outputDirMode match {
         case Some(s) => s match {
           case `singleOutputMode` => new SingleOutput {
-            val outputDirectory = outputAsMap(singleOutputKey)
+            val outputDirectory = outputAsMap.values.head
           }
           case `multipleOutputMode` => new MultipleOutput {
             val outputGroups: Array[MultipleOutput.OutputGroup] = outputAsMap.toArray.map {

--- a/internal/zinc-persist/src/test/scala/sbt/inc/TextAnalysisFormatSpecification.scala
+++ b/internal/zinc-persist/src/test/scala/sbt/inc/TextAnalysisFormatSpecification.scala
@@ -26,7 +26,7 @@ object TextAnalysisFormatTest extends Properties("TextAnalysisFormat") {
                     |0 -> single
                     |output directories:
                     |1 items
-                    |file:/output_dir -> file:/dummy
+                    |file:/dummy -> file:/dummy
                     |compile options:
                     |0 items
                     |javac options:


### PR DESCRIPTION
Pulling in a commit from @romanowski's 1.0 branch.
Apparently on Windows this fixes a file path output bug.
