### PR TITLE
Warn on transitive macro recompilation, with opt-out

### DIFF
--- a/internal/compiler-interface/src/main/datatype/incremental.json
+++ b/internal/compiler-interface/src/main/datatype/incremental.json
@@ -136,6 +136,11 @@
           "name": "extra",
           "type": "java.util.Map<String,String>",
           "doc": "Extra options"
+        },
+        {
+          "name": "logRecompileOnMacro",
+          "type": "boolean",
+          "doc": "Determines whether to log information on file recompiled due to a transitive macro change"
         }
       ]
     },

--- a/internal/compiler-interface/src/main/java/xsbti/compile/IncOptionsUtil.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/IncOptionsUtil.java
@@ -26,6 +26,7 @@ public class IncOptionsUtil {
   public static final String RECOMPILE_ON_MACRO_DEF_KEY = "recompileOnMacroDef";
   public static final String NAME_HASHING_KEY = "nameHashing";
   public static final String ANT_STYLE_KEY = "antStyle";
+  public static final String LOG_RECOMPILE_ON_MACRO = "logRecompileOnMacro";
   private static final String XSBTI_NOTHING = "NOTHING";
 
   public static int defaultTransitiveStep() {
@@ -84,6 +85,10 @@ public class IncOptionsUtil {
     return new HashMap<String, String>();
   }
 
+  public static boolean defaultLogRecompileOnMacro() {
+    return true;
+  }
+
   public static IncOptions defaultIncOptions() {
     IncOptions retval = new IncOptions(
       defaultTransitiveStep(), defaultRecompileAllFraction(),
@@ -91,7 +96,7 @@ public class IncOptionsUtil {
       defaultApiDiffContextSize(), defaultApiDumpDirectory(),
       defaultClassfileManagerType(), defaultRecompileOnMacroDef(),
       defaultNameHashing(), defaultAntStyle(),
-      defaultExtra());
+      defaultExtra(), defaultLogRecompileOnMacro());
     return retval;
   }
 
@@ -149,6 +154,10 @@ public class IncOptionsUtil {
 
     if (values.containsKey(ANT_STYLE_KEY)) {
       base = base.withAntStyle(Boolean.parseBoolean(values.get(ANT_STYLE_KEY)));
+    }
+
+    if (values.containsKey(LOG_RECOMPILE_ON_MACRO)) {
+      base = base.withLogRecompileOnMacro(Boolean.parseBoolean(values.get(LOG_RECOMPILE_ON_MACRO)));
     }
 
     return base;

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -6,9 +6,11 @@ package internal
 package inc
 
 import java.io.File
-import sbt.util.Logger
+
 import scala.annotation.tailrec
-import xsbti.compile.{ DependencyChanges, IncOptions, CompileAnalysis }
+
+import sbt.util.{ Level, Logger }
+import xsbti.compile.{ CompileAnalysis, DependencyChanges, IncOptions }
 
 /**
  * Helper class to run incremental compilation algorithm.
@@ -23,7 +25,10 @@ object Incremental {
   class PrefixingLogger(val prefix: String)(orig: Logger) extends Logger {
     def trace(t: => Throwable): Unit = orig.trace(t)
     def success(message: => String): Unit = orig.success(message)
-    def log(level: sbt.util.Level.Value, message: => String): Unit = orig.log(level, message.replaceAll("(?m)^", prefix))
+    def log(level: Level.Value, message: => String): Unit = level match {
+      case Level.Debug => orig.log(level, message.replaceAll("(?m)^", prefix))
+      case _           => orig.log(level, message)
+    }
   }
 
   /**

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalNameHashing.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalNameHashing.scala
@@ -14,7 +14,7 @@ import xsbt.api.{ APIUtil, SameAPI }
  */
 private final class IncrementalNameHashing(log: sbt.util.Logger, options: IncOptions) extends IncrementalCommon(log, options) {
 
-  private val memberRefInvalidator = new MemberRefInvalidator(log)
+  private val memberRefInvalidator = new MemberRefInvalidator(log, options.logRecompileOnMacro())
 
   // Package objects are fragile: if they inherit from an invalidated class, get "class file needed by package is missing" error
   //  This might be too conservative: we probably only need package objects for packages of invalidated classes.

--- a/zinc/src/sbt-test/reporter/errors-reported/A.scala
+++ b/zinc/src/sbt-test/reporter/errors-reported/A.scala
@@ -1,0 +1,3 @@
+class A {
+  val x: String = 0
+}

--- a/zinc/src/sbt-test/reporter/errors-reported/pending
+++ b/zinc/src/sbt-test/reporter/errors-reported/pending
@@ -1,0 +1,3 @@
+-> compile
+
+> checkErrors 1

--- a/zinc/src/sbt-test/reporter/warnings-reported/A.scala
+++ b/zinc/src/sbt-test/reporter/warnings-reported/A.scala
@@ -1,0 +1,4 @@
+class A {
+  val x: List[Int] = Nil
+  x.isInstanceOf[List[String]]
+}

--- a/zinc/src/sbt-test/reporter/warnings-reported/test
+++ b/zinc/src/sbt-test/reporter/warnings-reported/test
@@ -1,0 +1,3 @@
+> compile
+> checkWarnings 1
+> checkWarning 0 "fruitless type test"


### PR DESCRIPTION
Forward port of sbt/sbt#2637 and sbt/sbt#2659. Fixes #142

A forward port of the test (hopefully) to follow.

---

I would love to have a test for this, like I do for sbt 0.13, but I would need some help, as I don't know how things are done in this codebase. Thanks.
