### PR TITLE
Fix the performance of extract used name

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/ExtractUsedNames.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ExtractUsedNames.scala
@@ -87,6 +87,7 @@ class ExtractUsedNames[GlobalType <: CallbackGlobal](val global: GlobalType) ext
      *     https://github.com/sbt/sbt/issues/1544
      */
     private val inspectedOriginalTrees = collection.mutable.Set.empty[Tree]
+    private val inspectedTypeTrees = collection.mutable.Set.empty[Tree]
 
     override def traverse(tree: Tree): Unit = tree match {
       case MacroExpansionOf(original) if inspectedOriginalTrees.add(original) =>
@@ -138,7 +139,9 @@ class ExtractUsedNames[GlobalType <: CallbackGlobal](val global: GlobalType) ext
       // to types but that might be a bad thing because it might expand aliases eagerly which
       // not what we need
       case t: TypeTree if t.original != null =>
-        t.original.foreach(traverse)
+        if (inspectedTypeTrees.add(t.original)) {
+          t.original.foreach(traverse)
+        }
       case t if t.hasSymbolField =>
         addSymbol(t.symbol)
         if (t.tpe != null)

--- a/internal/compiler-bridge/src/test/resources/ExtractUsedNamesPerformance.scala.source
+++ b/internal/compiler-bridge/src/test/resources/ExtractUsedNamesPerformance.scala.source
@@ -1,0 +1,177 @@
+package acme
+
+/**
+ * File took pattern from shapeless hlist.scala and tupler.scala just
+ * for performance test
+ */
+
+sealed trait HList extends Product with Serializable
+
+final case class ::[+H, +T <: HList](head: H, tail: T) extends HList {
+  override def toString = head match {
+    case _: ::[_, _] => "(" + head + ") :: " + tail.toString
+    case _ => head + " :: " + tail.toString
+  }
+}
+
+sealed trait HNil extends HList {
+  def ::[H](h: H) = acme.::(h, this)
+  override def toString = "HNil"
+}
+
+case object HNil extends HNil
+
+trait DepFn1[T] {
+  type Out
+  def apply(t: T): Out
+}
+
+trait Tupler[L <: HList] extends DepFn1[L] with Serializable
+
+object Tupler extends TuplerInstances {
+  def apply[L <: HList](implicit tupler: Tupler[L]): Aux[L, tupler.Out] = tupler
+
+  implicit val hnilTupler: Aux[HNil, Unit] =
+    new Tupler[HNil] {
+      type Out = Unit
+      def apply(l: HNil): Out = ()
+    }
+}
+
+import Tupler._
+
+trait TuplerInstances {
+  type Aux[L <: HList, Out0] = Tupler[L] { type Out = Out0 }
+
+  implicit def hlistTupler1[A]: Aux[A :: HNil, Tuple1[A]] =
+    new Tupler[A :: HNil] {
+      type Out = Tuple1[A]
+      def apply(l: A :: HNil): Out = l match { case a :: HNil => Tuple1(a) }
+    }
+
+  implicit def hlistTupler2[A, B]: Aux[A :: B :: HNil, (A, B)] =
+    new Tupler[A :: B :: HNil] {
+      type Out = (A, B)
+      def apply(l: A :: B :: HNil): Out = l match { case a :: b :: HNil => (a, b) }
+    }
+
+  implicit def hlistTupler3[A, B, C]: Aux[A :: B :: C :: HNil, (A, B, C)] =
+    new Tupler[A :: B :: C :: HNil] {
+      type Out = (A, B, C)
+      def apply(l: A :: B :: C :: HNil): Out = l match { case a :: b :: c :: HNil => (a, b, c) }
+    }
+
+  implicit def hlistTupler4[A, B, C, D]: Aux[A :: B :: C :: D :: HNil, (A, B, C, D)] =
+    new Tupler[A :: B :: C :: D :: HNil] {
+      type Out = (A, B, C, D)
+      def apply(l: A :: B :: C :: D :: HNil): Out = l match { case a :: b :: c :: d :: HNil => (a, b, c, d) }
+    }
+
+  implicit def hlistTupler5[A, B, C, D, E]: Aux[A :: B :: C :: D :: E :: HNil, (A, B, C, D, E)] =
+    new Tupler[A :: B :: C :: D :: E :: HNil] {
+      type Out = (A, B, C, D, E)
+      def apply(l: A :: B :: C :: D :: E :: HNil): Out = l match { case a :: b :: c :: d :: e :: HNil => (a, b, c, d, e) }
+    }
+
+  implicit def hlistTupler6[A, B, C, D, E, F]: Aux[A :: B :: C :: D :: E :: F :: HNil, (A, B, C, D, E, F)] =
+    new Tupler[A :: B :: C :: D :: E :: F :: HNil] {
+      type Out = (A, B, C, D, E, F)
+      def apply(l: A :: B :: C :: D :: E :: F :: HNil): Out = l match { case a :: b :: c :: d :: e :: f :: HNil => (a, b, c, d, e, f) }
+    }
+
+  implicit def hlistTupler7[A, B, C, D, E, F, G]: Aux[A :: B :: C :: D :: E :: F :: G :: HNil, (A, B, C, D, E, F, G)] =
+    new Tupler[A :: B :: C :: D :: E :: F :: G :: HNil] {
+      type Out = (A, B, C, D, E, F, G)
+      def apply(l: A :: B :: C :: D :: E :: F :: G :: HNil): Out = l match { case a :: b :: c :: d :: e :: f :: g :: HNil => (a, b, c, d, e, f, g) }
+    }
+
+  implicit def hlistTupler8[A, B, C, D, E, F, G, H]: Aux[A :: B :: C :: D :: E :: F :: G :: H :: HNil, (A, B, C, D, E, F, G, H)] =
+    new Tupler[A :: B :: C :: D :: E :: F :: G :: H :: HNil] {
+      type Out = (A, B, C, D, E, F, G, H)
+      def apply(l: A :: B :: C :: D :: E :: F :: G :: H :: HNil): Out = l match { case a :: b :: c :: d :: e :: f :: g :: h :: HNil => (a, b, c, d, e, f, g, h) }
+    }
+
+  implicit def hlistTupler9[A, B, C, D, E, F, G, H, I]: Aux[A :: B :: C :: D :: E :: F :: G :: H :: I :: HNil, (A, B, C, D, E, F, G, H, I)] =
+    new Tupler[A :: B :: C :: D :: E :: F :: G :: H :: I :: HNil] {
+      type Out = (A, B, C, D, E, F, G, H, I)
+      def apply(l: A :: B :: C :: D :: E :: F :: G :: H :: I :: HNil): Out = l match { case a :: b :: c :: d :: e :: f :: g :: h :: i :: HNil => (a, b, c, d, e, f, g, h, i) }
+    }
+
+  implicit def hlistTupler10[A, B, C, D, E, F, G, H, I, J]: Aux[A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: HNil, (A, B, C, D, E, F, G, H, I, J)] =
+    new Tupler[A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: HNil] {
+      type Out = (A, B, C, D, E, F, G, H, I, J)
+      def apply(l: A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: HNil): Out = l match { case a :: b :: c :: d :: e :: f :: g :: h :: i :: j :: HNil => (a, b, c, d, e, f, g, h, i, j) }
+    }
+
+  implicit def hlistTupler11[A, B, C, D, E, F, G, H, I, J, K]: Aux[A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: HNil, (A, B, C, D, E, F, G, H, I, J, K)] =
+    new Tupler[A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: HNil] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K)
+      def apply(l: A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: HNil): Out = l match { case a :: b :: c :: d :: e :: f :: g :: h :: i :: j :: k :: HNil => (a, b, c, d, e, f, g, h, i, j, k) }
+    }
+
+  implicit def hlistTupler12[A, B, C, D, E, F, G, H, I, J, K, L]: Aux[A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: HNil, (A, B, C, D, E, F, G, H, I, J, K, L)] =
+    new Tupler[A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: HNil] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L)
+      def apply(l: A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: HNil): Out = l match { case a :: b :: c :: d :: e :: f :: g :: h :: i :: j :: k :: l :: HNil => (a, b, c, d, e, f, g, h, i, j, k, l) }
+    }
+
+  implicit def hlistTupler13[A, B, C, D, E, F, G, H, I, J, K, L, M]: Aux[A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: HNil, (A, B, C, D, E, F, G, H, I, J, K, L, M)] =
+    new Tupler[A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: HNil] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M)
+      def apply(l: A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: HNil): Out = l match { case a :: b :: c :: d :: e :: f :: g :: h :: i :: j :: k :: l :: m :: HNil => (a, b, c, d, e, f, g, h, i, j, k, l, m) }
+    }
+
+  implicit def hlistTupler14[A, B, C, D, E, F, G, H, I, J, K, L, M, N]: Aux[A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: HNil, (A, B, C, D, E, F, G, H, I, J, K, L, M, N)] =
+    new Tupler[A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: HNil] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N)
+      def apply(l: A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: HNil): Out = l match { case a :: b :: c :: d :: e :: f :: g :: h :: i :: j :: k :: l :: m :: n :: HNil => (a, b, c, d, e, f, g, h, i, j, k, l, m, n) }
+    }
+
+  implicit def hlistTupler15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]: Aux[A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: HNil, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)] =
+    new Tupler[A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: HNil] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)
+      def apply(l: A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: HNil): Out = l match { case a :: b :: c :: d :: e :: f :: g :: h :: i :: j :: k :: l :: m :: n :: o :: HNil => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) }
+    }
+
+  implicit def hlistTupler16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P]: Aux[A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: P :: HNil, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)] =
+    new Tupler[A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: P :: HNil] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)
+      def apply(l: A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: P :: HNil): Out = l match { case a :: b :: c :: d :: e :: f :: g :: h :: i :: j :: k :: l :: m :: n :: o :: p :: HNil => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) }
+    }
+
+  implicit def hlistTupler17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q]: Aux[A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: P :: Q :: HNil, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)] =
+    new Tupler[A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: P :: Q :: HNil] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)
+      def apply(l: A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: P :: Q :: HNil): Out = l match { case a :: b :: c :: d :: e :: f :: g :: h :: i :: j :: k :: l :: m :: n :: o :: p :: q :: HNil => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q) }
+    }
+
+  implicit def hlistTupler18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R]: Aux[A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: P :: Q :: R :: HNil, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)] =
+    new Tupler[A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: P :: Q :: R :: HNil] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)
+      def apply(l: A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: P :: Q :: R :: HNil): Out = l match { case a :: b :: c :: d :: e :: f :: g :: h :: i :: j :: k :: l :: m :: n :: o :: p :: q :: r :: HNil => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r) }
+    }
+
+  implicit def hlistTupler19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S]: Aux[A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: P :: Q :: R :: S :: HNil, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)] =
+    new Tupler[A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: P :: Q :: R :: S :: HNil] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)
+      def apply(l: A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: P :: Q :: R :: S :: HNil): Out = l match { case a :: b :: c :: d :: e :: f :: g :: h :: i :: j :: k :: l :: m :: n :: o :: p :: q :: r :: s :: HNil => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s) }
+    }
+
+  implicit def hlistTupler20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T]: Aux[A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: P :: Q :: R :: S :: T :: HNil, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)] =
+    new Tupler[A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: P :: Q :: R :: S :: T :: HNil] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)
+      def apply(l: A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: P :: Q :: R :: S :: T :: HNil): Out = l match { case a :: b :: c :: d :: e :: f :: g :: h :: i :: j :: k :: l :: m :: n :: o :: p :: q :: r :: s :: t :: HNil => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t) }
+    }
+
+  implicit def hlistTupler21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U]: Aux[A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: P :: Q :: R :: S :: T :: U :: HNil, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)] =
+    new Tupler[A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: P :: Q :: R :: S :: T :: U :: HNil] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)
+      def apply(l: A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: P :: Q :: R :: S :: T :: U :: HNil): Out = l match { case a :: b :: c :: d :: e :: f :: g :: h :: i :: j :: k :: l :: m :: n :: o :: p :: q :: r :: s :: t :: u :: HNil => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u) }
+    }
+
+  implicit def hlistTupler22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V]: Aux[A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: P :: Q :: R :: S :: T :: U :: V :: HNil, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)] =
+    new Tupler[A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: P :: Q :: R :: S :: T :: U :: V :: HNil] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)
+      def apply(l: A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: P :: Q :: R :: S :: T :: U :: V :: HNil): Out = l match { case a :: b :: c :: d :: e :: f :: g :: h :: i :: j :: k :: l :: m :: n :: o :: p :: q :: r :: s :: t :: u :: v :: HNil => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v) }
+    }
+}

