### PR TITLE
Log at info level when compilation completes

### DIFF
--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -62,6 +62,8 @@ final class MixedAnalyzingCompiler(
       }
     // TODO - Maybe on "Mixed" we should try to compile both Scala + Java.
     if (order == JavaThenScala) { compileJava(); compileScala() } else { compileScala(); compileJava() }
+    if (javaSrcs.size + scalaSrcs.size > 0)
+      log.info("Done compiling.")
   }
 
   private[this] def outputDirectories(output: Output): Seq[File] = output match {


### PR DESCRIPTION
So this is not the most exciting PR ever, but...

Currently zinc outputs a log before it starts compilation:

```
[info] Compiling 1 Scala source to /Users/chris/tmp/foo/target/scala-2.11/test-classes...
```

but it doesn't log anything (except for timing logs at debug level) when compilation completes. As we all know, compiling Scala code is a potentially long-running operation, so I think it's worth logging on completion.

Up for debate: should this log be skipped if the compiler returned errors? I don't really have a strong opinion either way.

## Background

I was bitten by the lack of this log recently when I tried to run a buggy test containing an infinite loop. sbt printed output like this and then hung:

```
> test
[info] Updating {file:/Users/chris/tmp/sbt-example/}sbt-example...
[info] Resolving jline#jline;2.12.1 ...
[info] Done updating.
[info] Compiling 1 Scala source to /Users/chris/tmp/foo/target/scala-2.11/test-classes...
```

The project was quite implicit-heavy, so my first thought was that the compiler was chasing a diverging implicit or something like that. In actual fact, the compilation had successfully completed and the tests had started running.