### PR TITLE
Split API info into another zip entry

### DIFF
--- a/internal/compiler-interface/src/main/datatype/other.json
+++ b/internal/compiler-interface/src/main/datatype/other.json
@@ -16,7 +16,7 @@
 				},
 				{
 					"name": "api",
-					"type": "Companions"
+					"type": "lazy Companions"
 				},
 				{
 					"name": "apiHash",

--- a/internal/zinc-apiinfo/src/main/scala/xsbt/api/APIUtil.scala
+++ b/internal/zinc-apiinfo/src/main/scala/xsbt/api/APIUtil.scala
@@ -17,9 +17,6 @@ object APIUtil {
 
   def isScalaSourceName(name: String): Boolean = name.endsWith(".scala")
 
-  def hasPackageObject(analyzedClass: AnalyzedClass): Boolean =
-    analyzedClass.api.objectApi.definitionType == DefinitionType.PackageModule
-
   def hasMacro(c: ClassLike): Boolean =
     {
       val check = new HasMacro

--- a/internal/zinc-apiinfo/src/main/scala/xsbt/api/SameAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/xsbt/api/SameAPI.scala
@@ -11,7 +11,7 @@ import scala.collection.{ immutable, mutable }
 /** Checks the API of two source files for equality.*/
 object SameAPI {
   def apply(a: AnalyzedClass, b: AnalyzedClass): Boolean =
-    (a.apiHash == b.apiHash) && apply(a.api, b.api)
+    (a.apiHash == b.apiHash)
 
   def apply(a: Definition, b: Definition): Boolean =
     (new SameAPI(false, true)).sameDefinitions(List(a), List(b), true)

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/APIs.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/APIs.scala
@@ -6,6 +6,7 @@ package internal
 package inc
 
 import xsbti.api._
+import xsbti.SafeLazy
 import APIs.getAPI
 import xsbt.api.{ APIUtil, SameAPI }
 
@@ -47,7 +48,7 @@ object APIs {
   val emptyCompilation = new xsbti.api.Compilation(-1, Array())
   val emptyNameHashes = new xsbti.api.NameHashes(Array.empty, Array.empty)
   val emptyCompanions = new xsbti.api.Companions(emptyAPI, emptyAPI)
-  val emptyAnalyzedClass = new xsbti.api.AnalyzedClass(emptyCompilation, emptyName, emptyCompanions, emptyAPIHash,
+  val emptyAnalyzedClass = new xsbti.api.AnalyzedClass(emptyCompilation, emptyName, SafeLazy(emptyCompanions), emptyAPIHash,
     emptyNameHashes, false)
   def getAPI[T](map: Map[T, AnalyzedClass], className: T): AnalyzedClass = map.getOrElse(className, emptyAnalyzedClass)
 }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/CompanionsStore.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/CompanionsStore.scala
@@ -1,0 +1,11 @@
+package sbt
+package internal
+package inc
+
+import xsbti.api._
+
+// This intentionally provides only get() since set() needs to be part of
+// the zip file created for Analysis store.
+trait CompanionsStore {
+  def get(): Option[(Map[String, Companions], Map[String, Companions])]
+}

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Compile.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Compile.scala
@@ -9,7 +9,7 @@ import sbt.internal.inc.Analysis.{ LocalProduct, NonLocalProduct }
 import xsbt.api.{ NameHashing, APIUtil, HashAPI }
 import xsbti.api._
 import xsbti.compile.{ DependencyChanges, Output, SingleOutput, MultipleOutput, CompileAnalysis, IncOptions }
-import xsbti.{ Position, Problem, Severity }
+import xsbti.{ Position, Problem, Severity, SafeLazy }
 import sbt.util.Logger
 import sbt.util.Logger.{ m2o, problem }
 import java.io.File
@@ -268,7 +268,7 @@ private final class AnalysisCallback(
     val hasMacro: Boolean = macroClasses.contains(name)
     val (companions, apiHash) = companionsWithHash(name)
     val nameHashes = nameHashesForCompanions(name)
-    val ac = new AnalyzedClass(compilation, name, companions, apiHash, nameHashes, hasMacro)
+    val ac = new AnalyzedClass(compilation, name, SafeLazy(companions), apiHash, nameHashes, hasMacro)
     ac
   }
 

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalNameHashing.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalNameHashing.scala
@@ -21,7 +21,7 @@ private final class IncrementalNameHashing(log: sbt.util.Logger, options: IncOpt
   protected def invalidatedPackageObjects(invalidatedClasses: Set[String], relations: Relations,
     apis: APIs): Set[String] = {
     transitiveDeps(invalidatedClasses, logging = false)(relations.inheritance.internal.reverse) filter {
-      className => APIUtil.hasPackageObject(apis.internalAPI(className))
+      _.endsWith(".package")
     }
   }
 

--- a/internal/zinc-core/src/test/scala/sbt/inc/TestAnalysisCallback.scala
+++ b/internal/zinc-core/src/test/scala/sbt/inc/TestAnalysisCallback.scala
@@ -5,6 +5,7 @@ package inc
 import java.io.File
 
 import scala.collection.mutable.{ ArrayBuffer, HashMap }
+import xsbti.SafeLazy
 import xsbti.api._
 import xsbti.api.DependencyContext._
 import xsbt.api.{ HashAPI, NameHashing, APIUtil }
@@ -104,7 +105,7 @@ class TestAnalysisCallback(
     val hasMacro: Boolean = macroClasses.contains(name)
     val (companions, apiHash) = companionsWithHash(name)
     val nameHashes = nameHashesForCompanions(name)
-    val ac = new AnalyzedClass(compilation, name, companions, apiHash, nameHashes, hasMacro)
+    val ac = new AnalyzedClass(compilation, name, SafeLazy(companions), apiHash, nameHashes, hasMacro)
     ac
   }
 

--- a/internal/zinc-core/src/test/scala/sbt/inc/TestCaseGenerators.scala
+++ b/internal/zinc-core/src/test/scala/sbt/inc/TestCaseGenerators.scala
@@ -114,7 +114,7 @@ object TestCaseGenerators {
     apiHash <- arbitrary[Int]
     hasMacro <- arbitrary[Boolean]
     nameHashes <- genNameHashes(Seq(name))
-  } yield new AnalyzedClass(new Compilation(startTime, Array()), name, makeCompanions(name), apiHash, nameHashes, hasMacro)
+  } yield new AnalyzedClass(new Compilation(startTime, Array()), name, SafeLazy(makeCompanions(name)), apiHash, nameHashes, hasMacro)
 
   def genClasses(all_defns: Seq[String]): Gen[Seq[AnalyzedClass]] =
     Gen.sequence[List[AnalyzedClass], AnalyzedClass](all_defns.map(genClass))

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/FileBasedStore.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/FileBasedStore.scala
@@ -17,9 +17,9 @@ object FileBasedStore {
   private val analysisFileName = "inc_compile.txt"
   private val companionsFileName = "api_companions.txt"
 
-  def apply(file: File): AnalysisStore = new FileBasedStore0(file)
+  def apply(file: File): AnalysisStore = new FileBasedStoreImpl(file)
 
-  private final class FileBasedStore0(file: File) extends AnalysisStore {
+  private final class FileBasedStoreImpl(file: File) extends AnalysisStore {
     val companionsStore = new FileBasedCompanionsMapStore(file)
 
     def set(analysis: CompileAnalysis, setup: MiniSetup): Unit = {
@@ -30,11 +30,8 @@ object FileBasedStore {
           outputStream.putNextEntry(new ZipEntry(analysisFileName))
           TextAnalysisFormat.write(writer, analysis, setup)
           outputStream.closeEntry()
-          val apis = analysis match { case a: Analysis => a.apis }
-          val internal = apis.internal map { case (k, v) => k -> v.api }
-          val external = apis.external map { case (k, v) => k -> v.api }
           outputStream.putNextEntry(new ZipEntry(companionsFileName))
-          TextAnalysisFormat.writeCompanionMap(writer, internal, external)
+          TextAnalysisFormat.writeCompanionMap(writer, analysis match { case a: Analysis => a.apis })
           outputStream.closeEntry()
       }
     }

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/TextAnalysisFormat.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/TextAnalysisFormat.scala
@@ -94,9 +94,9 @@ object TextAnalysisFormat {
   }
 
   // Writes the "api" portion of xsbti.api.AnalyzedClass.
-  def writeCompanionMap(out: Writer, internal: Map[String, Companions], external: Map[String, Companions]): Unit = {
+  def writeCompanionMap(out: Writer, apis: APIs): Unit = {
     VersionF.write(out)
-    CompanionsF.write(out, internal, external)
+    CompanionsF.write(out, apis)
     out.flush()
   }
 
@@ -294,6 +294,12 @@ object TextAnalysisFormat {
 
     val stringToCompanions = ObjectStringifier.stringToObj[Companions] _
     val companionsToString = ObjectStringifier.objToString[Companions] _
+
+    def write(out: Writer, apis: APIs): Unit = {
+      val internal = apis.internal map { case (k, v) => k -> v.api }
+      val external = apis.external map { case (k, v) => k -> v.api }
+      write(out, internal, external)
+    }
 
     def write(out: Writer, internal: Map[String, Companions], external: Map[String, Companions]): Unit = {
       writeMap(out)(Headers.internal, internal, identity[String], companionsToString, inlineVals = false)

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/TextAnalysisFormat.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/TextAnalysisFormat.scala
@@ -4,8 +4,8 @@ package inc
 
 import java.io._
 import sbt.internal.util.Relation
-import xsbti.T2
-import xsbti.api.{ AnalyzedClass, Compilation }
+import xsbti.{ T2, SafeLazy }
+import xsbti.api.{ AnalyzedClass, Compilation, Companions, NameHashes, Lazy }
 import xsbti.compile.{ CompileAnalysis, MultipleOutput, SingleOutput, MiniOptions, MiniSetup }
 import javax.xml.bind.DatatypeConverter
 import java.net.URI
@@ -58,13 +58,15 @@ object TextAnalysisFormat {
   import sbt.util.Logger.{ m2o, position, problem }
 
   private implicit val compilationF: Format[Compilation] = xsbt.api.CompilationFormat
-  private implicit val analyzedClassFormat: Format[AnalyzedClass] = xsbt.api.AnalyzedClassFormat
+  private implicit val nameHashesFormat: Format[NameHashes] = xsbt.api.NameHashesFormat
+  private implicit val companionsFomrat: Format[Companions] = xsbt.api.CompanionsFormat
   private implicit def problemFormat: Format[Problem] = asProduct4(problem _)(p => (p.category, p.position, p.message, p.severity))
   private implicit def positionFormat: Format[Position] =
     asProduct7(position _)(p => (m2o(p.line), p.lineContent, m2o(p.offset), m2o(p.pointer), m2o(p.pointerSpace), m2o(p.sourcePath), m2o(p.sourceFile)))
   private implicit val severityFormat: Format[Severity] =
     wrap[Severity, Byte](_.ordinal.toByte, b => Severity.values.apply(b.toInt))
   private implicit val integerFormat: Format[Integer] = wrap[Integer, Int](_.toInt, Integer.valueOf)
+  private implicit val analyzedClassFormat: Format[AnalyzedClass] = xsbt.api.AnalyzedClassFormats.analyzedClassFormat
   private implicit def infoFormat: Format[SourceInfo] =
     wrap[SourceInfo, (Seq[Problem], Seq[Problem])](si => (si.reportedProblems, si.unreportedProblems), { case (a, b) => SourceInfos.makeInfo(a, b) })
   private implicit def seqFormat[T](implicit optionFormat: Format[T]): Format[Seq[T]] = viaSeq[Seq[T], T](x => x)
@@ -74,6 +76,7 @@ object TextAnalysisFormat {
       val get2: A2 = a2
     }
 
+  // Companions portion of the API info is written in a separate entry later.
   def write(out: Writer, analysis: CompileAnalysis, setup: MiniSetup): Unit = {
     val analysis0 = analysis match { case analysis: Analysis => analysis }
     VersionF.write(out)
@@ -90,16 +93,29 @@ object TextAnalysisFormat {
     out.flush()
   }
 
-  def read(in: BufferedReader): (CompileAnalysis, MiniSetup) = {
+  // Writes the "api" portion of xsbti.api.AnalyzedClass.
+  def writeCompanionMap(out: Writer, internal: Map[String, Companions], external: Map[String, Companions]): Unit = {
+    VersionF.write(out)
+    CompanionsF.write(out, internal, external)
+    out.flush()
+  }
+
+  // Companions portion of the API info is read from a separate file lazily.
+  def read(in: BufferedReader, companionsStore: CompanionsStore): (CompileAnalysis, MiniSetup) = {
     VersionF.read(in)
     val setup = FormatTimer.time("read setup") { MiniSetupF.read(in) }
     val relations = FormatTimer.time("read relations") { RelationsF.read(in, setup.nameHashing) }
     val stamps = FormatTimer.time("read stamps") { StampsF.read(in) }
-    val apis = FormatTimer.time("read apis") { APIsF.read(in) }
+    val apis = FormatTimer.time("read apis") { APIsF.read(in, companionsStore) }
     val infos = FormatTimer.time("read sourceinfos") { SourceInfosF.read(in) }
     val compilations = FormatTimer.time("read compilations") { CompilationsF.read(in) }
 
     (Analysis.Empty.copy(stamps, apis, relations, infos, compilations), setup)
+  }
+
+  def readCompanionMap(in: BufferedReader): (Map[String, Companions], Map[String, Companions]) = {
+    VersionF.read(in)
+    CompanionsF.read(in)
   }
 
   private[this] object VersionF {
@@ -257,12 +273,37 @@ object TextAnalysisFormat {
       FormatTimer.close("sbinary write")
     }
 
-    def read(in: BufferedReader): APIs = {
+    def read(in: BufferedReader, companionsStore: CompanionsStore): APIs = {
+      val companions: Lazy[(Map[String, Companions], Map[String, Companions])] = SafeLazy(companionsStore.get().get)
       val internal = readMap(in)(Headers.internal, identity[String], stringToAnalyzedClass)
       val external = readMap(in)(Headers.external, identity[String], stringToAnalyzedClass)
       FormatTimer.close("base64 -> bytes")
       FormatTimer.close("sbinary read")
-      APIs(internal, external)
+      APIs(
+        internal map { case (k, v) => k -> v.withApi(SafeLazy(companions.get._1(k))) },
+        external map { case (k, v) => k -> v.withApi(SafeLazy(companions.get._2(k))) }
+      )
+    }
+  }
+
+  private[this] object CompanionsF {
+    object Headers {
+      val internal = "internal comanions"
+      val external = "external comanions"
+    }
+
+    val stringToCompanions = ObjectStringifier.stringToObj[Companions] _
+    val companionsToString = ObjectStringifier.objToString[Companions] _
+
+    def write(out: Writer, internal: Map[String, Companions], external: Map[String, Companions]): Unit = {
+      writeMap(out)(Headers.internal, internal, identity[String], companionsToString, inlineVals = false)
+      writeMap(out)(Headers.external, external, identity[String], companionsToString, inlineVals = false)
+    }
+
+    def read(in: BufferedReader): (Map[String, Companions], Map[String, Companions]) = {
+      val internal = readMap(in)(Headers.internal, identity[String], stringToCompanions)
+      val external = readMap(in)(Headers.external, identity[String], stringToCompanions)
+      (internal, external)
     }
   }
 

--- a/internal/zinc-persist/src/main/scala/xsbt/api/AnalyzedClassFormat.scala
+++ b/internal/zinc-persist/src/main/scala/xsbt/api/AnalyzedClassFormat.scala
@@ -3,20 +3,22 @@
  */
 package xsbt.api
 
+import xsbti.SafeLazy
 import xsbti.api._
 import sbinary._
+import sbinary.DefaultProtocol._
+import sbt.internal.inc.APIs.emptyCompanions
 
-object AnalyzedClassFormat extends Format[AnalyzedClass] {
-  import java.io._
-  def reads(in: Input): AnalyzedClass =
-    {
-      val oin = new ObjectInputStream(new InputWrapperStream(in))
-      try { oin.readObject.asInstanceOf[AnalyzedClass] } finally { oin.close() }
-    }
-  def writes(out: Output, src: AnalyzedClass): Unit = {
-    val oout = new ObjectOutputStream(new OutputWrapperStream(out))
-    try { oout.writeObject(src) } finally { oout.close() }
-  }
+object AnalyzedClassFormats {
+  // This will throw out API information intentionally.
+  def analyzedClassFormat(implicit ev0: Format[Compilation], ev1: Format[NameHashes]): Format[AnalyzedClass] =
+    wrap[AnalyzedClass, (Compilation, String, Int, NameHashes, Boolean)](
+      a => (a.compilation, a.name, a.apiHash, a.nameHashes, a.hasMacro),
+      (x: (Compilation, String, Int, NameHashes, Boolean)) => x match {
+        case (compilation: Compilation, name: String, apiHash: Int, nameHashes: NameHashes, hasMacro: Boolean) =>
+          new AnalyzedClass(compilation, name, SafeLazy(emptyCompanions), apiHash, nameHashes, hasMacro)
+      }
+    )
 }
 final class InputWrapperStream(in: Input) extends java.io.InputStream {
   def toInt(b: Byte) = if (b < 0) b + 256 else b.toInt

--- a/internal/zinc-persist/src/main/scala/xsbt/api/CompanionsFormat.scala
+++ b/internal/zinc-persist/src/main/scala/xsbt/api/CompanionsFormat.scala
@@ -1,0 +1,16 @@
+package xsbt.api
+
+import xsbti.api._
+import sbinary._
+
+object CompanionsFormat extends Format[Companions] {
+  import java.io._
+  def reads(in: Input): Companions = {
+    val oin = new ObjectInputStream(new InputWrapperStream(in))
+    try { oin.readObject.asInstanceOf[Companions] } finally { oin.close() }
+  }
+  def writes(out: Output, src: Companions): Unit = {
+    val oout = new ObjectOutputStream(new OutputWrapperStream(out))
+    try { oout.writeObject(src) } finally { oout.close() }
+  }
+}

--- a/internal/zinc-persist/src/main/scala/xsbt/api/NameHashesFormat.scala
+++ b/internal/zinc-persist/src/main/scala/xsbt/api/NameHashesFormat.scala
@@ -1,0 +1,17 @@
+package xsbt.api
+
+import xsbti.api._
+import sbinary._
+
+object NameHashesFormat extends Format[NameHashes] {
+  import java.io._
+  def reads(in: Input): NameHashes =
+    {
+      val oin = new ObjectInputStream(new InputWrapperStream(in))
+      try { oin.readObject.asInstanceOf[NameHashes] } finally { oin.close() }
+    }
+  def writes(out: Output, src: NameHashes): Unit = {
+    val oout = new ObjectOutputStream(new OutputWrapperStream(out))
+    try { oout.writeObject(src) } finally { oout.close() }
+  }
+}

--- a/internal/zinc-persist/src/test/scala/sbt/inc/TextAnalysisFormatSpecification.scala
+++ b/internal/zinc-persist/src/test/scala/sbt/inc/TextAnalysisFormatSpecification.scala
@@ -1,9 +1,9 @@
 package sbt
 package inc
 
-import xsbti.api.ExternalDependency
+import xsbti.api.{ ExternalDependency, Companions }
 import xsbti.compile.{ MiniSetup, MiniOptions }
-import sbt.internal.inc.{ Analysis, Exists, SourceInfos, TestCaseGenerators, TextAnalysisFormat }
+import sbt.internal.inc.{ Analysis, Exists, SourceInfos, TestCaseGenerators, TextAnalysisFormat, CompanionsStore }
 import sbt.util.InterfaceUtil._
 
 import java.io.{ BufferedReader, File, StringReader, StringWriter }
@@ -43,6 +43,9 @@ object TextAnalysisFormatTest extends Properties("TextAnalysisFormat") {
                     |extra:
                     |1 items
                     |key -> value""".stripMargin
+  val companionStore = new CompanionsStore {
+    def get(): Option[(Map[String, Companions], Map[String, Companions])] = None
+  }
 
   property("Write and read empty Analysis") = {
 
@@ -55,7 +58,7 @@ object TextAnalysisFormatTest extends Properties("TextAnalysisFormat") {
 
     val reader = new BufferedReader(new StringReader(result))
 
-    val (readAnalysis: Analysis, readSetup) = TextAnalysisFormat.read(reader)
+    val (readAnalysis: Analysis, readSetup) = TextAnalysisFormat.read(reader, companionStore)
 
     compare(analysis, readAnalysis) && result.startsWith(commonHeader)
   }
@@ -89,7 +92,7 @@ object TextAnalysisFormatTest extends Properties("TextAnalysisFormat") {
 
     val reader = new BufferedReader(new StringReader(result))
 
-    val (readAnalysis: Analysis, readSetup) = TextAnalysisFormat.read(reader)
+    val (readAnalysis: Analysis, readSetup) = TextAnalysisFormat.read(reader, companionStore)
 
     compare(analysis, readAnalysis) && result.startsWith(commonHeader)
   }
@@ -105,7 +108,7 @@ object TextAnalysisFormatTest extends Properties("TextAnalysisFormat") {
       result.startsWith(commonHeader)
       val reader = new BufferedReader(new StringReader(result))
 
-      val (readAnalysis: Analysis, readSetup) = TextAnalysisFormat.read(reader)
+      val (readAnalysis: Analysis, readSetup) = TextAnalysisFormat.read(reader, companionStore)
 
       compare(analysis, readAnalysis) && result.startsWith(commonHeader)
     }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,11 +32,13 @@ object Dependencies {
   lazy val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.13.1"
   lazy val scalatest = "org.scalatest" %% "scalatest" % "2.2.6"
   lazy val junit = "junit" % "junit" % "4.11"
+  lazy val diffUtils = "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0"
   def testDependencies = Seq(libraryDependencies ++=
     Seq(
       utilTesting % Test,
       scalaCheck % Test,
       scalatest % Test,
-      junit % Test
+      junit % Test,
+      diffUtils % Test
     ))
 }

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -198,6 +198,6 @@ object MixedAnalyzingCompiler {
     }
 
   /** Create a an analysis store cache at the desired location. */
-  def staticCachedStore(cacheFile: File) = staticCache(cacheFile, AnalysisStore.sync(AnalysisStore.cached(FileBasedStore(cacheFile))))
-
+  def staticCachedStore(analysisFile: File): AnalysisStore =
+    staticCache(analysisFile, AnalysisStore.sync(AnalysisStore.cached(FileBasedStore(analysisFile))))
 }

--- a/zinc/src/test/scala/sbt/inc/IncrementalCompilerSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/IncrementalCompilerSpec.scala
@@ -90,7 +90,7 @@ class IncrementalCompilerSpec extends BridgeProviderSpecification {
 
   it should "trigger full compilation if extra changes" in {
     IO.withTemporaryDirectory { tempDir =>
-      val cacheFile = tempDir / "target" / "inc_compile"
+      val cacheFile = tempDir / "target" / "inc_compile.zip"
       val fileStore = AnalysisStore.cached(FileBasedStore(cacheFile))
 
       val knownSampleGoodFile = tempDir / "src" / "Good.scala"
@@ -107,7 +107,7 @@ class IncrementalCompilerSpec extends BridgeProviderSpecification {
       val cs = compiler.compilers(si, ClasspathOptionsUtil.boot, None, sc)
       val prev0 = compiler.emptyPreviousResult
       val lookup = new Lookup(_ => prev0.analysis)
-      val incOptions = IncOptionsUtil.defaultIncOptions()
+      val incOptions = IncOptionsUtil.defaultIncOptions().withApiDebug(true)
       val reporter = new LoggerReporter(maxErrors, log, identity)
       val extra = Array(InterfaceUtil.t2(("key", "value")))
       val setup = compiler.setup(lookup, skip = false, tempDir / "inc_compile", CompilerCache.fresh, incOptions, reporter, None, extra)
@@ -115,7 +115,6 @@ class IncrementalCompilerSpec extends BridgeProviderSpecification {
       val in = compiler.inputs(si.allJars, sources, classesDir, Array(), Array(), maxErrors, Array(),
         CompileOrder.Mixed, cs, setup, prev0)
       val result = compiler.compile(in, log)
-      //val prev = compiler.previousResult(result)
       fileStore.set(result.analysis match { case a: Analysis => a }, result.setup)
       val prev = fileStore.get match {
         case Some((a, s)) => new PreviousResult(Maybe.just(a), Maybe.just(s))


### PR DESCRIPTION
It's been reported that for large code bases with thousands of files,
the Analysis object reaches the size of 100MB, mostly from the API info
blob.

This changes SameAPI.apply to use only the API hash, and thereby
removing the necessity to load previous API info during the incremental
compilation.

To prevent needless reading of API info, the companions map is now
stored into another zip entry, which is read lazily.

/cc @gkossakowski, @romanowski 
