### PR TITLE
Fix library dependency modification detection

### DIFF
--- a/internal/compiler-interface/src/main/contraband/incremental.json
+++ b/internal/compiler-interface/src/main/contraband/incremental.json
@@ -203,6 +203,16 @@
       ]
     },
     {
+      "name": "FileHash",
+      "namespace": "xsbti.compile",
+      "target": "Java",
+      "type": "record",
+      "fields": [
+        { "name": "file", "type": "java.io.File" },
+        { "name": "hash", "type": "int"    }
+      ]
+    },
+    {
       "name": "MiniOptions",
       "namespace": "xsbti.compile",
       "target": "Java",
@@ -210,8 +220,8 @@
       "doc": "Compilation options. This is used as part of CompileSetup.",
       "fields": [
         {
-          "name": "classpath",
-          "type": "java.io.File*",
+          "name": "classpathHash",
+          "type": "FileHash*",
           "doc": [
             "The classpath to use for compilation.",
             "This will be modified according to the ClasspathOptions used to configure the ScalaCompiler."

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
@@ -367,7 +367,7 @@ private[inc] abstract class IncrementalCommon(log: sbt.util.Logger, options: Inc
             val classNames = previousRelations.libraryClassNames(file)
             classNames exists { binaryClassName =>
               // classpath has not changed since the last compilation, so use the faster detection.
-              if (lookup.changedClasspath.isEmpty)
+              if (lookup.changedClasspathHash.isEmpty)
                 lookup.lookupAnalysis(binaryClassName) match {
                   case None    => false
                   case Some(e) => inv(s"shadowing is detected for class $binaryClassName")

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Lookup.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Lookup.scala
@@ -2,7 +2,7 @@ package sbt.internal.inc
 
 import java.io.File
 
-import xsbti.compile.{ CompileAnalysis, ExternalHooks }
+import xsbti.compile.{ CompileAnalysis, ExternalHooks, FileHash }
 
 /**
  * A trait that encapsulates looking up elements on a classpath and looking up
@@ -12,7 +12,7 @@ trait Lookup extends ExternalLookup {
   /**
    * Returns the current classpath if the classpath has changed from the last compilation.
    */
-  def changedClasspath: Option[Vector[File]]
+  def changedClasspathHash: Option[Vector[FileHash]]
 
   def analyses: Vector[CompileAnalysis]
 

--- a/internal/zinc-persist/src/test/scala/sbt/inc/TextAnalysisFormatSpecification.scala
+++ b/internal/zinc-persist/src/test/scala/sbt/inc/TextAnalysisFormatSpecification.scala
@@ -28,7 +28,7 @@ object TextAnalysisFormatTest extends Properties("TextAnalysisFormat") {
                     |output directories:
                     |1 items
                     |file:/dummy -> file:/dummy
-                    |classpath options:
+                    |classpath hash:
                     |0 items
                     |compile options:
                     |0 items

--- a/zinc/src/main/scala/sbt/internal/inc/LookupImpl.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/LookupImpl.scala
@@ -4,23 +4,25 @@ import java.io.File
 
 import sbt.util.Logger._
 import xsbti.Maybe
-import xsbti.compile.{ CompileAnalysis, MiniSetup }
+import xsbti.compile.{ CompileAnalysis, MiniSetup, FileHash }
 
 class LookupImpl(compileConfiguration: CompileConfiguration, previousSetup: Option[MiniSetup]) extends Lookup {
   private val classpath: Vector[File] = compileConfiguration.classpath.toVector
+  private val classpathHash: Vector[FileHash] = compileConfiguration.currentSetup.options.classpathHash.toVector
+
   lazy val analyses: Vector[Analysis] =
     classpath flatMap { entry =>
       m2o(compileConfiguration.perClasspathEntryLookup.analysis(entry)) map
         { case a: Analysis => a }
     }
-  lazy val previousClasspath: Vector[File] =
+  lazy val previousClasspathHash: Vector[FileHash] =
     previousSetup match {
-      case Some(x) => x.options.classpath.toVector
+      case Some(x) => x.options.classpathHash.toVector
       case _       => Vector()
     }
-  def changedClasspath: Option[Vector[File]] =
-    if (classpath == previousClasspath) None
-    else Some(classpath)
+  def changedClasspathHash: Option[Vector[FileHash]] =
+    if (classpathHash == previousClasspathHash) None
+    else Some(classpathHash)
 
   private val entry = MixedAnalyzingCompiler.classPathLookup(compileConfiguration)
 

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -121,7 +121,10 @@ object MixedAnalyzingCompiler {
     extra: List[(String, String)]
   ): CompileConfiguration =
     {
-      val compileSetup = new MiniSetup(output, new MiniOptions(classpath.toArray, options.toArray, javacOptions.toArray),
+      val classpathHash = classpath map { x =>
+        new FileHash(x, Stamp.hash(x).hashCode)
+      }
+      val compileSetup = new MiniSetup(output, new MiniOptions(classpathHash.toArray, options.toArray, javacOptions.toArray),
         scalac.scalaInstance.actualVersion, compileOrder,
         incrementalCompilerOptions.nameHashing, incrementalCompilerOptions.storeApis(),
         (extra map InterfaceUtil.t2).toArray)

--- a/zinc/src/sbt-test/source-dependencies/binary/build.json
+++ b/zinc/src/sbt-test/source-dependencies/binary/build.json
@@ -1,0 +1,10 @@
+{
+  "projects": [
+    {
+      "name": "use"
+    },
+    {
+      "name": "dep"
+    }
+  ]
+}

--- a/zinc/src/sbt-test/source-dependencies/binary/changes/Break.scala
+++ b/zinc/src/sbt-test/source-dependencies/binary/changes/Break.scala
@@ -1,0 +1,1 @@
+object Break

--- a/zinc/src/sbt-test/source-dependencies/binary/dep/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/binary/dep/A.scala
@@ -1,0 +1,3 @@
+object A {
+  val x = 3
+}

--- a/zinc/src/sbt-test/source-dependencies/binary/test
+++ b/zinc/src/sbt-test/source-dependencies/binary/test
@@ -1,0 +1,12 @@
+> dep/package
+$ copy-file dep/target/dep.jar use/lib/dep.jar
+
+# done this way because last modified times often have ~1s resolution
+> use/compile
+$ sleep 2000
+
+$ copy-file changes/Break.scala dep/A.scala
+> dep/package
+$ copy-file dep/target/dep.jar use/lib/dep.jar
+
+-> use/compile

--- a/zinc/src/sbt-test/source-dependencies/binary/use/B.scala
+++ b/zinc/src/sbt-test/source-dependencies/binary/use/B.scala
@@ -1,0 +1,3 @@
+object B {
+  val y = A.x
+}


### PR DESCRIPTION
This PR is on top of https://github.com/sbt/zinc/pull/208 to reproduce and fix the regression caught by "binary" scripted test.

Fixes sbt/zinc#207

I broke the logic in sbt/zinc#180, which relies on classpath change detection. This reproduces and fixes the library modification detection by invalidating the JAR.
Previously, I was only using the file names to see if the classpath has changed, now it will use the SHA-1 of the content.