--- a/internal/compiler-bridge/src/test/scala/xsbt/ExtractUsedNamesPerformanceSpecification.scala
+++ b/internal/compiler-bridge/src/test/scala/xsbt/ExtractUsedNamesPerformanceSpecification.scala
@@ -1,0 +1,101 @@
+package xsbt
+
+import java.net.URI
+import java.nio.file.FileSystem
+import java.nio.file.FileSystemNotFoundException
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Paths
+
+import sbt.internal.util.UnitSpec
+
+class ExtractUsedNamesPerformanceSpecification extends UnitSpec {
+  private def initFileSystem(uri: URI): Option[FileSystem] = {
+    try
+      Option(FileSystems.getFileSystem(uri))
+    catch {
+      case _: FileSystemNotFoundException =>
+        val env = Map("create" -> "true")
+        import scala.collection.JavaConverters._
+        Option(FileSystems.newFileSystem(uri, env.asJava))
+      case _: IllegalArgumentException =>
+        Option(FileSystems.getDefault)
+    }
+  }
+
+  val TestResource = "/ExtractUsedNamesPerformance.scala.source"
+
+  it should "be executed in reasonable time" in {
+    var zipfs: Option[FileSystem] = None
+    val src = try {
+      val fileUri = getClass.getResource(TestResource).toURI
+      zipfs = initFileSystem(fileUri)
+      new String(Files.readAllBytes(Paths.get(fileUri)))
+    } finally
+      zipfs.foreach { fs => try fs.close catch { case _: Throwable => /*ignore*/ } }
+    import org.scalatest.concurrent.Timeouts._
+    import org.scalatest.time.SpanSugar._
+    val usedNames = failAfter(30 seconds) {
+      val compilerForTesting = new ScalaCompilerForUnitTesting(nameHashing = true)
+      compilerForTesting.extractUsedNamesFromSrc(src)
+    }
+    val expectedNamesForTupler = Set("<init>", "Object", "scala", "tupler", "TuplerInstances", "DepFn1", "HNil", "$anon", "Out", "Tupler", "hnilTupler", "acme", "L", "Aux", "HList", "Serializable", "Unit")
+    val expectedNamesForTuplerInstances = Set("E", "Tuple4", "e", "case7", "Tuple15", "s", "case19", "T7", "x", "TuplerInstances", "matchEnd19", "T20", "Tuple11", "HNil", "matchEnd6", "p16", "$anon", "T19", "p20", "T2", "p10", "case22", "p19", "n", "Tuple12", "case11", "Tuple22", "p12", "matchEnd7", "N", "p4", "T13", "case26", "Tuple19", "p7", "p5", "j", "Out", "T", "p23", "case15", "matchEnd20", "t", "p21", "matchEnd15", "J", "head", "case13", "u", "matchEnd18", "U", "Tupler", "f", "T8", "T16", "F", "Tuple3", "case8", "case18", "case24", "Boolean", "matchEnd21", "A", "matchEnd26", "a", "Tuple14", "T1", "::", "Nothing", "p18", "case20", "m", "matchEnd10", "M", "matchEnd25", "tail", "Tuple2", "matchEnd5", "p15", "matchEnd23", "I", "i", "matchEnd14", "AnyRef", "Tuple8", "matchEnd8", "case25", "T12", "p3", "case14", "case23", "T5", "matchEnd22", "T17", "v", "p22", "Tuple18", "G", "Tuple13", "matchEnd12", "<init>", "V", "q", "p11", "Q", "case12", "L", "b", "apply", "Object", "g", "B", "l", "==", "Out0", "Tuple1", "matchEnd9", "P", "p2", "T15", "Aux", "matchEnd24", "p", "scala", "matchEnd11", "Tuple20", "HList", "case17", "T9", "p14", "Tuple7", "matchEnd17", "T4", "case28", "T22", "p17", "C", "Tuple6", "MatchError", "T11", "x1", "H", "case16", "matchEnd13", "c", "Tuple9", "h", "T6", "T18", "r", "K", "Tuple17", "p9", "R", "ne", "T14", "case21", "k", "case10", "Tuple21", "O", "case9", "Tuple10", "Any", "T10", "case27", "Tuple5", "D", "p13", "o", "p6", "p8", "matchEnd16", "S", "T21", "Tuple16", "d", "T3")
+    val expectedNamesForRefinement = Set("Out0")
+    val `expectedNamesFor::` = Set("x", "package", "T2", "ScalaRunTime", "T", "Iterator", "head", "asInstanceOf", "Boolean", "A", "$" + "isInstanceOf", "T1", "||", "::", "Nothing", "x$1", "any2stringadd", "acme", "typedProductIterator", "tail", "Tuple2", "AnyRef", "isInstanceOf", "Int", "<init>", "_hashCode", "apply", "Object", "x$0", "==", "Some", "IndexOutOfBoundsException", "T0", "Predef", "scala", "matchEnd4", "HList", "None", "x1", "toString", "H", "+", "&&", "Serializable", "Product", "case6", "::$1", "eq", "Any", "runtime", "String")
+    val expectedNamesForDepFn1 = Set("DepFn1", "Out", "T", "AnyRef", "scala")
+    val expectedNamesForHNil = Set("x", "package", "HNil", "ScalaRunTime", "T", "Iterator", "Boolean", "$" + "isInstanceOf", "::", "Nothing", "x$1", "acme", "typedProductIterator", "Int", "<init>", "apply", "Object", "IndexOutOfBoundsException", "scala", "HList", "toString", "H", "Serializable", "h", "Product", "Any", "runtime", "matchEnd3", "String")
+    val expectedNamesForHList = Set("Tupler", "acme", "scala", "Serializable", "Product")
+    assert(usedNames("acme.Tupler") === expectedNamesForTupler)
+    assert(usedNames("acme.TuplerInstances") === expectedNamesForTuplerInstances)
+    assert(usedNames("acme.TuplerInstances.<refinement>") === expectedNamesForRefinement)
+    assert(usedNames("acme.$colon$colon") === `expectedNamesFor::`)
+    assert(usedNames("acme.DepFn1") === expectedNamesForDepFn1)
+    assert(usedNames("acme.HNil") === expectedNamesForHNil)
+    assert(usedNames("acme.HList") === expectedNamesForHList)
+  }
+
+  it should "correctly find Out0 (not stored in inspected trees) both in TuplerInstances and TuplerInstances.<refinement>" in {
+    val src = """|sealed trait HList extends Product with Serializable
+                 |trait DepFn1[T] {
+                 |  type Out
+                 |  def apply(t: T): Out
+                 |}
+                 |trait Tupler[L <: HList] extends DepFn1[L] with Serializable
+                 |trait TuplerInstances {
+                 |  type Aux[L <: HList, Out0] = Tupler[L] { type Out = Out0 }
+                 |}""".stripMargin
+    val compilerForTesting = new ScalaCompilerForUnitTesting(nameHashing = true)
+    val usedNames = compilerForTesting.extractUsedNamesFromSrc(src)
+    val expectedNamesForTuplerInstances = Set("Tupler", "AnyRef", "L", "Out0", "scala", "HList")
+    val expectedNamesForTuplerInstancesRefinement = Set("Out0")
+    assert(usedNames("TuplerInstances") === expectedNamesForTuplerInstances)
+    assert(usedNames("TuplerInstances.<refinement>") === expectedNamesForTuplerInstancesRefinement)
+  }
+
+  it should "correctly collect used names from macro extension" in {
+    val ext = """|package acme
+                 |import scala.reflect.macros.blackbox.Context
+                 |
+                 |object Foo {
+                 |  def foo_impl[A](c: Context)(implicit atag: c.WeakTypeTag[A]): c.Expr[List[A]] = {
+                 |    import c.universe._
+                 |    reify { List.empty[A] }
+                 |  }
+                 |}""".stripMargin
+    val cod = """|package acme
+                 |import scala.language.experimental.macros
+                 |
+                 |class Bar {
+                 |  def bar[Out] = macro Foo.foo_impl[Out]
+                 |}""".stripMargin
+    val compilerForTesting = new ScalaCompilerForUnitTesting(nameHashing = true)
+    val (_, analysis) = compilerForTesting.compileSrcs(List(List(ext), List(cod)), true)
+    val usedNames = analysis.usedNames.toMap
+
+    val expectedNamesForFoo = Set("TypeApplyExtractor", "mkIdent", "package", "<repeated>", "tpe", "in", "$u", "internal", "reify", "WeakTypeTag", "Name", "empty", "collection", "ThisType", "staticModule", "staticPackage", "Singleton", "T", "asInstanceOf", "ReificationSupportApi", "U", "Expr", "Universe", "TypeApply", "A", "Tree", "Nothing", "acme", "ClassSymbol", "blackbox", "AnyRef", "Context", "mkTypeTree", "immutable", "SelectExtractor", "<init>", "$treecreator1", "apply", "Object", "macros", "moduleClass", "Foo", "T0", "Symbol", "Predef", "scala", "asModule", "Internal", "$m", "TypeCreator", "TermNameExtractor", "ModuleSymbol", "staticClass", "universe", "c", "<refinement>", "TypeTree", "List", "Select", "TermName", "Mirror", "atag", "reificationSupport", "rootMirror", "reflect", "TypeRef", "Ident", "Any", "TreeCreator", "$typecreator2", "$m$untyped", "String", "Type")
+    val expectedNamesForBar = Set("experimental", "package", "WeakTypeTag", "Out", "foo_impl", "Expr", "A", "Nothing", "acme", "AnyRef", "Context", "<init>", "language", "Object", "macros", "Bar", "Foo", "scala", "List", "Any")
+    assert(usedNames("acme.Foo") === expectedNamesForFoo)
+    assert(usedNames("acme.Bar") === expectedNamesForBar)
+  }
+}

--- a/internal/compiler-bridge/src/test/scala/xsbt/ScalaCompilerForUnitTesting.scala
+++ b/internal/compiler-bridge/src/test/scala/xsbt/ScalaCompilerForUnitTesting.scala
@@ -106,7 +106,7 @@ class ScalaCompilerForUnitTesting(nameHashing: Boolean = true) {
    * The sequence of temporary files corresponding to passed snippets and analysis
    * callback is returned as a result.
    */
-  private def compileSrcs(
+  private[xsbt] def compileSrcs(
     groupedSrcs: List[List[String]],
     reuseCompilerInstance: Boolean
   ): (Seq[File], TestCallback) = {


### PR DESCRIPTION
This is a replacement of https://github.com/sbt/zinc/pull/187

I kept the tests written by @wpopielarski, but significantly simplified the fix implementation.

```diff
-        t.original.foreach(traverse)
+        if (inspectedTypeTrees.add(t.original)) {
+          t.original.foreach(traverse)
+        }
```
