### PR TITLE
Adding column number information into compiler output

### DIFF
--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/LoggerReporter.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/LoggerReporter.scala
@@ -96,7 +96,8 @@ class LoggerReporter(maximumErrors: Int, log: Logger, sourcePositionMapper: Posi
       log(msg)
     else {
       val sourcePrefix = m2o(pos.sourcePath).getOrElse("")
-      val lineNumberString = m2o(pos.line).map(":" + _ + ":").getOrElse(":") + " "
+      val columnNumber = m2o(pos.pointer).map(_.toInt + 1).getOrElse(1)
+      val lineNumberString = m2o(pos.line).map(":" + _ + ":" + columnNumber + ":").getOrElse(":") + " "
       log(sourcePrefix + lineNumberString + msg)
       val lineContent = pos.lineContent
       if (!lineContent.isEmpty) {


### PR DESCRIPTION
Currently compiler output lacks column number information easily
accessible for cli tools.

This change is adding column number just behind line number

```
[error] /Users/me/column/src/main/scala/Column.scala:5:31: type mismatch;
```

Initial PR was against 0.13.13 branch https://github.com/sbt/sbt/pull/2785, but after discussion was moved here.
