### PR TITLE
Mark compactify as a passing test

### DIFF
--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -186,6 +186,12 @@ final class IncHandler(directory: File, scriptedLog: Logger) extends BridgeProvi
         p.checkMessage(index.toInt, expected, Severity.Error)
       case (p, other, _) =>
         p.unrecognizedArguments("checkError", other)
+    },
+    "checkNoClassFiles" -> {
+      case (p, Nil, i) =>
+        p.checkNoGeneratedClassFiles()
+        ()
+      case (p, xs, _) => p.acceptsNoArguments("checkNoClassFiles", xs)
     }
   )
 
@@ -207,6 +213,7 @@ case class ProjectStructure(name: String, dependsOn: Vector[String], baseDirecto
   }
   val targetDir = baseDirectory / "target"
   val classesDir = targetDir / "classes"
+  val generatedClassFiles = classesDir ** "*.class"
   val scalaSourceDirectory = baseDirectory / "src" / "main" / "scala"
   val javaSourceDirectory = baseDirectory / "src" / "main" / "java"
   def scalaSources: List[File] =
@@ -299,6 +306,12 @@ case class ProjectStructure(name: String, dependsOn: Vector[String], baseDirecto
 
     assertClasses(expected.toSet, products(src))
     ()
+  }
+
+  def checkNoGeneratedClassFiles(): Unit = {
+    val allClassFiles = generatedClassFiles.get.mkString("\n\t")
+    if (!allClassFiles.isEmpty)
+      sys.error(s"Classes existed:\n\t$allClassFiles")
   }
 
   def checkDependencies(i: IncInstance, className: String, expected: List[String]): Unit = {

--- a/zinc/src/sbt-test/source-dependencies/compactify/build.sbt
+++ b/zinc/src/sbt-test/source-dependencies/compactify/build.sbt
@@ -1,8 +1,3 @@
-TaskKey[Unit]("output-empty") <<= classDirectory in Configurations.Compile map { outputDirectory =>
-	def classes = (outputDirectory ** "*.class").get
-	if(!classes.isEmpty) sys.error("Classes existed:\n\t" + classes.mkString("\n\t")) else ()
-}
-
 // apparently Travis CI stopped allowing long file names
 // it fails with the default setting of 255 characters so
 // we have to set lower limit ourselves

--- a/zinc/src/sbt-test/source-dependencies/compactify/pending
+++ b/zinc/src/sbt-test/source-dependencies/compactify/pending
@@ -1,8 +1,0 @@
-# Marked pending due to https://github.com/sbt/sbt/issues/1553
-
-> output-empty
-> compile
--> output-empty
-$ delete src/main/scala/For.scala src/main/scala/Nested.scala
-> compile
-> output-empty

--- a/zinc/src/sbt-test/source-dependencies/compactify/test
+++ b/zinc/src/sbt-test/source-dependencies/compactify/test
@@ -1,0 +1,6 @@
+> checkNoClassFiles
+> compile
+-> checkNoClassFiles
+$ delete src/main/scala/For.scala src/main/scala/Nested.scala
+> compile
+> checkNoClassFiles


### PR DESCRIPTION
Compactify was never marked as a passing test after we got a regression
in https://github.com/sbt/sbt/issues/1553.

For some reason, the scripted setup was not recognizing tasks defined
locally in the `build.sbt`, and so we add this functionality to
`IncHandler` which is the responsible of mapping task keys to their
actual implementation in sbt-scripted.

Aside from moving this functionality around and marking the test as
passing, I took the liberty to modify the name of `output-empty` for
something clearer in spirit: `checkNoClassFiles`.