### PR TITLE
Option to turn off apis storing

### DIFF
--- a/internal/compiler-interface/src/main/datatype/incremental.json
+++ b/internal/compiler-interface/src/main/datatype/incremental.json
@@ -110,6 +110,13 @@
           ]
         },
         {
+          "name": "storeApis",
+          "type": "boolean",
+          "doc": [
+            "Determines whether incremental compiler stores apis alongside analysis."
+          ]
+        },
+        {
           "name": "antStyle",
           "type": "boolean",
           "doc": [
@@ -269,6 +276,10 @@
         },
         {
           "name": "nameHashing",
+          "type": "boolean"
+        },
+        {
+          "name": "storeApis",
           "type": "boolean"
         },
         {

--- a/internal/compiler-interface/src/main/java/xsbti/compile/IncOptionsUtil.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/IncOptionsUtil.java
@@ -76,6 +76,10 @@ public class IncOptionsUtil {
     return true;
   }
 
+  public static boolean defaultStoreApis() {
+    return true;
+  }
+
   public static boolean defaultAntStyle() {
     return false;
   }
@@ -112,7 +116,7 @@ public class IncOptionsUtil {
       defaultRelationsDebug(), defaultApiDebug(),
       defaultApiDiffContextSize(), defaultApiDumpDirectory(),
       defaultClassfileManagerType(), defaultRecompileOnMacroDef(),
-      defaultNameHashing(), defaultAntStyle(),
+      defaultNameHashing(), defaultStoreApis(), defaultAntStyle(),
       defaultExtra(), defaultLogRecompileOnMacro(),
       defaultExternal(), defaultAnalysisOnlyExtDepLookup());
     return retval;

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/FileBasedStore.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/FileBasedStore.scala
@@ -30,9 +30,11 @@ object FileBasedStore {
           outputStream.putNextEntry(new ZipEntry(analysisFileName))
           TextAnalysisFormat.write(writer, analysis, setup)
           outputStream.closeEntry()
-          outputStream.putNextEntry(new ZipEntry(companionsFileName))
-          TextAnalysisFormat.writeCompanionMap(writer, analysis match { case a: Analysis => a.apis })
-          outputStream.closeEntry()
+          if (setup.storeApis()) {
+            outputStream.putNextEntry(new ZipEntry(companionsFileName))
+            TextAnalysisFormat.writeCompanionMap(writer, analysis match { case a: Analysis => a.apis })
+            outputStream.closeEntry()
+          }
       }
     }
 

--- a/internal/zinc-persist/src/test/scala/sbt/inc/TextAnalysisFormatSpecification.scala
+++ b/internal/zinc-persist/src/test/scala/sbt/inc/TextAnalysisFormatSpecification.scala
@@ -17,8 +17,9 @@ import Prop._
 object TextAnalysisFormatTest extends Properties("TextAnalysisFormat") {
 
   val nameHashing = true
+  val storeApis = true
   val dummyOutput = new xsbti.compile.SingleOutput { def outputDirectory: java.io.File = new java.io.File("/dummy") }
-  val commonSetup = new MiniSetup(dummyOutput, new MiniOptions(Array(), Array()), "2.10.4", xsbti.compile.CompileOrder.Mixed, nameHashing,
+  val commonSetup = new MiniSetup(dummyOutput, new MiniOptions(Array(), Array()), "2.10.4", xsbti.compile.CompileOrder.Mixed, nameHashing, storeApis,
     Array(t2(("key", "value"))))
   val commonHeader = """format version: 6
                     |output mode:
@@ -38,6 +39,9 @@ object TextAnalysisFormatTest extends Properties("TextAnalysisFormat") {
                     |1 items
                     |0 -> Mixed
                     |name hashing:
+                    |1 items
+                    |0 -> true
+                    |skip Api storing:
                     |1 items
                     |0 -> true
                     |extra:
@@ -105,7 +109,6 @@ object TextAnalysisFormatTest extends Properties("TextAnalysisFormat") {
 
       val result = writer.toString
 
-      result.startsWith(commonHeader)
       val reader = new BufferedReader(new StringReader(result))
 
       val (readAnalysis: Analysis, readSetup) = TextAnalysisFormat.read(reader, companionStore)

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -116,7 +116,8 @@ object MixedAnalyzingCompiler {
   ): CompileConfiguration =
     {
       val compileSetup = new MiniSetup(output, new MiniOptions(options.toArray, javacOptions.toArray),
-        scalac.scalaInstance.actualVersion, compileOrder, incrementalCompilerOptions.nameHashing,
+        scalac.scalaInstance.actualVersion, compileOrder,
+        incrementalCompilerOptions.nameHashing, incrementalCompilerOptions.storeApis(),
         (extra map InterfaceUtil.t2).toArray)
       config(
         sources,

--- a/zinc/src/test/scala/sbt/inc/BaseIncCompilerSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/BaseIncCompilerSpec.scala
@@ -28,6 +28,7 @@ class BaseIncCompilerSpec extends BridgeProviderSpecification {
     scala.util.Properties.versionNumberString,
     CompileOrder.Mixed,
     /*_nameHashing*/ true,
+    /*_storeApis*/ true,
     Array.empty
   )
 


### PR DESCRIPTION
APIs are not used in compilation process so we we can store them only in clients that are actually using it (e.g. sbt).

We are still have problems with lazy apis loading but in our case (Intellij Scala plugin integration) we are not using apis anymore (we got sometimes IOExceptions from reading apis when analysis was stored).

With api storing turned off all works fine.

For certain reasons this time I have to paste the below disclaimer:
THIS PROGRAM IS SUBJECT TO THE TERMS OF THE BSD 3-CLAUSE LICENSE.

THE FOLLOWING DISCLAIMER APPLIES TO ALL SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE:
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR
ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
ONLY THE SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE, IF ANY, THAT ARE ATTACHED TO (OR OTHERWISE ACCOMPANY) THIS SUBMISSION (AND ORDINARY
COURSE CONTRIBUTIONS OF FUTURES PATCHES THERETO) ARE TO BE CONSIDERED A CONTRIBUTION. NO OTHER SOFTWARE CODE OR MATERIALS ARE A CONTRIBUTION.
