### PR TITLE
Speed up external dependencies lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+.idea

--- a/internal/compiler-interface/src/main/datatype/incremental.json
+++ b/internal/compiler-interface/src/main/datatype/incremental.json
@@ -146,6 +146,14 @@
           "name": "externalHooks",
           "type": "xsbti.compile.ExternalHooks",
           "doc": "External hooks that allows clients e.g. IDEs to interacts with compilation internals"
+        },
+        {
+          "name": "analysisOnlyExtDepLookup",
+          "type": "boolean",
+          "doc": [
+            "Ignore classpath entries without Analysis when searching for external dependencies.",
+            "It might miss changes in classes from jars external class directories."
+          ]
         }
       ]
     },

--- a/internal/compiler-interface/src/main/java/xsbti/compile/IncOptionsUtil.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/IncOptionsUtil.java
@@ -102,6 +102,10 @@ public class IncOptionsUtil {
     return true;
   }
 
+  public static boolean defaultAnalysisOnlyExtDepLookup() {
+    return false;
+  }
+
   public static IncOptions defaultIncOptions() {
     IncOptions retval = new IncOptions(
       defaultTransitiveStep(), defaultRecompileAllFraction(),
@@ -110,7 +114,7 @@ public class IncOptionsUtil {
       defaultClassfileManagerType(), defaultRecompileOnMacroDef(),
       defaultNameHashing(), defaultAntStyle(),
       defaultExtra(), defaultLogRecompileOnMacro(),
-      defaultExternal());
+      defaultExternal(), defaultAnalysisOnlyExtDepLookup());
     return retval;
   }
 

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala
@@ -18,7 +18,12 @@ import sbt.io.syntax._
  * the analysis plugin.  Because these call Scala code for a different Scala version than the one used for this class, they must
  * be compiled for the version of Scala being used.
  */
