### PR TITLE
Fix #192: Handle local dependencies for Java classes

### DIFF
--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
@@ -16,11 +16,11 @@ object ClassToAPI {
   def apply(c: Seq[Class[_]]): Seq[api.ClassLike] = process(c)._1
 
   // (api, public inherited classes)
-  def process(c: Seq[Class[_]]): (Seq[api.ClassLike], Set[(Class[_], Class[_])]) =
+  def process(classes: Seq[Class[_]]): (Seq[api.ClassLike], Set[(Class[_], Class[_])]) =
     {
-      val pkgs = packages(c).map(p => new api.Package(p))
+      val pkgs = packages(classes).map(p => new api.Package(p))
       val cmap = emptyClassMap
-      val defs = c.flatMap(toDefinitions(cmap))
+      val defs = classes.flatMap(toDefinitions(cmap))
       cmap.lz.foreach(_.get()) // force thunks to ensure all inherited dependencies are recorded
       val classApis = cmap.allNonLocalClasses.toSeq
       val inDeps = cmap.inherited.toSet

--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
@@ -20,7 +20,7 @@ object ClassToAPI {
     {
       val pkgs = packages(c).map(p => new api.Package(p))
       val cmap = emptyClassMap
-      val defs = c.filter(isTopLevel).flatMap(toDefinitions(cmap))
+      val defs = c.flatMap(toDefinitions(cmap))
       cmap.lz.foreach(_.get()) // force thunks to ensure all inherited dependencies are recorded
       val classApis = cmap.allNonLocalClasses.toSeq
       val inDeps = cmap.inherited.toSet

--- a/zinc/src/main/scala/sbt/internal/inc/javac/AnalyzingJavaCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/javac/AnalyzingJavaCompiler.scala
@@ -66,16 +66,14 @@ final class AnalyzingJavaCompiler private[sbt] (
         val classesFinder = PathFinder(outputDirectory) ** "*.class"
         (classesFinder, classesFinder.get, srcs)
       }
-      // Here we construct a class-loader we'll use to load + analyze the
+      // Construct a class-loader we'll use to load + analyze
+      // dependencies from the Javac generated class files
       val loader = ClasspathUtilities.toLoader(searchClasspath)
       // TODO - Perhaps we just record task 0/2 here
       timed("Java compilation", log) {
         val args = JavaCompiler.commandArguments(absClasspath, output, options, scalaInstance, classpathOptions)
-        val success = javac.run({
-          sources sortBy {
-            _.getAbsolutePath
-          }
-        }.toArray, args.toArray, incToolOptions, reporter, log)
+        val javaSources = sources.sortBy(_.getAbsolutePath).toArray
+        val success = javac.run(javaSources, args.toArray, incToolOptions, reporter, log)
         if (!success) {
           // TODO - Will the reporter have problems from Scalac?  It appears like it does not, only from the most recent run.
           // This is because the incremental compiler will not run javac if scalac fails.

--- a/zinc/src/sbt-test/source-dependencies/anon-class-java-depends-on-scala/JJ.java
+++ b/zinc/src/sbt-test/source-dependencies/anon-class-java-depends-on-scala/JJ.java
@@ -1,0 +1,11 @@
+public class JJ {
+	public static void main(String[] args) {
+    // Declare anonymous class depending on Scala class
+		S s = new S() {
+      public void foo(String s) {
+        System.out.println(s);
+      }
+    };
+    s.foo("ahoy");
+	}
+}

--- a/zinc/src/sbt-test/source-dependencies/anon-class-java-depends-on-scala/build.sbt
+++ b/zinc/src/sbt-test/source-dependencies/anon-class-java-depends-on-scala/build.sbt
@@ -1,0 +1,1 @@
+compileOrder := CompileOrder.Mixed

--- a/zinc/src/sbt-test/source-dependencies/anon-class-java-depends-on-scala/changes/S1.scala
+++ b/zinc/src/sbt-test/source-dependencies/anon-class-java-depends-on-scala/changes/S1.scala
@@ -1,0 +1,3 @@
+abstract class S {
+	def foo(s:String): Unit
+}

--- a/zinc/src/sbt-test/source-dependencies/anon-class-java-depends-on-scala/changes/S2.scala
+++ b/zinc/src/sbt-test/source-dependencies/anon-class-java-depends-on-scala/changes/S2.scala
@@ -1,0 +1,3 @@
+abstract class S {
+	def foo2(s:String): Unit
+}

--- a/zinc/src/sbt-test/source-dependencies/anon-class-java-depends-on-scala/test
+++ b/zinc/src/sbt-test/source-dependencies/anon-class-java-depends-on-scala/test
@@ -1,0 +1,4 @@
+$ copy-file changes/S1.scala S.scala
+> compile
+$ copy-file changes/S2.scala S.scala
+-> compile

--- a/zinc/src/sbt-test/source-dependencies/anon-java-scala-class/A.java
+++ b/zinc/src/sbt-test/source-dependencies/anon-java-scala-class/A.java
@@ -1,0 +1,3 @@
+public class A {
+  public A() {}
+}

--- a/zinc/src/sbt-test/source-dependencies/anon-java-scala-class/B.java
+++ b/zinc/src/sbt-test/source-dependencies/anon-java-scala-class/B.java
@@ -1,0 +1,3 @@
+public class B extends A {
+  public B() {}
+}

--- a/zinc/src/sbt-test/source-dependencies/anon-java-scala-class/C.scala
+++ b/zinc/src/sbt-test/source-dependencies/anon-java-scala-class/C.scala
@@ -1,0 +1,5 @@
+class C {
+  def foo: Unit = {
+    val myFoo = new B {}
+  }
+}

--- a/zinc/src/sbt-test/source-dependencies/anon-java-scala-class/D.scala
+++ b/zinc/src/sbt-test/source-dependencies/anon-java-scala-class/D.scala
@@ -1,0 +1,5 @@
+class D extends C {
+  // mention abc name to check if local inheritance dependencies are _not_ included in member reference
+  // extension of inheritance invalidation
+  def bar(abc: Int): Int = abc
+}

--- a/zinc/src/sbt-test/source-dependencies/anon-java-scala-class/changes/A2.java
+++ b/zinc/src/sbt-test/source-dependencies/anon-java-scala-class/changes/A2.java
@@ -1,0 +1,6 @@
+public class A {
+  public A() {}
+  public String hey() {
+    return "Hey";
+  }
+}

--- a/zinc/src/sbt-test/source-dependencies/anon-java-scala-class/test
+++ b/zinc/src/sbt-test/source-dependencies/anon-java-scala-class/test
@@ -1,0 +1,16 @@
+# Verifies if dependencies introduced by Java inheritance by local classes are handled correctly.
+# See sbt-test 'local-class-inheritance' for a similar test in Scala.
+
+> compile
+
+$ copy-file changes/A2.java A.java
+> compile
+# D should be compiled only at the beginning; it depends by inheritance only
+# on C and C's public interface is not affected by changes to A
+> checkRecompilations 0 D
+# A is explicitly changed
+> checkRecompilations 1 A
+# B is recompiled because it depends by inheritance on A
+# C is recompiled because it depends by local inheritance on B but its
+# dependencies (D) are not recompiled
+> checkRecompilations 2 B C

--- a/zinc/src/sbt-test/source-dependencies/inner-class-java-depends-on-scala/JJ.java
+++ b/zinc/src/sbt-test/source-dependencies/inner-class-java-depends-on-scala/JJ.java
@@ -1,0 +1,12 @@
+public class JJ {
+	public static void main(String[] args) {
+    // Declare anonymous class depending on Scala class
+    class FromScala extends S {
+      public void foo(String s) {
+        System.out.println(s);
+      }
+    }
+    S s = new FromScala();
+    s.foo("ahoy");
+	}
+}

--- a/zinc/src/sbt-test/source-dependencies/inner-class-java-depends-on-scala/build.sbt
+++ b/zinc/src/sbt-test/source-dependencies/inner-class-java-depends-on-scala/build.sbt
@@ -1,0 +1,1 @@
+compileOrder := CompileOrder.Mixed

--- a/zinc/src/sbt-test/source-dependencies/inner-class-java-depends-on-scala/changes/S1.scala
+++ b/zinc/src/sbt-test/source-dependencies/inner-class-java-depends-on-scala/changes/S1.scala
@@ -1,0 +1,3 @@
+abstract class S {
+	def foo(s:String): Unit
+}

--- a/zinc/src/sbt-test/source-dependencies/inner-class-java-depends-on-scala/changes/S2.scala
+++ b/zinc/src/sbt-test/source-dependencies/inner-class-java-depends-on-scala/changes/S2.scala
@@ -1,0 +1,3 @@
+abstract class S {
+	def foo2(s:String): Unit
+}

--- a/zinc/src/sbt-test/source-dependencies/inner-class-java-depends-on-scala/test
+++ b/zinc/src/sbt-test/source-dependencies/inner-class-java-depends-on-scala/test
@@ -1,0 +1,4 @@
+$ copy-file changes/S1.scala S.scala
+> compile
+$ copy-file changes/S2.scala S.scala
+-> compile

--- a/zinc/src/sbt-test/source-dependencies/local-class-inheritance-from-java/A.java
+++ b/zinc/src/sbt-test/source-dependencies/local-class-inheritance-from-java/A.java
@@ -1,0 +1,3 @@
+public class A {
+  public A() {}
+}

--- a/zinc/src/sbt-test/source-dependencies/local-class-inheritance-from-java/B.java
+++ b/zinc/src/sbt-test/source-dependencies/local-class-inheritance-from-java/B.java
@@ -1,0 +1,3 @@
+public class B extends A {
+  public B() {}
+}

--- a/zinc/src/sbt-test/source-dependencies/local-class-inheritance-from-java/C.scala
+++ b/zinc/src/sbt-test/source-dependencies/local-class-inheritance-from-java/C.scala
@@ -1,0 +1,5 @@
+class C {
+  def foo: Unit = {
+    class Foo extends B
+  }
+}

--- a/zinc/src/sbt-test/source-dependencies/local-class-inheritance-from-java/D.scala
+++ b/zinc/src/sbt-test/source-dependencies/local-class-inheritance-from-java/D.scala
@@ -1,0 +1,5 @@
+class D extends C {
+  // mention abc name to check if local inheritance dependencies are _not_ included in member reference
+  // extension of inheritance invalidation
+  def bar(abc: Int): Int = abc
+}

--- a/zinc/src/sbt-test/source-dependencies/local-class-inheritance-from-java/changes/A2.java
+++ b/zinc/src/sbt-test/source-dependencies/local-class-inheritance-from-java/changes/A2.java
@@ -1,0 +1,6 @@
+public class A {
+  public A() {}
+  public String hey() {
+    return "Hey";
+  }
+}

--- a/zinc/src/sbt-test/source-dependencies/local-class-inheritance-from-java/test
+++ b/zinc/src/sbt-test/source-dependencies/local-class-inheritance-from-java/test
@@ -1,0 +1,16 @@
+# Verifies if dependencies introduced by Java inheritance by local classes are handled correctly.
+# See sbt-test 'local-class-inheritance' for a similar test in Scala.
+
+> compile
+
+$ copy-file changes/A2.java A.java
+> compile
+# D should be compiled only at the beginning; it depends by inheritance only
+# on C and C's public interface is not affected by changes to A
+> checkRecompilations 0 D
+# A is explicitly changed
+> checkRecompilations 1 A
+# B is recompiled because it depends by inheritance on A
+# C is recompiled because it depends by local inheritance on B but its
+# dependencies (D) are not recompiled
+> checkRecompilations 2 B C


### PR DESCRIPTION
Aside from fixing #192, the two first commits add more tests and guard against
the occurrence of `NoType` in the traversers.

Zinc incrementally compiles both Java and Scala sources. Most of the time,
Scala sources depend on Java sources and it's important that when Java sources
are modified, Scala sources that depend on those modifications are also
compiled again. Supporting this use case is simple -- Scalac pickles
information from Java class files and turns them into symbols that can be
handled by Zinc.

The situation starts to get trickier when it's turned around. If we want our
Java sources to be recompiled when there are Scala changes, we have to detect
the dependencies at the Java level. Java sources are compiled by javac, so we
have no symbol information whatsoever we can use to detect dependencies. To
solve this problem, Zinc class-loads the generated class files by Javac and
reflectively detects any dependency at the class level. Thanks to the clas file
[constant pool](https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.4),
we can also know which classes a given class file refers to -- buying us the
analog of the name hashing algorithm implemented by @gkossakowski in Scala
sources.


Before, local class files were correctly honoured by Zinc and linked to their
original source file (remember that javac creates a new class file for every
class that is not top level). However, local classes were not analyzed by
`ClassAPI` and registered as dependencies.

These commits introduce local dependencies by inheritance from Java classes to
Scala classes. It applies a similar fix to the one provided in https://github.com/gkossakowski/sbt/commit/47416b394e3730d67367da9f011f8ef3de23b576.
In the commit messages, I dive into a more succint explanation of the fixes,
feel free to check them out.

This work is done by the [Scala Center](https://scala.epfl.ch/).