### PR TITLE
Faster zinc

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/API.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/API.scala
@@ -39,12 +39,12 @@ final class API(val global: CallbackGlobal) {
       if (global.callback.nameHashing) {
         val extractUsedNames = new ExtractUsedNames[global.type](global)
         val allUsedNames = extractUsedNames.extract(unit)
-        def showUsedNames(className: String, names: Set[String]): String =
+        def showUsedNames(className: String, names: Iterable[String]): String =
           s"$className:\n\t${names.mkString(", ")}"
         debuglog("The " + sourceFile + " contains the following used names:\n" +
           allUsedNames.map((showUsedNames _).tupled).mkString("\n"))
         allUsedNames foreach {
-          case (className: String, names: Set[String]) =>
+          case (className: String, names: Iterable[String]) =>
             names foreach { (name: String) => callback.usedName(className, name) }
         }
       }

--- a/internal/compiler-bridge/src/main/scala/xsbt/API.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/API.scala
@@ -21,7 +21,8 @@ final class API(val global: CallbackGlobal) {
     override def run(): Unit =
       {
         val start = System.currentTimeMillis
-        super.run
+        super.run()
+        callback.apiPhaseCompleted()
         val stop = System.currentTimeMillis
         debuglog("API phase took : " + ((stop - start) / 1000.0) + " s")
       }

--- a/internal/compiler-bridge/src/main/scala/xsbt/GlobalHelpers.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/GlobalHelpers.scala
@@ -15,6 +15,29 @@ trait GlobalHelpers {
     typeSymbolCollector.collect(tp).toSet
   }
 
+  def foreachSymbolInType(tpe: Type)(op: Symbol => Unit): Unit = {
+    new ForEachTypeTraverser(_ match {
+      case null =>
+      case tpe =>
+        val sym = tpe.typeSymbolDirect
+        if (!sym.hasPackageFlag) op(sym)
+    }).traverse(tpe)
+  }
+
+  /** Returns true if given tree contains macro attchment. In such case calls func on tree from attachment. */
+  def processMacroExpansion(in: Tree)(func: Tree => Unit): Boolean = {
+    // Hotspot
+    var seen = false
+    in.attachments.all.foreach {
+      case _ if seen =>
+      case macroAttachment: analyzer.MacroExpansionAttachment =>
+        func(macroAttachment.expandee)
+        seen = true
+      case _ =>
+    }
+    seen
+  }
+
   object MacroExpansionOf {
     def unapply(tree: Tree): Option[Tree] = {
       tree.attachments.all.collect {

--- a/internal/compiler-bridge/src/main/scala/xsbt/LocateClassFile.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/LocateClassFile.scala
@@ -3,6 +3,7 @@
  */
 package xsbt
 
+import scala.reflect.io.NoAbstractFile
 import scala.tools.nsc.symtab.Flags
 import scala.tools.nsc.io.AbstractFile
 
@@ -16,13 +17,13 @@ abstract class LocateClassFile extends ClassName {
   import global._
 
   private[this] final val classSeparator = '.'
-  protected def classFile(sym: Symbol): Option[(AbstractFile, String, Boolean)] =
+  protected def classFile(sym: Symbol): Option[(AbstractFile, String)] =
     // package can never have a corresponding class file; this test does not
     // catch package objects (that do not have this flag set)
     if (sym hasFlag scala.tools.nsc.symtab.Flags.PACKAGE) None else {
-      import scala.tools.nsc.symtab.Flags
-      val binaryClassName = flatname(sym, classSeparator) + sym.moduleSuffix
-      findClass(binaryClassName).map { case (file, inOut) => (file, binaryClassName, inOut) } orElse {
+      val file = sym.associatedFile
+
+      if (file == NoAbstractFile) {
         if (isTopLevelModule(sym)) {
           val linked = sym.companionClass
           if (linked == NoSymbol)
@@ -31,6 +32,8 @@ abstract class LocateClassFile extends ClassName {
             classFile(linked)
         } else
           None
+      } else {
+        Some((file, flatname(sym, classSeparator) + sym.moduleSuffix))
       }
     }
 

--- a/internal/compiler-interface/src/main/java/xsbti/AnalysisCallback.java
+++ b/internal/compiler-interface/src/main/java/xsbti/AnalysisCallback.java
@@ -47,4 +47,10 @@ public interface AnalysisCallback {
      *       Do not depend on it, please.
      */
     boolean nameHashing();
+
+    /** Called at the end of dependency phase. Can be used e.g. to wait on asynchronous tasks. */
+    void dependencyPhaseCompleted();
+
+    /** Called at the end of dependency phase. Can be used e.g. to wait on asynchronous tasks. */
+    void apiPhaseCompleted();
 }

--- a/internal/compiler-interface/src/test/scala/xsbti/TestCallback.scala
+++ b/internal/compiler-interface/src/test/scala/xsbti/TestCallback.scala
@@ -45,6 +45,10 @@ class TestCallback(override val nameHashing: Boolean = false) extends AnalysisCa
     ()
   }
   def problem(category: String, pos: xsbti.Position, message: String, severity: xsbti.Severity, reported: Boolean): Unit = ()
+
+  override def dependencyPhaseCompleted(): Unit = {}
+
+  override def apiPhaseCompleted(): Unit = {}
 }
 
 object TestCallback {

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Analyze.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Analyze.scala
@@ -27,7 +27,7 @@ private[sbt] object Analyze {
       try { Some(Class.forName(tpe, false, loader)) }
       catch { case e: Throwable => errMsg.foreach(msg => log.warn(msg + " : " + e.toString)); None }
 
-    val productToClassName = mutable.Set.empty[String]
+    val classNames = mutable.Set.empty[String]
     val sourceToClassFiles = mutable.HashMap[File, Buffer[ClassFile]](
       sources zip Seq.fill(sources.size)(new ArrayBuffer[ClassFile]): _*
     )
@@ -53,7 +53,7 @@ private[sbt] object Analyze {
       srcClassName match {
         case Some(srcClassName) =>
           analysis.generatedNonLocalClass(source, newClass, binaryClassName, srcClassName)
-          productToClassName += srcClassName
+          classNames += srcClassName
         case None => analysis.generatedLocalClass(source, newClass)
       }
 
@@ -93,7 +93,7 @@ private[sbt] object Analyze {
         trapAndLog(log) {
           val scalaLikeTypeName = onBinaryName.replace('$', '.')
 
-          if (productToClassName.contains(scalaLikeTypeName))
+          if (classNames.contains(scalaLikeTypeName))
             analysis.classDependency(scalaLikeTypeName, fromClassName, context)
           else
             for (file <- classfilesCache.get(onBinaryName).orElse(loadFromClassloader()))

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Compile.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Compile.scala
@@ -304,4 +304,8 @@ private final class AnalysisCallback(
 
         a.addSource(src, analyzedApis, stamp, info, nonLocalProds, localProds, internalDeps, externalDeps, binDeps)
     }
+
+  override def dependencyPhaseCompleted(): Unit = {}
+
+  override def apiPhaseCompleted(): Unit = {}
 }

--- a/internal/zinc-core/src/test/scala/sbt/inc/TestAnalysisCallback.scala
+++ b/internal/zinc-core/src/test/scala/sbt/inc/TestAnalysisCallback.scala
@@ -176,4 +176,8 @@ class TestAnalysisCallback(
   }
 
   def problem(category: String, pos: xsbti.Position, message: String, severity: xsbti.Severity, reported: Boolean): Unit = ()
+
+  override def dependencyPhaseCompleted(): Unit = {}
+
+  override def apiPhaseCompleted(): Unit = {}
 }


### PR DESCRIPTION
Changes in this PR makes zinc-based compilation comparable intellij-based incremental compilation. 

For single project overhead in compilation (measured as sbt-related phases time in scalc) was reduced from over 10-15% (with bug reported by @wpopielarski even above 30%) to around 5%.

We also reduce significantly overhead in analyzing java compilation (Intellij it is still  faster since it uses faster java compiler).

Overall with some changes to build infra with this changes I get similar performance that Intellij can offer for full build.

More detailed information are placed in commit messages.

Changes are done only to 2.11 sources but can be backported later to 2.10 ones.

For certain reasons this time I have to paste the below disclaimer:
THIS PROGRAM IS SUBJECT TO THE TERMS OF THE BSD 3-CLAUSE LICENSE.

THE FOLLOWING DISCLAIMER APPLIES TO ALL SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE:
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR
ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
ONLY THE SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE, IF ANY, THAT ARE ATTACHED TO (OR OTHERWISE ACCOMPANY) THIS SUBMISSION (AND ORDINARY
COURSE CONTRIBUTIONS OF FUTURES PATCHES THERETO) ARE TO BE CONSIDERED A CONTRIBUTION. NO OTHER SOFTWARE CODE OR MATERIALS ARE A CONTRIBUTION.