-final class AnalyzingCompiler private (val scalaInstance: XScalaInstance, val provider: CompilerInterfaceProvider, override val classpathOptions: ClasspathOptions, onArgsF: Seq[String] => Unit) extends CachedCompilerProvider with ScalaCompiler {
+final class AnalyzingCompiler private (
+  val scalaInstance: XScalaInstance,
+  val provider: CompilerInterfaceProvider,
+  override val classpathOptions: ClasspathOptions,
+  onArgsF: Seq[String] => Unit
+) extends CachedCompilerProvider with ScalaCompiler {
   def this(scalaInstance: XScalaInstance, provider: CompilerInterfaceProvider, cp: ClasspathOptions) =
     this(scalaInstance, provider, cp, _ => ())
   def this(scalaInstance: XScalaInstance, provider: CompilerInterfaceProvider) = this(scalaInstance, provider, ClasspathOptionsUtil.auto)

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
@@ -128,21 +128,22 @@ private[inc] abstract class IncrementalCommon(log: sbt.util.Logger, options: Inc
    * providing the API before and after the last step.  The functions should return
    * an empty API if the class did not/does not exist.
    */
-  def changedIncremental(lastClasses: collection.Set[String], oldAPI: String => AnalyzedClass,
-    newAPI: String => AnalyzedClass): APIChanges =
-    {
-      val oldApis = lastClasses.toSeq map oldAPI
-      val newApis = lastClasses.toSeq map newAPI
-      val apiChanges = (lastClasses, oldApis, newApis).zipped.flatMap {
-        (className, oldApi, newApi) => sameClass(className, oldApi, newApi)
-      }
-
-      if (Incremental.apiDebug(options) && apiChanges.nonEmpty) {
-        logApiChanges(apiChanges, oldAPI, newAPI)
-      }
-
-      new APIChanges(apiChanges)
+  def changedIncremental(
+    lastClasses: collection.Set[String],
+    oldAPI: String => AnalyzedClass,
+    newAPI: String => AnalyzedClass
+  ): APIChanges = {
+    val apiChanges = lastClasses.flatMap { className =>
+      sameClass(className, oldAPI(className), newAPI(className))
     }
+
+    if (Incremental.apiDebug(options) && apiChanges.nonEmpty) {
+      logApiChanges(apiChanges, oldAPI, newAPI)
+    }
+
+    new APIChanges(apiChanges)
+  }
+
   def sameClass(className: String, a: AnalyzedClass, b: AnalyzedClass): Option[APIChange] = {
     // Clients of a modified class (ie, one that doesn't satisfy `shortcutSameClass`) containing macros must be recompiled.
     val hasMacro = a.hasMacro || b.hasMacro

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Locate.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Locate.scala
@@ -40,7 +40,7 @@ object Locate {
   def entry(classpath: Seq[File], lookup: PerClasspathEntryLookup): String => Option[File] =
     {
       val entries = classpath.toStream.map { entry => (entry, lookup.definesClass(entry)) }
-      className => entries.collect { case (entry, defines) if defines(className) => entry }.headOption
+      className => entries.collectFirst { case (entry, defines) if defines(className) => entry }
     }
   def resolve(f: File, className: String): File = if (f.isDirectory) classFile(f, className) else f
 

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Lookup.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Lookup.scala
@@ -26,7 +26,6 @@ trait Lookup extends ExternalLookup {
 
   /**
    * Return an Analysis instance that has the given class file registered as a product.
-   * as a product.
    *
    * @param classFile
    * @return

--- a/internal/zinc-persist/src/test/scala/sbt/inc/TextAnalysisFormatSpecification.scala
+++ b/internal/zinc-persist/src/test/scala/sbt/inc/TextAnalysisFormatSpecification.scala
@@ -54,7 +54,6 @@ object TextAnalysisFormatTest extends Properties("TextAnalysisFormat") {
     TextAnalysisFormat.write(writer, analysis, commonSetup)
 
     val result = writer.toString
-    // println(result)
 
     val reader = new BufferedReader(new StringReader(result))
 

--- a/zinc/src/main/scala/sbt/internal/inc/CompileConfiguration.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/CompileConfiguration.scala
@@ -25,15 +25,27 @@ import xsbti.compile.{ GlobalsCache, CompileProgress, IncOptions, MiniSetup, Com
  */
 final class CompileConfiguration(
   val sources: Seq[File],
-  val classpath: Seq[File],
+  override val classpath: Seq[File],
   val previousAnalysis: CompileAnalysis,
   val previousSetup: Option[MiniSetup],
-  val currentSetup: MiniSetup,
+  override val currentSetup: MiniSetup,
   val progress: Option[CompileProgress],
-  val perClasspathEntryLookup: PerClasspathEntryLookup,
+  override val perClasspathEntryLookup: PerClasspathEntryLookup,
   val reporter: Reporter,
-  val compiler: xsbti.compile.ScalaCompiler,
+  override val compiler: xsbti.compile.ScalaCompiler,
   val javac: xsbti.compile.JavaCompiler,
   val cache: GlobalsCache,
-  val incOptions: IncOptions
-)
+  override val incOptions: IncOptions
+) extends CompilerClasspathConfig
+
+trait CompilerClasspathConfig {
+  val currentSetup: MiniSetup
+
+  def classpath: Seq[File]
+
+  def perClasspathEntryLookup: PerClasspathEntryLookup
+
+  def compiler: xsbti.compile.ScalaCompiler
+
+  def incOptions: IncOptions
+}

--- a/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
@@ -103,46 +103,6 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
       throw ex
   }
 
-  private class LookupImpl(compileConfiguration: CompileConfiguration) extends Lookup {
-    private val entry = MixedAnalyzingCompiler.classPathLookup(compileConfiguration)
-
-    override def lookupOnClasspath(binaryClassName: String): Option[File] =
-      entry(binaryClassName)
-
-    override def lookupAnalysis(classFile: File): Option[CompileAnalysis] =
-      m2o(compileConfiguration.perClasspathEntryLookup.analysis(classFile))
-
-    override def lookupAnalysis(binaryDependency: File, binaryClassName: String): Option[CompileAnalysis] = {
-      lookupOnClasspath(binaryClassName) flatMap { defines =>
-        if (binaryDependency != Locate.resolve(defines, binaryClassName))
-          None
-        else
-          lookupAnalysis(defines)
-      }
-    }
-
-    lazy val externalLookup = Option(compileConfiguration.incOptions.externalHooks())
-      .flatMap(ext => Option(ext.externalLookup()))
-      .collect {
-        case externalLookup: ExternalLookup => externalLookup
-      }
-
-    override def lookupAnalysis(binaryClassName: String): Option[CompileAnalysis] =
-      lookupOnClasspath(binaryClassName).flatMap(lookupAnalysis)
-
-    override def changedSources(previousAnalysis: Analysis): Option[Changes[File]] =
-      externalLookup.flatMap(_.changedSources(previousAnalysis))
-
-    override def changedBinaries(previousAnalysis: Analysis): Option[Set[File]] =
-      externalLookup.flatMap(_.changedBinaries(previousAnalysis))
-
-    override def removedProducts(previousAnalysis: Analysis): Option[Set[File]] =
-      externalLookup.flatMap(_.removedProducts(previousAnalysis))
-
-    override def shouldDoIncrementalCompilation(changedClasses: Set[String], analysis: Analysis): Boolean =
-      externalLookup.forall(_.shouldDoIncrementalCompilation(changedClasses, analysis))
-  }
-
   /** Actually runs the incremental compiler using the given mixed compiler.  This will prune the inputs based on the MiniSetup. */
   private def compileInternal(
     mixedCompiler: MixedAnalyzingCompiler,

--- a/zinc/src/main/scala/sbt/internal/inc/LookupImpl.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/LookupImpl.scala
@@ -1,0 +1,57 @@
+package sbt.internal.inc
+
+import java.io.File
+
+import sbt.util.Logger._
+import xsbti.Maybe
+import xsbti.compile.CompileAnalysis
+
+class LookupImpl(compileConfiguration: CompilerClasspathConfig) extends Lookup {
+  private val (classpath, entry) = MixedAnalyzingCompiler.searchClasspathAndLookup(compileConfiguration)
+
+  /** External dependencies (Analysis) ordered in the same way as on classpath */
+  private val externalDependenciesCp: Stream[Analysis] = classpath.toStream.flatMap(analysisForCpEntry)
+
+  private lazy val externalLookup = Option(compileConfiguration.incOptions.externalHooks())
+    .flatMap(ext => Option(ext.externalLookup()))
+    .collect {
+      case externalLookup: ExternalLookup => externalLookup
+    }
+
+  override def lookupOnClasspath(binaryClassName: String): Option[File] =
+    entry(binaryClassName)
+
+  override def lookupAnalysis(classFile: File): Option[CompileAnalysis] =
+    externalDependenciesCp.find(definesProduct(classFile))
+
+  override def lookupAnalysis(binaryDependency: File, binaryClassName: String): Option[CompileAnalysis] =
+    for {
+      classpathEntry <- lookupOnClasspath(binaryClassName)
+      analysis <- analysisForCpEntry(classpathEntry)
+      if definesProduct(binaryDependency)(analysis)
+    } yield analysis
+
+  override def lookupAnalysis(binaryClassName: String): Option[CompileAnalysis] =
+    if (compileConfiguration.incOptions.analysisOnlyExtDepLookup())
+      externalDependenciesCp.find(_.relations.binaryClassName.reverseMap.contains(binaryClassName))
+    else lookupOnClasspath(binaryClassName).flatMap(analysisForCpEntry)
+
+  override def changedSources(previousAnalysis: Analysis): Option[Changes[File]] =
+    externalLookup.flatMap(_.changedSources(previousAnalysis))
+
+  override def changedBinaries(previousAnalysis: Analysis): Option[Set[File]] =
+    externalLookup.flatMap(_.changedBinaries(previousAnalysis))
+
+  override def removedProducts(previousAnalysis: Analysis): Option[Set[File]] =
+    externalLookup.flatMap(_.removedProducts(previousAnalysis))
+
+  private def definesProduct(product: File)(a: Analysis): Boolean =
+    a.stamps.products.contains(product)
+
+  private def analysisForCpEntry(cpEntry: File): Option[Analysis] =
+    m2o(compileConfiguration.perClasspathEntryLookup.analysis(cpEntry).asInstanceOf[Maybe[Analysis]])
+
+  override def shouldDoIncrementalCompilation(changedClasses: Set[String], analysis: Analysis): Boolean =
+    externalLookup.forall(_.shouldDoIncrementalCompilation(changedClasses, analysis))
+}
+

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -156,7 +156,7 @@ object MixedAnalyzingCompiler {
   }
 
   /** Returns the search classpath (for dependencies) and a function which can also do so. */
-  def searchClasspathAndLookup(config: CompileConfiguration): (Seq[File], String => Option[File]) = {
+  def searchClasspathAndLookup(config: CompilerClasspathConfig): (Seq[File], String => Option[File]) = {
     import config._
     import currentSetup._
     val absClasspath = classpath.map(_.getAbsoluteFile)

--- a/zinc/src/test/scala/sbt/inc/BaseIncCompilerSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/BaseIncCompilerSpec.scala
@@ -1,0 +1,135 @@
+package sbt.inc
+
+import java.io.File
+
+import sbt.internal.inc.Analysis.NonLocalProduct
+import sbt.internal.inc._
+import sbt.io.IO
+import sbt.util.InterfaceUtil._
+import sbt.util.Logger
+import xsbti.Maybe
+import xsbti.compile._
+
+/**
+ * Author: Krzysztof Romanowski
+ */
+class BaseIncCompilerSpec extends BridgeProviderSpecification {
+
+  def mockedCompiler(in: File): ScalaCompiler = {
+    val scalaVersion = scala.util.Properties.versionNumberString
+    val compilerBridge = getCompilerBridge(in, Logger.Null, scalaVersion)
+    val instance = scalaInstance(scalaVersion)
+    new AnalyzingCompiler(instance, CompilerInterfaceProvider.constant(compilerBridge), ClasspathOptionsUtil.boot)
+  }
+
+  def mockedMiniSetup: MiniSetup = new MiniSetup(
+    new Output {},
+    new MiniOptions(Array.empty, Array.empty),
+    scala.util.Properties.versionNumberString,
+    CompileOrder.Mixed,
+    /*_nameHashing*/ true,
+    Array.empty
+  )
+
+  case class TestCompilerClasspathConfig(
+    override val classpath: Seq[File],
+    override val perClasspathEntryLookup: PerClasspathEntryLookup,
+    override val compiler: xsbti.compile.ScalaCompiler,
+    override val currentSetup: MiniSetup = mockedMiniSetup,
+    override val incOptions: IncOptions = IncOptionsUtil.defaultIncOptions()
+  ) extends CompilerClasspathConfig
+
+  protected def mockedConfig(mockedClasspath: Seq[File], mockedLookup: PerClasspathEntryLookup, tempDir: File): TestCompilerClasspathConfig =
+    TestCompilerClasspathConfig(mockedClasspath, mockedLookup, mockedCompiler(tempDir))
+}
+
+abstract class ClasspathEntry(in: DirectorySetup) {
+  def classpathEntry: File
+
+  def analysis: Option[Analysis]
+
+  in.register(this)
+}
+
+class VirtualDir(val name: String, val classes: Seq[String], val in: DirectorySetup) extends ClasspathEntry(in) {
+  val dir = new File(in.baseDir, name)
+  dir.mkdirs()
+
+  val classFiles = classes.map(classFile)
+  classFiles.foreach(_.createNewFile())
+
+  override def classpathEntry: File = dir
+
+  override def analysis: Option[Analysis] = None
+
+  def classFile(binaryName: String) = new File(dir, s"$binaryName.class")
+}
+
+case class VirtualJar(override val name: String, override val classes: Seq[String], override val in: DirectorySetup)
+  extends VirtualDir(name + "_tmp", classes, in) {
+  val location = new File(in.baseDir, s"$name.jar")
+
+  IO.zip(classFiles.map(f => f -> f.getName), location)
+
+  override def classpathEntry: File = location
+
+  override def analysis: Option[Analysis] = None
+}
+
+case class VirtualProject(name: String, in: DirectorySetup) extends ClasspathEntry(in) {
+  private var _analysis: Analysis = Analysis.Empty
+
+  def newSource(v: VirtualSource): Analysis = {
+    val newAnalysis = Analysis.empty(true)
+      .addSource(
+        v.sourceFile,
+        Seq(APIs.emptyAnalyzedClass.withName(v.name)),
+        Stamp.hash(v.sourceFile),
+        SourceInfos.emptyInfo,
+        Seq(NonLocalProduct(v.name, v.name, v.classFile, Stamp.lastModified(v.classFile))),
+        Nil, Nil, Nil, Nil
+      )
+    _analysis ++= newAnalysis
+    newAnalysis
+  }
+
+  val baseDir = new File(in.baseDir, name)
+  baseDir.mkdirs()
+
+  val src = new File(baseDir, "src")
+  src.mkdir()
+
+  val out = new File(baseDir, "out")
+  out.mkdir()
+
+  override def classpathEntry: File = out
+
+  override def analysis: Option[Analysis] = Some(_analysis)
+}
+
+case class VirtualSource(name: String, in: VirtualProject) {
+  val sourceFile = new File(in.src, s"$name.scala")
+  val classFile = new File(in.out, s"$name.class")
+
+  sourceFile.createNewFile()
+  classFile.createNewFile()
+
+  val analysis = in.newSource(this)
+}
+
+class DirectorySetup(val baseDir: File) {
+  private var myEntries = Seq.empty[ClasspathEntry]
+
+  def register(entry: ClasspathEntry) = myEntries :+= entry
+
+  def classpath = myEntries.map(_.classpathEntry)
+
+  def analysisMap = myEntries.map(e => e.classpathEntry -> e.analysis).toMap
+
+  def entryLookup = new PerClasspathEntryLookup() {
+    override def analysis(classpathEntry: File): Maybe[CompileAnalysis] =
+      o2m(analysisMap.get(classpathEntry).flatten)
+
+    override def definesClass(classpathEntry: File): DefinesClass = Locate.definesClass(classpathEntry)
+  }
+}

--- a/zinc/src/test/scala/sbt/inc/LookupSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/LookupSpec.scala
@@ -1,0 +1,149 @@
+package sbt.inc
+
+import java.io.File
+
+import sbt.internal.inc.Analysis.LocalProduct
+import sbt.internal.inc.{ CompilerClasspathConfig, _ }
+import sbt.io.IO
+import sbt.util.{ InterfaceUtil, Logger }
+import xsbti.Maybe
+import xsbti.compile._
+import InterfaceUtil.o2m
+
+class LookupSpec extends BaseIncCompilerSpec {
+  behavior of "LookupImpl"
+
+  protected case class ProjectSetup(in: File) extends DirectorySetup(in) {
+
+    val jar1 = VirtualJar("jar1", Seq("J1J2", "J1P1", "J1C1"), this)
+    val classesDir1 = new VirtualDir("classes1", Seq("J1C1", "C1C2", "C1P1", "C1J2"), this)
+
+    object project1 extends VirtualProject("project1", this) {
+      val P1P2 = VirtualSource("P1P2", this)
+      val J1P1 = VirtualSource("J1P1", this)
+      val C1P1 = VirtualSource("C1P1", this)
+      val P1C2 = VirtualSource("P1C2", this)
+      val P1J2 = VirtualSource("P1J2", this)
+    }
+
+    project1
+
+    val jar2 = VirtualJar("jar2", Seq("J1J2", "C1J2", "P1J2", "J2"), this)
+    val classesDir2 = new VirtualDir("classes2", Seq("C1C2", "P1C2", "C2"), this)
+
+    object project2 extends VirtualProject("project2", this) {
+      val P1P2 = VirtualSource("P1P2", this)
+      val P2 = VirtualSource("P2", this)
+    }
+
+    project2
+
+    val config = mockedConfig(classpath, entryLookup, in)
+
+    val lookup = new LookupImpl(config)
+  }
+
+  private def mockedProjectContext(op: ProjectSetup => Unit) = IO.withTemporaryDirectory(tempDir => op(new ProjectSetup(tempDir)))
+
+  private def withAnalysisOnlyExtDepLookup(value: Boolean, from: ProjectSetup): LookupImpl = {
+    import from._
+    new LookupImpl(config.copy(incOptions = config.incOptions.withAnalysisOnlyExtDepLookup(value)))
+  }
+
+  it should "find correct analysis for binary name - fast lookup on" in mockedProjectContext { setup =>
+    import setup._
+
+    val lookup = withAnalysisOnlyExtDepLookup(true, setup)
+
+    lookup.lookupAnalysis("P1P2") shouldEqual project1.analysis
+    lookup.lookupAnalysis("P1J2") shouldEqual project1.analysis
+    lookup.lookupAnalysis("P1C2") shouldEqual project1.analysis
+    lookup.lookupAnalysis("J1P1") shouldEqual project1.analysis
+    lookup.lookupAnalysis("C1P1") shouldEqual project1.analysis
+
+    lookup.lookupAnalysis("P2") shouldEqual project2.analysis
+
+    lookup.lookupAnalysis("J1J2") shouldEqual None
+    lookup.lookupAnalysis("C1C2") shouldEqual None
+
+    lookup.lookupAnalysis("P1.P2") shouldEqual None
+    lookup.lookupAnalysis("P1P2$") shouldEqual None
+    lookup.lookupAnalysis("P1$P2") shouldEqual None
+  }
+
+  it should "find correct analysis for binary name - fast lookup off" in mockedProjectContext { setup =>
+    import setup._
+
+    val lookup = withAnalysisOnlyExtDepLookup(false, setup)
+
+    lookup.lookupAnalysis("P1P2") shouldEqual project1.analysis
+    lookup.lookupAnalysis("P1J2") shouldEqual project1.analysis
+    lookup.lookupAnalysis("P1C2") shouldEqual project1.analysis
+
+    lookup.lookupAnalysis("P2") shouldEqual project2.analysis
+
+    lookup.lookupAnalysis("J1P1") shouldEqual None
+    lookup.lookupAnalysis("C1P1") shouldEqual None
+
+    lookup.lookupAnalysis("J1J2") shouldEqual None
+    lookup.lookupAnalysis("C1C2") shouldEqual None
+
+    lookup.lookupAnalysis("P1.P2") shouldEqual None
+    lookup.lookupAnalysis("P1P2$") shouldEqual None
+    lookup.lookupAnalysis("P1$P2") shouldEqual None
+  }
+
+  it should "find correct analysis for class file" in mockedProjectContext { setup =>
+    import setup._
+
+    lookup.lookupAnalysis(project1.P1P2.classFile) shouldEqual project1.analysis
+    lookup.lookupAnalysis(project2.P1P2.classFile) shouldEqual project2.analysis
+    lookup.lookupAnalysis(project2.P2.classFile) shouldEqual project2.analysis
+    lookup.lookupAnalysis(project1.P1J2.classFile) shouldEqual project1.analysis
+    lookup.lookupAnalysis(project1.P1C2.classFile) shouldEqual project1.analysis
+
+    lookup.lookupAnalysis(classesDir1.classFile("C1C2")) shouldEqual None
+  }
+
+  it should "find correct analysis for class file and binary name" in mockedProjectContext { setup =>
+    import setup._
+
+    lookup.lookupAnalysis(project1.P1P2.classFile, "P1P2") shouldEqual project1.analysis
+    lookup.lookupAnalysis(project1.P1J2.classFile, "P1J2") shouldEqual project1.analysis
+    lookup.lookupAnalysis(project1.P1C2.classFile, "P1C2") shouldEqual project1.analysis
+
+    lookup.lookupAnalysis(project2.P1P2.classFile, "P1P2") shouldEqual None
+    lookup.lookupAnalysis(project2.P2.classFile, "P2") shouldEqual project2.analysis
+
+    lookup.lookupAnalysis(project1.J1P1.classFile, "J1P1") shouldEqual None
+
+    lookup.lookupAnalysis(project1.C1P1.classFile, "C1P1") shouldEqual None
+  }
+
+  it should "find correct class file for binary name" in mockedProjectContext { setup =>
+    import setup._
+
+    lookup.lookupOnClasspath("J1J2") shouldEqual Some(jar1.location)
+    lookup.lookupOnClasspath("J1C1") shouldEqual Some(jar1.location)
+    lookup.lookupOnClasspath("J1P1") shouldEqual Some(jar1.location)
+
+    lookup.lookupOnClasspath("C1P1") shouldEqual Some(classesDir1.dir)
+    lookup.lookupOnClasspath("C1C2") shouldEqual Some(classesDir1.dir)
+    lookup.lookupOnClasspath("C1J2") shouldEqual Some(classesDir1.dir)
+
+    lookup.lookupOnClasspath("P1P2") shouldEqual Some(project1.out)
+    lookup.lookupOnClasspath("P1J2") shouldEqual Some(project1.out)
+    lookup.lookupOnClasspath("P1C2") shouldEqual Some(project1.out)
+
+    lookup.lookupOnClasspath("J2") shouldEqual Some(jar2.location)
+
+    lookup.lookupOnClasspath("C2") shouldEqual Some(classesDir2.dir)
+
+    lookup.lookupOnClasspath("P2") shouldEqual Some(project2.out)
+
+    lookup.lookupOnClasspath("Ala") shouldEqual None
+    lookup.lookupOnClasspath("C1P1$") shouldEqual None
+    lookup.lookupOnClasspath("C1.P1") shouldEqual None
+  }
+
+}


### PR DESCRIPTION
Previously in order to find Analysis for given class name zinc fist have to enumerated whole classpath (each class in each jar or classes directory). In huge workspace it might take over 40 sec – and this was overhead for each compilation (even the smallest).

Now zinc searches for given analysis in all analysis ordered in the same way as classpath so whole classpath enumeration is skipped for searching for changed sources. Now overhead is barely  noticeable.

This might not detect correct changes if class x.X was previously present only in ouput of depended project but later class with same binary name was added to raw classes directory that is earlier on classpath. This is true if this situation happens when jar content is changed (so x.X is added there) however this should be capture as change in binary dependencies.

From reasons above I deiced to keep old behavior under flag.

For certain reasons this time I have to paste the below disclaimer:
THIS PROGRAM IS SUBJECT TO THE TERMS OF THE BSD 3-CLAUSE LICENSE.

THE FOLLOWING DISCLAIMER APPLIES TO ALL SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE:
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR
ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
ONLY THE SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE, IF ANY, THAT ARE ATTACHED TO (OR OTHERWISE ACCOMPANY) THIS SUBMISSION (AND ORDINARY
COURSE CONTRIBUTIONS OF FUTURES PATCHES THERETO) ARE TO BE CONSIDERED A CONTRIBUTION. NO OTHER SOFTWARE CODE OR MATERIALS ARE A CONTRIBUTION.
