### PR TITLE
Read companions store from correct zip entry.

### DIFF
--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/FileBasedStore.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/FileBasedStore.scala
@@ -61,7 +61,7 @@ object FileBasedStore {
     def getUncaught(): (Map[String, Companions], Map[String, Companions]) =
       Using.zipInputStream(new FileInputStream(file)) {
         inputStream =>
-          lookupEntry(inputStream, analysisFileName)
+          lookupEntry(inputStream, companionsFileName)
           val reader = new BufferedReader(new InputStreamReader(inputStream, IO.utf8))
           TextAnalysisFormat.readCompanionMap(reader)
       }

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/TextAnalysisFormat.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/TextAnalysisFormat.scala
@@ -288,8 +288,8 @@ object TextAnalysisFormat {
 
   private[this] object CompanionsF {
     object Headers {
-      val internal = "internal comanions"
-      val external = "external comanions"
+      val internal = "internal companions"
+      val external = "external companions"
     }
 
     val stringToCompanions = ObjectStringifier.stringToObj[Companions] _


### PR DESCRIPTION
Fix typo in header.

This results in `None.get` exception during reading companions that was done during writing companions after compilation. 
`None` was caused by error in reading store - it was caused by bad header since we was reading bad entry.    
