### PR TITLE
Add option to disable incremental compilation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -311,7 +311,7 @@ lazy val zincScripted = (project in internalPath / "zinc-scripted").
   configure(addSbtUtilScripted)
 
 lazy val publishBridgesAndTest = Command.args("publishBridgesAndTest", "<version>") { (state, args) =>
-  require(args.nonEmpty)
+  require(args.nonEmpty, "Missing arguments to publishBridgesAndTest. Maybe quotes are missing around command?")
   val version = args mkString ""
     s"${compilerInterface.id}/publishLocal" ::
     // using plz here causes: java.lang.OutOfMemoryError: GC overhead limit exceeded

--- a/internal/compiler-bridge/src-2.10/main/scala/xsbt/CompilerInterface.scala
+++ b/internal/compiler-bridge/src-2.10/main/scala/xsbt/CompilerInterface.scala
@@ -218,8 +218,10 @@ private final class CachedCompiler0(args: Array[String], output: Output, initial
     override lazy val phaseDescriptors =
       {
         phasesSet += sbtAnalyzer
-        phasesSet += sbtDependency
-        phasesSet += apiExtractor
+        if (callback.enabled()) {
+          phasesSet += sbtDependency
+          phasesSet += apiExtractor
+        }
         superComputePhaseDescriptors
       }
     // Required because computePhaseDescriptors is private in 2.8 (changed to protected sometime later).

--- a/internal/compiler-bridge/src/main/scala/xsbt/CompilerInterface.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CompilerInterface.scala
@@ -213,8 +213,10 @@ private final class CachedCompiler0(args: Array[String], output: Output, initial
     override lazy val phaseDescriptors =
       {
         phasesSet += sbtAnalyzer
-        phasesSet += sbtDependency
-        phasesSet += apiExtractor
+        if (callback.enabled()) {
+          phasesSet += sbtDependency
+          phasesSet += apiExtractor
+        }
         superComputePhaseDescriptors
       }
     // Required because computePhaseDescriptors is private in 2.8 (changed to protected sometime later).

--- a/internal/compiler-interface/src/main/contraband/incremental.json
+++ b/internal/compiler-interface/src/main/contraband/incremental.json
@@ -117,6 +117,13 @@
           ]
         },
         {
+          "name": "enabled",
+          "type": "boolean",
+          "doc": [
+            "Determines whether incremental compilation is enabled."
+          ]
+        },
+        {
           "name": "antStyle",
           "type": "boolean",
           "doc": [

--- a/internal/compiler-interface/src/main/java/xsbti/AnalysisCallback.java
+++ b/internal/compiler-interface/src/main/java/xsbti/AnalysisCallback.java
@@ -53,4 +53,8 @@ public interface AnalysisCallback {
 
     /** Called at the end of dependency phase. Can be used e.g. to wait on asynchronous tasks. */
     void apiPhaseCompleted();
+
+    /** Determines if incremental compilation is enabled.
+     * If returns false, only xsbt-analyzer phase will be added (in order to report generated classes) */
+    boolean enabled();
 }

--- a/internal/compiler-interface/src/main/java/xsbti/compile/IncOptionsUtil.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/IncOptionsUtil.java
@@ -84,6 +84,10 @@ public class IncOptionsUtil {
     return true;
   }
 
+  public static boolean defaultEnabled() {
+    return true;
+  }
+
   public static boolean defaultAntStyle() {
     return false;
   }
@@ -117,7 +121,7 @@ public class IncOptionsUtil {
       defaultApiDiffContextSize(), defaultApiDumpDirectory(),
       defaultClassfileManagerType(), defaultUseCustomizedFileManager(),
       defaultRecompileOnMacroDef(), defaultNameHashing(),
-      defaultStoreApis(), defaultAntStyle(),
+      defaultStoreApis(), defaultEnabled(), defaultAntStyle(),
       defaultExtra(), defaultLogRecompileOnMacro(),
       defaultExternal());
     return retval;

--- a/internal/compiler-interface/src/test/scala/xsbti/TestCallback.scala
+++ b/internal/compiler-interface/src/test/scala/xsbti/TestCallback.scala
@@ -44,6 +44,9 @@ class TestCallback(override val nameHashing: Boolean = false) extends AnalysisCa
     apis(source) += api
     ()
   }
+
+  override def enabled(): Boolean = true
+
   def problem(category: String, pos: xsbti.Position, message: String, severity: xsbti.Severity, reported: Boolean): Unit = ()
 
   override def dependencyPhaseCompleted(): Unit = {}

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Compile.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Compile.scala
@@ -237,6 +237,8 @@ private final class AnalysisCallback(
 
   def nameHashing: Boolean = options.nameHashing
 
+  override def enabled(): Boolean = options.enabled
+
   def get: Analysis =
     addUsedNames(addCompilation(addProductsAndDeps(Analysis.empty(nameHashing = nameHashing))))
 

--- a/internal/zinc-core/src/test/scala/sbt/inc/TestAnalysisCallback.scala
+++ b/internal/zinc-core/src/test/scala/sbt/inc/TestAnalysisCallback.scala
@@ -175,6 +175,8 @@ class TestAnalysisCallback(
     }
   }
 
+  override def enabled(): Boolean = true
+
   def problem(category: String, pos: xsbti.Position, message: String, severity: xsbti.Severity, reported: Boolean): Unit = ()
 
   override def dependencyPhaseCompleted(): Unit = {}


### PR DESCRIPTION
Now it is possible to disable incremental compilation metadata creation in IncOptions and directly in AnalysisCallback.

With this flag on e.g. Intellij scala plugin can migrate to new zinc (since it also uses zinc to in it's own incremental compiler but with zinc incremental compilation off)