### PR TITLE
Move NoopClassFileManager out of test for other non-javac use cases

### DIFF
--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/NoopClassFileManager.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/NoopClassFileManager.scala
@@ -1,0 +1,14 @@
+package sbt.internal.inc
+
+import java.io.File
+
+import xsbti.compile.ClassFileManager
+
+/**
+ * A noop ClassFileManager that applies to non-javac tools.
+ */
+class NoopClassFileManager extends ClassFileManager {
+  override def delete(classes: Array[File]): Unit = ()
+  override def generated(classes: Array[File]): Unit = ()
+  override def complete(success: Boolean): Unit = ()
+}

--- a/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/TestClassFileManager.scala
+++ b/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/TestClassFileManager.scala
@@ -2,29 +2,17 @@ package sbt.internal.inc
 
 import java.io.File
 
-import xsbti.compile.ClassFileManager
-
 import scala.collection.mutable
 
 /**
  * Collection of `ClassFileManager`s used for testing purposes.
  */
-class NoopClassFileManager extends ClassFileManager {
-  override def delete(classes: Array[File]): Unit = ()
-  override def generated(classes: Array[File]): Unit = ()
-  override def complete(success: Boolean): Unit = ()
-}
-
 class CollectingClassFileManager extends NoopClassFileManager {
   /** Collect generated classes, with public access to allow inspection. */
   val generatedClasses = new mutable.HashSet[File]
-
-  override def delete(classes: Array[File]): Unit = ()
 
   override def generated(classes: Array[File]): Unit = {
     generatedClasses ++= classes
     ()
   }
-
-  override def complete(success: Boolean): Unit = ()
 }

--- a/zinc-compile/src/main/scala/sbt/inc/Doc.scala
+++ b/zinc-compile/src/main/scala/sbt/inc/Doc.scala
@@ -3,6 +3,7 @@ package inc
 
 import java.io.{ File, PrintWriter }
 
+import sbt.internal.inc.NoopClassFileManager
 import sbt.io.syntax._
 import sbt.io.IO
 import sbt.util.Logger
@@ -39,7 +40,7 @@ object Doc {
         if (sources.isEmpty) log.info("No sources available, skipping " + description + "...")
         else {
           log.info(description.capitalize + " to " + outputDirectory.absolutePath + "...")
-          doDoc.run(sources, classpath, outputDirectory, options, null, log, reporter)
+          doDoc.run(sources, classpath, outputDirectory, options, new NoopClassFileManager(), log, reporter)
           log.info(description.capitalize + " successful.")
         }
     }
@@ -54,7 +55,7 @@ object Doc {
               if (inChanged || outChanged) {
                 IO.delete(outputDirectory)
                 IO.createDirectory(outputDirectory)
-                doDoc.run(sources, classpath, outputDirectory, options, null, log, reporter)
+                doDoc.run(sources, classpath, outputDirectory, options, new NoopClassFileManager(), log, reporter)
               } else log.debug("Doc uptodate: " + outputDirectory.getAbsolutePath)
             }
           }


### PR DESCRIPTION
This should fix https://ci.twitter.biz/job/pants-performance-compile-gizmoduck-server-tests/2843/consoleFull

> a48811eb72c45ef97990036ebe345065994d0919/main/src/main/scala/sbt/Defaults.scala:856: not enough arguments for method run: (sources: List[java.io.File], classpath: List[java.io.File], outputDirectory: java.io.File, options: List[String], classFileManager: xsbti.compile.ClassFileManager, log: sbt.util.Logger, reporter: xsbti.Reporter)Unit.
> [sbt] [error] Unspecified value parameter reporter.
> [sbt] [error]           javadoc.run(srcs.toList, cp, out, javacOptions.value.toList, s.log, reporter)

Test:
- https://travis-ci.org/peiyuwang/zinc/builds/169135437 is green
- Also locally tested sbt by running `sbt test`, previously broken with above error
