### PR TITLE
Logger reporter uses event logging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,3 +3,9 @@
 To contribute to Zinc, you or your employer must sign Lightbend Contributor License Agreement <https://www.lightbend.com/contribute/cla>.
 
 If you add a new file, run `createHeaders` task from sbt shell to put the copyright notice.
+
+### To build with other module source
+
+```
+$ sbt -Dsbtio.path=../io -Dsbtutil.path=../util -Dsbtlm.path=../librarymanagement
+```

--- a/internal/compiler-bridge/src-2.10/main/scala/xsbt/DelegatingReporter.scala
+++ b/internal/compiler-bridge/src-2.10/main/scala/xsbt/DelegatingReporter.scala
@@ -5,6 +5,8 @@ package xsbt
 
 import xsbti.{ F0, Logger, Maybe }
 import java.io.File
+import sbt.util.InterfaceUtil.o2jo
+import java.util.Optional
 
 private object DelegatingReporter {
   def apply(settings: scala.tools.nsc.Settings, delegate: xsbti.Reporter): DelegatingReporter =
@@ -73,13 +75,13 @@ private final class DelegatingReporter(warnFatal: Boolean, noWarn: Boolean, priv
     }
   private[this] def position(sourcePath0: Option[String], sourceFile0: Option[File], line0: Option[Int], lineContent0: String, offset0: Option[Int], pointer0: Option[Int], pointerSpace0: Option[String]) =
     new xsbti.Position {
-      val line = o2mi(line0)
+      val line = o2oi(line0)
       val lineContent = lineContent0
-      val offset = o2mi(offset0)
-      val sourcePath = o2m(sourcePath0)
-      val sourceFile = o2m(sourceFile0)
-      val pointer = o2mi(pointer0)
-      val pointerSpace = o2m(pointerSpace0)
+      val offset = o2oi(offset0)
+      val sourcePath = o2jo(sourcePath0)
+      val sourceFile = o2jo(sourceFile0)
+      val pointer = o2oi(pointer0)
+      val pointerSpace = o2jo(pointerSpace0)
       override def toString =
         (sourcePath0, line0) match {
           case (Some(s), Some(l)) => s + ":" + l
@@ -97,6 +99,5 @@ private final class DelegatingReporter(warnFatal: Boolean, noWarn: Boolean, priv
     }
 
   import java.lang.{ Integer => I }
-  private[this] def o2mi(opt: Option[Int]): Maybe[I] = opt match { case None => Maybe.nothing[I]; case Some(s) => Maybe.just[I](s) }
-  private[this] def o2m[S](opt: Option[S]): Maybe[S] = opt match { case None => Maybe.nothing[S]; case Some(s) => Maybe.just(s) }
+  private[this] def o2oi(opt: Option[Int]): Optional[I] = opt match { case None => Optional.empty[I]; case Some(s) => Optional.ofNullable[I](s) }
 }

--- a/internal/compiler-bridge/src-2.10/main/scala/xsbt/DelegatingReporter.scala
+++ b/internal/compiler-bridge/src-2.10/main/scala/xsbt/DelegatingReporter.scala
@@ -74,7 +74,7 @@ private final class DelegatingReporter(warnFatal: Boolean, noWarn: Boolean, priv
         Option(posIn) match {
           case None | Some(NoPosition) => None
           case Some(x: FakePos)        => None
-          case x                       => Option(posIn.finalPosition)
+          case x                       => Option(posIn.inUltimateSource(posIn.source))
         }
       posOpt match {
         case None      => position(None, None, None, "", None, None, None)

--- a/internal/compiler-bridge/src/main/scala/xsbt/DelegatingReporter.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/DelegatingReporter.scala
@@ -7,8 +7,9 @@
 
 package xsbt
 
-import xsbti.{ F0, Logger, Maybe }
 import java.io.File
+import sbt.util.InterfaceUtil.o2jo
+import java.util.Optional
 
 private object DelegatingReporter {
   def apply(settings: scala.tools.nsc.Settings, delegate: xsbti.Reporter): DelegatingReporter =
@@ -70,13 +71,13 @@ private final class DelegatingReporter(warnFatal: Boolean, noWarn: Boolean, priv
     }
   private[this] def position(sourcePath0: Option[String], sourceFile0: Option[File], line0: Option[Int], lineContent0: String, offset0: Option[Int], pointer0: Option[Int], pointerSpace0: Option[String]) =
     new xsbti.Position {
-      val line = o2mi(line0)
+      val line = o2oi(line0)
       val lineContent = lineContent0
-      val offset = o2mi(offset0)
-      val sourcePath = o2m(sourcePath0)
-      val sourceFile = o2m(sourceFile0)
-      val pointer = o2mi(pointer0)
-      val pointerSpace = o2m(pointerSpace0)
+      val offset = o2oi(offset0)
+      val sourcePath = o2jo(sourcePath0)
+      val sourceFile = o2jo(sourceFile0)
+      val pointer = o2oi(pointer0)
+      val pointerSpace = o2jo(pointerSpace0)
       override def toString =
         (sourcePath0, line0) match {
           case (Some(s), Some(l)) => s + ":" + l
@@ -94,6 +95,5 @@ private final class DelegatingReporter(warnFatal: Boolean, noWarn: Boolean, priv
     }
 
   import java.lang.{ Integer => I }
-  private[this] def o2mi(opt: Option[Int]): Maybe[I] = opt match { case None => Maybe.nothing[I]; case Some(s) => Maybe.just[I](s) }
-  private[this] def o2m[S](opt: Option[S]): Maybe[S] = opt match { case None => Maybe.nothing[S]; case Some(s) => Maybe.just(s) }
+  private[this] def o2oi(opt: Option[Int]): Optional[I] = opt match { case None => Optional.empty[I]; case Some(s) => Optional.ofNullable[I](s) }
 }

--- a/internal/compiler-bridge/src/main/scala/xsbt/DelegatingReporter.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/DelegatingReporter.scala
@@ -8,12 +8,40 @@
 package xsbt
 
 import java.io.File
-import sbt.util.InterfaceUtil.o2jo
 import java.util.Optional
 
 private object DelegatingReporter {
   def apply(settings: scala.tools.nsc.Settings, delegate: xsbti.Reporter): DelegatingReporter =
     new DelegatingReporter(Command.getWarnFatal(settings), Command.getNoWarn(settings), delegate)
+
+  class PositionImpl(sourcePath0: Option[String], sourceFile0: Option[File],
+    line0: Option[Int], lineContent0: String, offset0: Option[Int], pointer0: Option[Int], pointerSpace0: Option[String]) extends xsbti.Position {
+    val line = o2oi(line0)
+    val lineContent = lineContent0
+    val offset = o2oi(offset0)
+    val sourcePath = o2jo(sourcePath0)
+    val sourceFile = o2jo(sourceFile0)
+    val pointer = o2oi(pointer0)
+    val pointerSpace = o2jo(pointerSpace0)
+    override def toString =
+      (sourcePath0, line0) match {
+        case (Some(s), Some(l)) => s + ":" + l
+        case (Some(s), _)       => s + ":"
+        case _                  => ""
+      }
+  }
+
+  import java.lang.{ Integer => I }
+  private[xsbt] def o2oi(opt: Option[Int]): Optional[I] =
+    opt match {
+      case Some(s) => Optional.ofNullable[I](s: I)
+      case None    => Optional.empty[I]
+    }
+  private[xsbt] def o2jo[A](o: Option[A]): Optional[A] =
+    o match {
+      case Some(v) => Optional.ofNullable(v)
+      case None    => Optional.empty[A]()
+    }
 }
 
 // The following code is based on scala.tools.nsc.reporters.{AbstractReporter, ConsoleReporter}
@@ -21,7 +49,7 @@ private object DelegatingReporter {
 // Original author: Martin Odersky
 private final class DelegatingReporter(warnFatal: Boolean, noWarn: Boolean, private[this] var delegate: xsbti.Reporter) extends scala.tools.nsc.reporters.Reporter {
   import scala.reflect.internal.util.{ FakePos, NoPosition, Position }
-
+  import DelegatingReporter._
   def dropDelegate(): Unit = { delegate = null }
   def error(msg: String): Unit = error(FakePos("scalac"), msg)
 
@@ -45,16 +73,15 @@ private final class DelegatingReporter(warnFatal: Boolean, noWarn: Boolean, priv
   }
   def convert(posIn: Position): xsbti.Position =
     {
-      val pos =
-        posIn match {
-          case null | NoPosition => NoPosition
-          case x: FakePos        => x
-          case x =>
-            posIn.finalPosition
+      val posOpt =
+        Option(posIn) match {
+          case None | Some(NoPosition) => None
+          case Some(x: FakePos)        => None
+          case x                       => Option(posIn.finalPosition)
         }
-      pos match {
-        case NoPosition | FakePos(_) => position(None, None, None, "", None, None, None)
-        case _                       => makePosition(pos)
+      posOpt match {
+        case None      => new PositionImpl(None, None, None, "", None, None, None)
+        case Some(pos) => makePosition(pos)
       }
     }
   private[this] def makePosition(pos: Position): xsbti.Position =
@@ -67,23 +94,7 @@ private final class DelegatingReporter(warnFatal: Boolean, noWarn: Boolean, priv
       val offset = pos.point
       val pointer = offset - src.lineToOffset(src.offsetToLine(offset))
       val pointerSpace = ((lineContent: Seq[Char]).take(pointer).map { case '\t' => '\t'; case x => ' ' }).mkString
-      position(Option(sourcePath), Option(sourceFile), Some(line), lineContent, Some(offset), Some(pointer), Some(pointerSpace))
-    }
-  private[this] def position(sourcePath0: Option[String], sourceFile0: Option[File], line0: Option[Int], lineContent0: String, offset0: Option[Int], pointer0: Option[Int], pointerSpace0: Option[String]) =
-    new xsbti.Position {
-      val line = o2oi(line0)
-      val lineContent = lineContent0
-      val offset = o2oi(offset0)
-      val sourcePath = o2jo(sourcePath0)
-      val sourceFile = o2jo(sourceFile0)
-      val pointer = o2oi(pointer0)
-      val pointerSpace = o2jo(pointerSpace0)
-      override def toString =
-        (sourcePath0, line0) match {
-          case (Some(s), Some(l)) => s + ":" + l
-          case (Some(s), _)       => s + ":"
-          case _                  => ""
-        }
+      new PositionImpl(Option(sourcePath), Option(sourceFile), Option(line), lineContent, Option(offset), Option(pointer), Option(pointerSpace))
     }
 
   import xsbti.Severity.{ Info, Warn, Error }
@@ -93,7 +104,4 @@ private final class DelegatingReporter(warnFatal: Boolean, noWarn: Boolean, priv
       case WARNING => Warn
       case ERROR   => Error
     }
-
-  import java.lang.{ Integer => I }
-  private[this] def o2oi(opt: Option[Int]): Optional[I] = opt match { case None => Optional.empty[I]; case Some(s) => Optional.ofNullable[I](s) }
 }

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/LoggerReporter.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/LoggerReporter.scala
@@ -35,8 +35,7 @@ object LoggerReporter {
       jo2o(pos.offset) == jo2o(o.offset) &&
         jo2o(pos.sourceFile) == jo2o(o.sourceFile)
     override def hashCode =
-      jo2o(pos.offset).hashCode * 31
-    jo2o(pos.sourceFile).hashCode
+      jo2o(pos.offset).hashCode * 31 + jo2o(pos.sourceFile).hashCode
   }
 
   def countElementsAsString(n: Int, elements: String): String =

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/LoggerReporter.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/LoggerReporter.scala
@@ -20,6 +20,7 @@ import java.util.EnumMap
 import scala.collection.mutable
 import LoggerReporter._
 import sbt.util.Logger
+import sbt.internal.util.ManagedLogger
 import Logger.{ m2o, o2m, position, problem }
 import Severity.{ Error, Info => SInfo, Warn }
 
@@ -50,7 +51,7 @@ object LoggerReporter {
     }
 }
 
-class LoggerReporter(maximumErrors: Int, log: Logger, sourcePositionMapper: Position => Position = { p => p }) extends xsbti.Reporter {
+class LoggerReporter(maximumErrors: Int, log: ManagedLogger, sourcePositionMapper: Position => Position = { p => p }) extends xsbti.Reporter {
   val positions = new mutable.HashMap[PositionKey, Severity]
   val count = new EnumMap[Severity, Int](classOf[Severity])
   private[this] val allProblems = new mutable.ListBuffer[Problem]

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/ProblemStringFormats.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/ProblemStringFormats.scala
@@ -1,0 +1,32 @@
+package sbt
+package internal
+package inc
+
+import xsbti.Problem
+import sbt.util.ShowLines
+import sbt.util.InterfaceUtil.jo2o
+
+/**
+ * The string representation of compiler warnings and error messages,
+ * used by LoggerReporter and the logging system.
+ */
+trait ProblemStringFormats {
+  implicit lazy val ProblemStringFormat: ShowLines[Problem] = new ShowLines[Problem] {
+    def showLines(p: Problem): Seq[String] =
+      p match {
+        case p if !p.position.sourcePath.isPresent && !p.position.line.isPresent => Vector(p.message)
+        case _ =>
+          val pos = p.position
+          val sourcePrefix = jo2o(pos.sourcePath).getOrElse("")
+          val columnNumber = jo2o(pos.pointer).map(_.toInt + 1).getOrElse(1)
+          val lineNumberString = jo2o(pos.line).map(":" + _ + ":" + columnNumber + ":").getOrElse(":") + " "
+          val line1 = sourcePrefix + lineNumberString + p.message
+          val lineContent = pos.lineContent
+          if (!lineContent.isEmpty) {
+            Vector(line1, lineContent) ++
+              (for { space <- jo2o(pos.pointerSpace) }
+                yield (space + "^")).toVector // pointer to the column position of the error/warning
+          } else Vector(line1)
+      }
+  }
+}

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/DiagnosticsReporter.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/DiagnosticsReporter.scala
@@ -11,11 +11,11 @@ package internal
 package inc
 package javac
 
+import java.util.Optional
 import java.io.File
 import javax.tools.{ Diagnostic, JavaFileObject, DiagnosticListener }
-
-import sbt.util.Logger
-import xsbti.{ Severity, Reporter, Maybe }
+import sbt.util.InterfaceUtil.o2jo
+import xsbti.{ Severity, Reporter }
 import javax.tools.Diagnostic.NOPOS
 
 /**
@@ -51,16 +51,7 @@ final class DiagnosticsReporter(reporter: Reporter) extends DiagnosticListener[J
       case _ => getRawMessage
     }
   }
-  private def fixSource[T <: JavaFileObject](source: T): Option[String] = {
-    try Option(source).map(_.toUri.normalize).map(new File(_)).map(_.getAbsolutePath)
-    catch {
-      case t: IllegalArgumentException =>
-        // Oracle JDK6 has a super dumb notion of what a URI is.  In fact, it's not even a legimitate URL, but a dump
-        // of the filename in a "I hope this works to toString it" kind of way.  This appears to work in practice
-        // but we may need to re-evaluate.
-        Option(source).map(_.toUri.toString)
-    }
-  }
+
   override def report(d: Diagnostic[_ <: JavaFileObject]): Unit = {
     val severity =
       d.getKind match {
@@ -69,66 +60,77 @@ final class DiagnosticsReporter(reporter: Reporter) extends DiagnosticListener[J
         case _ => Severity.Info
       }
     val msg = fixedDiagnosticMessage(d)
-    val pos: xsbti.Position =
-      new xsbti.Position {
-        // https://docs.oracle.com/javase/7/docs/api/javax/tools/Diagnostic.html
-        // Negative values (except NOPOS) and 0 are not valid line or column numbers,
-        // except that you can cause this number to occur by putting "abc {}" in A.java.
-        // This will cause Invalid position: 0 masking the actual error message
-        //     a/A.java:1: class, interface, or enum expected
-        private[this] def checkNoPos(n: Long): Option[Long] =
-          n match {
-            case NOPOS       => None
-            case x if x <= 0 => None
-            case x           => Option(x)
-          }
-
-        override val line: Maybe[Integer] = Logger.o2m(checkNoPos(d.getLineNumber) map { x => new Integer(x.toInt) })
-        def startPosition: Option[Long] = checkNoPos(d.getStartPosition)
-        def endPosition: Option[Long] = checkNoPos(d.getEndPosition)
-        override val offset: Maybe[Integer] = Logger.o2m(checkNoPos(d.getPosition) map { x => new Integer(x.toInt) })
-        override def lineContent: String = {
-          def getDiagnosticLine: Option[String] =
-            try {
-              // See com.sun.tools.javac.api.ClientCodeWrapper.DiagnosticSourceUnwrapper
-              val diagnostic = d.getClass.getField("d").get(d)
-              // See com.sun.tools.javac.util.JCDiagnostic#getDiagnosticSource
-              val getDiagnosticSourceMethod = diagnostic.getClass.getDeclaredMethod("getDiagnosticSource")
-              val getPositionMethod = diagnostic.getClass.getDeclaredMethod("getPosition")
-              (Option(getDiagnosticSourceMethod.invoke(diagnostic)), Option(getPositionMethod.invoke(diagnostic))) match {
-                case (Some(diagnosticSource), Some(position: java.lang.Long)) =>
-                  // See com.sun.tools.javac.util.DiagnosticSource
-                  val getLineMethod = diagnosticSource.getClass.getMethod("getLine", Integer.TYPE)
-                  Option(getLineMethod.invoke(diagnosticSource, new Integer(position.intValue()))).map(_.toString)
-                case _ => None
-              }
-            } catch {
-              // TODO - catch ReflectiveOperationException once sbt is migrated to JDK7
-              case ignored: Throwable => None
-            }
-
-          def getExpression: String =
-            Option(d.getSource) match {
-              case Some(source: JavaFileObject) =>
-                (Option(source.getCharContent(true)), startPosition, endPosition) match {
-                  case (Some(cc), Some(start), Some(end)) => cc.subSequence(start.toInt, end.toInt).toString
-                  case _                                  => ""
-                }
-              case _ => ""
-            }
-
-          getDiagnosticLine.getOrElse(getExpression)
-        }
-        private val sourceUri = fixSource(d.getSource)
-        override val sourcePath = Logger.o2m(sourceUri)
-        override val sourceFile = Logger.o2m(sourceUri.map(new File(_)))
-        override val pointer = Logger.o2m(Option.empty[Integer])
-        override val pointerSpace = Logger.o2m(Option.empty[String])
-        override def toString =
-          if (sourceUri.isDefined) s"${sourceUri.get}:${if (line.isDefined) line.get else -1}"
-          else ""
-      }
+    val pos: xsbti.Position = new PositionImpl(d)
     if (severity == Severity.Error) errorEncountered = true
     reporter.log(pos, msg, severity)
+  }
+
+  private class PositionImpl(d: Diagnostic[_ <: JavaFileObject]) extends xsbti.Position {
+    // https://docs.oracle.com/javase/7/docs/api/javax/tools/Diagnostic.html
+    // Negative values (except NOPOS) and 0 are not valid line or column numbers,
+    // except that you can cause this number to occur by putting "abc {}" in A.java.
+    // This will cause Invalid position: 0 masking the actual error message
+    //     a/A.java:1: class, interface, or enum expected
+    private[this] def checkNoPos(n: Long): Option[Long] =
+      n match {
+        case NOPOS       => None
+        case x if x <= 0 => None
+        case x           => Option(x)
+      }
+
+    override val line: Optional[Integer] = o2jo(checkNoPos(d.getLineNumber) map { x => new Integer(x.toInt) })
+    def startPosition: Option[Long] = checkNoPos(d.getStartPosition)
+    def endPosition: Option[Long] = checkNoPos(d.getEndPosition)
+    override val offset: Optional[Integer] = o2jo(checkNoPos(d.getPosition) map { x => new Integer(x.toInt) })
+    override def lineContent: String = {
+      def getDiagnosticLine: Option[String] =
+        try {
+          // See com.sun.tools.javac.api.ClientCodeWrapper.DiagnosticSourceUnwrapper
+          val diagnostic = d.getClass.getField("d").get(d)
+          // See com.sun.tools.javac.util.JCDiagnostic#getDiagnosticSource
+          val getDiagnosticSourceMethod = diagnostic.getClass.getDeclaredMethod("getDiagnosticSource")
+          val getPositionMethod = diagnostic.getClass.getDeclaredMethod("getPosition")
+          (Option(getDiagnosticSourceMethod.invoke(diagnostic)), Option(getPositionMethod.invoke(diagnostic))) match {
+            case (Some(diagnosticSource), Some(position: java.lang.Long)) =>
+              // See com.sun.tools.javac.util.DiagnosticSource
+              val getLineMethod = diagnosticSource.getClass.getMethod("getLine", Integer.TYPE)
+              Option(getLineMethod.invoke(diagnosticSource, new Integer(position.intValue()))).map(_.toString)
+            case _ => None
+          }
+        } catch {
+          // TODO - catch ReflectiveOperationException once sbt is migrated to JDK7
+          case ignored: Throwable => None
+        }
+
+      def getExpression: String =
+        Option(d.getSource) match {
+          case Some(source: JavaFileObject) =>
+            (Option(source.getCharContent(true)), startPosition, endPosition) match {
+              case (Some(cc), Some(start), Some(end)) => cc.subSequence(start.toInt, end.toInt).toString
+              case _                                  => ""
+            }
+          case _ => ""
+        }
+
+      getDiagnosticLine.getOrElse(getExpression)
+    }
+    private val sourceUri: Option[String] = fixSource(d.getSource)
+    override val sourcePath: Optional[String] = o2jo(sourceUri)
+    override val sourceFile: Optional[File] = o2jo(sourceUri.map(new File(_)))
+    override val pointer: Optional[Integer] = o2jo(Option.empty[Integer])
+    override val pointerSpace: Optional[String] = o2jo(Option.empty[String])
+    override def toString: String =
+      if (sourceUri.isDefined) s"${sourceUri.get}:${if (line.isPresent) line.get else -1}"
+      else ""
+    private def fixSource[T <: JavaFileObject](source: T): Option[String] = {
+      try Option(source).map(_.toUri.normalize).map(new File(_)).map(_.getAbsolutePath)
+      catch {
+        case t: IllegalArgumentException =>
+          // Oracle JDK6 has a super dumb notion of what a URI is.  In fact, it's not even a legimitate URL, but a dump
+          // of the filename in a "I hope this works to toString it" kind of way.  This appears to work in practice
+          // but we may need to re-evaluate.
+          Option(source).map(_.toUri.toString)
+      }
+    }
   }
 }

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavaErrorParser.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavaErrorParser.scala
@@ -13,30 +13,31 @@ package javac
 
 import java.io.File
 
-import sbt.util.Logger.o2m
+import java.util.Optional
+import sbt.util.InterfaceUtil.o2jo
 import xsbti.{ Problem, Severity, Maybe, Position }
 
 /** A wrapper around xsbti.Position so we can pass in Java input. */
 final case class JavaPosition(_sourceFilePath: String, _line: Int, _contents: String, _offset: Int) extends Position {
-  def line: Maybe[Integer] = o2m(Some(_line))
+  def line: Optional[Integer] = o2jo(Some(_line))
   def lineContent: String = _contents
-  def offset: Maybe[Integer] = o2m(Some(_offset))
-  def pointer: Maybe[Integer] = o2m(None)
-  def pointerSpace: Maybe[String] = o2m(None)
-  def sourcePath: Maybe[String] = o2m(Option(_sourceFilePath))
-  def sourceFile: Maybe[File] = o2m(Option(new File(_sourceFilePath)))
+  def offset: Optional[Integer] = o2jo(Some(_offset))
+  def pointer: Optional[Integer] = o2jo(None)
+  def pointerSpace: Optional[String] = o2jo(None)
+  def sourcePath: Optional[String] = o2jo(Option(_sourceFilePath))
+  def sourceFile: Optional[File] = o2jo(Option(new File(_sourceFilePath)))
   override def toString = s"${_sourceFilePath}:${_line}:${_offset}"
 }
 
 /** A position which has no information, because there is none. */
 object JavaNoPosition extends Position {
-  def line: Maybe[Integer] = o2m(None)
+  def line: Optional[Integer] = o2jo(None)
   def lineContent: String = ""
-  def offset: Maybe[Integer] = o2m(None)
-  def pointer: Maybe[Integer] = o2m(None)
-  def pointerSpace: Maybe[String] = o2m(None)
-  def sourcePath: Maybe[String] = o2m(None)
-  def sourceFile: Maybe[File] = o2m(None)
+  def offset: Optional[Integer] = o2jo(None)
+  def pointer: Optional[Integer] = o2jo(None)
+  def pointerSpace: Optional[String] = o2jo(None)
+  def sourcePath: Optional[String] = o2jo(None)
+  def sourceFile: Optional[File] = o2jo(None)
   override def toString = "NoPosition"
 }
 

--- a/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/javac/JavaCompilerSpec.scala
+++ b/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/javac/JavaCompilerSpec.scala
@@ -114,7 +114,7 @@ class JavaCompilerSpec extends UnitSpec {
         case Some(content) => p.position.lineContent contains content
         case _             => true
       }
-    def lineNumberCheck = p.position.line.isDefined && (p.position.line.get == lineno)
+    def lineNumberCheck = p.position.line.isPresent && (p.position.line.get == lineno)
     lineNumberCheck && lineContentCheck
   }
 
@@ -146,11 +146,11 @@ class JavaCompilerSpec extends UnitSpec {
     (fproblems zip lproblems) foreach {
       case (f, l) =>
         // TODO - We should check to see if the levenshtein distance of the messages is close...
-        if (f.position.sourcePath.isDefined) (f.position.sourcePath.get shouldBe l.position.sourcePath.get)
-        else l.position.sourcePath.isDefined shouldBe false
+        if (f.position.sourcePath.isPresent) (f.position.sourcePath.get shouldBe l.position.sourcePath.get)
+        else l.position.sourcePath.isPresent shouldBe false
 
-        if (f.position.line.isDefined) f.position.line.get shouldBe l.position.line.get
-        else l.position.line.isDefined shouldBe false
+        if (f.position.line.isPresent) f.position.line.get shouldBe l.position.line.get
+        else l.position.line.isPresent shouldBe false
 
         f.severity shouldBe l.severity
     }

--- a/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/javac/JavaCompilerSpec.scala
+++ b/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/javac/JavaCompilerSpec.scala
@@ -11,7 +11,7 @@ import xsbt.api.SameAPI
 import xsbti.{ Maybe, Problem, Severity }
 import xsbti.compile.{ IncToolOptions, IncToolOptionsUtil, JavaTools => XJavaTools }
 import sbt.io.IO
-import sbt.util.Logger
+import sbt.util.{ Logger, LogExchange }
 import sbt.internal.util.UnitSpec
 import org.scalatest.matchers._
 
@@ -158,7 +158,7 @@ class JavaCompilerSpec extends UnitSpec {
 
   def compile(c: XJavaTools, sources: Seq[File], args: Seq[String],
     incToolOptions: IncToolOptions = IncToolOptionsUtil.defaultIncToolOptions()): (Boolean, Array[Problem]) = {
-    val log = Logger.Null
+    val log = LogExchange.logger("JavaCompilerSpec")
     val reporter = new LoggerReporter(10, log)
     val result = c.javac.run(sources.toArray, args.toArray, incToolOptions, reporter, log)
     (result, reporter.problems)
@@ -166,7 +166,7 @@ class JavaCompilerSpec extends UnitSpec {
 
   def doc(c: XJavaTools, sources: Seq[File], args: Seq[String],
     incToolOptions: IncToolOptions = IncToolOptionsUtil.defaultIncToolOptions()): (Boolean, Array[Problem]) = {
-    val log = Logger.Null
+    val log = LogExchange.logger("JavaCompilerSpec")
     val reporter = new LoggerReporter(10, log)
     val result = c.javadoc.run(sources.toArray, args.toArray, incToolOptions, reporter, log)
     (result, reporter.problems)

--- a/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/javac/javaErrorParserSpec.scala
+++ b/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/javac/javaErrorParserSpec.scala
@@ -59,7 +59,7 @@ class JavaErrorParserSpec extends UnitSpec {
     val logger = Logger.Null
     val problems = parser.parseProblems(sampleErrorPosition, logger)
     problems should have size (1)
-    problems(0).position.offset.isDefined shouldBe true
+    problems(0).position.offset.isPresent shouldBe true
     problems(0).position.offset.get shouldBe 23
   }
 

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Compile.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Compile.scala
@@ -15,10 +15,9 @@ import xsbti.api._
 import xsbti.compile.{ CompileAnalysis, DependencyChanges, IncOptions, MultipleOutput, Output, SingleOutput }
 import xsbti.{ Position, Problem, Severity }
 import sbt.util.Logger
-import sbt.util.Logger.{ m2o, problem }
+import sbt.util.InterfaceUtil.{ o2jo, jo2o }
 import java.io.File
 import xsbti.api.DependencyContext
-import xsbti.api.DependencyContext.{ DependencyByInheritance, DependencyByMemberRef }
 import xsbti.compile.ClassFileManager
 
 /**
@@ -155,7 +154,7 @@ private final class AnalysisCallback(
 
   def problem(category: String, pos: Position, msg: String, severity: Severity, reported: Boolean): Unit =
     {
-      for (source <- m2o(pos.sourceFile)) {
+      for (source <- jo2o(pos.sourceFile)) {
         val map = if (reported) reporteds else unreporteds
         map.getOrElseUpdate(source, ListBuffer.empty) += Logger.problem(category, pos, msg, severity)
       }

--- a/internal/zinc-ivy-integration/src/test/scala/sbt/internal/inc/BridgeProviderSpecification.scala
+++ b/internal/zinc-ivy-integration/src/test/scala/sbt/internal/inc/BridgeProviderSpecification.scala
@@ -17,7 +17,7 @@ import xsbti.{ ComponentProvider, GlobalLock }
  * Base class for test suites that must be able to fetch and compile the compiler bridge.
  */
 abstract class BridgeProviderSpecification extends BaseIvySpecification {
-  log.setLevel(Level.Warn)
+  // log.setLevel(Level.Warn)
 
   def realLocal: Resolver =
     {

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/TextAnalysisFormat.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/TextAnalysisFormat.scala
@@ -16,7 +16,6 @@ import xsbti.T2
 import xsbti.api._
 import xsbti.compile._
 import javax.xml.bind.DatatypeConverter
-
 import sbt.util.InterfaceUtil
 
 // A text-based serialization format for Analysis objects.
@@ -31,14 +30,13 @@ class TextAnalysisFormat(override val mappers: AnalysisMappers) extends FormatCo
   import sbinary.DefaultProtocol._
   import sbinary.Format
   import xsbti.{ Position, Problem, Severity }
-  import sbt.util.Logger.{ m2o, position, problem }
 
   private implicit val compilationF: Format[Compilation] = xsbt.api.CompilationFormat
   private implicit val nameHashesFormat: Format[NameHashes] = xsbt.api.NameHashesFormat
   private implicit val companionsFomrat: Format[Companions] = xsbt.api.CompanionsFormat
   private implicit def problemFormat: Format[Problem] = asProduct4(problem _)(p => (p.category, p.position, p.message, p.severity))
   private implicit def positionFormat: Format[Position] =
-    asProduct7(position _)(p => (m2o(p.line), p.lineContent, m2o(p.offset), m2o(p.pointer), m2o(p.pointerSpace), m2o(p.sourcePath), m2o(p.sourceFile)))
+    asProduct7(position _)(p => (jo2o(p.line), p.lineContent, jo2o(p.offset), jo2o(p.pointer), jo2o(p.pointerSpace), jo2o(p.sourcePath), jo2o(p.sourceFile)))
   private implicit val severityFormat: Format[Severity] =
     wrap[Severity, Byte](_.ordinal.toByte, b => Severity.values.apply(b.toInt))
   private implicit val integerFormat: Format[Integer] = wrap[Integer, Int](_.toInt, Integer.valueOf)

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/TextAnalysisFormat.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/TextAnalysisFormat.scala
@@ -17,6 +17,7 @@ import xsbti.api._
 import xsbti.compile._
 import javax.xml.bind.DatatypeConverter
 import sbt.util.InterfaceUtil
+import sbt.util.InterfaceUtil.{ jo2o, problem, position }
 
 // A text-based serialization format for Analysis objects.
 // This code has been tuned for high performance, and therefore has non-idiomatic areas.

--- a/internal/zinc-scripted/src/main/contraband-scala/sbt/internal/inctest/Build.scala
+++ b/internal/zinc-scripted/src/main/contraband-scala/sbt/internal/inctest/Build.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using sbt-datatype.
+ * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/internal/zinc-scripted/src/main/contraband-scala/sbt/internal/inctest/BuildFormats.scala
+++ b/internal/zinc-scripted/src/main/contraband-scala/sbt/internal/inctest/BuildFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using sbt-datatype.
+ * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/internal/zinc-scripted/src/main/contraband-scala/sbt/internal/inctest/JsonProtocol.scala
+++ b/internal/zinc-scripted/src/main/contraband-scala/sbt/internal/inctest/JsonProtocol.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using sbt-datatype.
+ * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/internal/zinc-scripted/src/main/contraband-scala/sbt/internal/inctest/Project.scala
+++ b/internal/zinc-scripted/src/main/contraband-scala/sbt/internal/inctest/Project.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using sbt-datatype.
+ * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/internal/zinc-scripted/src/main/contraband-scala/sbt/internal/inctest/ProjectFormats.scala
+++ b/internal/zinc-scripted/src/main/contraband-scala/sbt/internal/inctest/ProjectFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using sbt-datatype.
+ * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -5,7 +5,7 @@ package inc
 import java.io.{ File, FileInputStream }
 import java.net.URLClassLoader
 import java.util.jar.Manifest
-import sbt.util.Logger
+import sbt.util.{ Logger, LogExchange }
 import sbt.util.InterfaceUtil._
 import xsbt.api.Discovery
 import xsbti.{ Maybe, Problem, Severity }
@@ -21,12 +21,13 @@ import java.util.Properties
 import sbt.internal.inc.classpath.{ ClasspathUtilities, ClassLoaderCache }
 import sbt.internal.scripted.{ StatementHandler, TestFailed }
 import sbt.internal.inctest.{ Build, Project, JsonProtocol }
+import sbt.internal.util.ManagedLogger
 import sjsonnew.support.scalajson.unsafe.{ Converter, Parser => JsonParser }
 import scala.collection.mutable
 
 final case class IncInstance(si: ScalaInstance, cs: XCompilers)
 
-final class IncHandler(directory: File, scriptedLog: Logger) extends BridgeProviderSpecification with StatementHandler {
+final class IncHandler(directory: File, scriptedLog: ManagedLogger) extends BridgeProviderSpecification with StatementHandler {
   type State = Option[IncInstance]
   type IncCommand = (ProjectStructure, List[String], IncInstance) => Unit
   val scalaVersion = scala.util.Properties.versionNumberString
@@ -50,6 +51,7 @@ final class IncHandler(directory: File, scriptedLog: Logger) extends BridgeProvi
       }
     }
   initBuildStructure()
+
   def initBuild: Build =
     if ((directory / "build.json").exists) {
       import JsonProtocol._
@@ -197,7 +199,7 @@ final class IncHandler(directory: File, scriptedLog: Logger) extends BridgeProvi
 
 }
 
-case class ProjectStructure(name: String, dependsOn: Vector[String], baseDirectory: File, scriptedLog: Logger,
+case class ProjectStructure(name: String, dependsOn: Vector[String], baseDirectory: File, scriptedLog: ManagedLogger,
   lookupProject: String => ProjectStructure) extends BridgeProviderSpecification {
   val scalaVersion = scala.util.Properties.versionNumberString
   val compiler = new IncrementalCompilerImpl

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/ScriptedHandlers.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/ScriptedHandlers.scala
@@ -1,6 +1,7 @@
 package sbt.internal.inc
 
 import sbt.internal.scripted._
+import sbt.internal.util.ManagedLogger
 
 class SleepingHandler(val handler: StatementHandler, delay: Long) extends StatementHandler {
   type State = handler.State
@@ -17,6 +18,13 @@ class IncScriptedHandlers extends HandlersProvider {
   def getHandlers(config: ScriptConfig): Map[Char, StatementHandler] = Map(
     '$' -> new SleepingHandler(new FileCommands(config.testDirectory()), 500),
     '#' -> CommentHandler,
-    '>' -> new IncHandler(config.testDirectory(), config.logger())
+    '>' -> {
+      val logger: ManagedLogger =
+        config.logger() match {
+          case x: ManagedLogger => x
+          case _                => sys.error("Expected ManagedLogger")
+        }
+      new IncHandler(config.testDirectory(), logger)
+    }
   )
 }

--- a/internal/zinc-testing/src/main/scala/sbt/internal/inc/BaseIvySpecification.scala
+++ b/internal/zinc-testing/src/main/scala/sbt/internal/inc/BaseIvySpecification.scala
@@ -15,10 +15,8 @@ import sbt.io.syntax._
 import java.io.File
 import sbt.internal.librarymanagement._
 import sbt.internal.librarymanagement.cross.CrossVersionUtil
-import sbt.util.Logger
-import sbt.internal.util.{ ConsoleLogger, FileBasedStore }
+import sbt.internal.util.FileBasedStore
 import sbt.librarymanagement._
-import ivyint.SbtChainResolver
 import Configurations._
 
 import sjsonnew.IsoString
@@ -36,8 +34,6 @@ trait BaseIvySpecification extends UnitSpec {
 
   implicit val isoString: IsoString[JValue] = IsoString.iso(CompactPrinter.apply, FixedParser.parseUnsafe)
   val fileToStore = (f: File) => new FileBasedStore(f, Converter)
-  lazy val log = ConsoleLogger()
-
   def configurations = Vector(Compile, Test, Runtime)
   def module(moduleId: ModuleID, deps: Vector[ModuleID], scalaFullVersion: Option[String],
     uo: UpdateOptions = UpdateOptions(), overrideScalaVersion: Boolean = true): IvySbt#Module = {

--- a/internal/zinc-testing/src/main/scala/sbt/internal/inc/UnitSpec.scala
+++ b/internal/zinc-testing/src/main/scala/sbt/internal/inc/UnitSpec.scala
@@ -26,7 +26,7 @@ object UnitSpec {
     val loggerName = "test-" + generateId.incrementAndGet
     val x = LogExchange.logger(loggerName)
     LogExchange.unbindLoggerAppenders(loggerName)
-    LogExchange.bindLoggerAppenders(loggerName, (consoleAppender -> Level.Debug) :: Nil)
+    LogExchange.bindLoggerAppenders(loggerName, (consoleAppender -> Level.Warn) :: Nil)
     x
   }
 }

--- a/internal/zinc-testing/src/main/scala/sbt/internal/inc/UnitSpec.scala
+++ b/internal/zinc-testing/src/main/scala/sbt/internal/inc/UnitSpec.scala
@@ -10,5 +10,23 @@ package internal
 package inc
 
 import org.scalatest._
+import sbt.util.{ Logger, LogExchange, Level }
+import sbt.internal.util.{ ManagedLogger, ConsoleOut, MainAppender }
+import java.util.concurrent.atomic.AtomicInteger
 
-abstract class UnitSpec extends FlatSpec with Matchers
+abstract class UnitSpec extends FlatSpec with Matchers {
+  lazy val log: ManagedLogger = UnitSpec.newLogger
+}
+
+object UnitSpec {
+  val console = ConsoleOut.systemOut
+  val consoleAppender = MainAppender.defaultScreen(console)
+  val generateId: AtomicInteger = new AtomicInteger
+  def newLogger: ManagedLogger = {
+    val loggerName = "test-" + generateId.incrementAndGet
+    val x = LogExchange.logger(loggerName)
+    LogExchange.unbindLoggerAppenders(loggerName)
+    LogExchange.bindLoggerAppenders(loggerName, (consoleAppender -> Level.Debug) :: Nil)
+    x
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,8 +11,8 @@ object Dependencies {
 
   val bootstrapSbtVersion = "0.13.8"
   private val ioVersion = "1.0.0-M9"
-  private val utilVersion = "1.0.0-M18"
-  private val lmVersion = "1.0.0-X4"
+  private val utilVersion = "1.0.0-M19"
+  private val lmVersion = "1.0.0-X5"
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion
 

--- a/project/sbt-contraband.sbt
+++ b/project/sbt-contraband.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.3.0-M3")
+addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.3.0-M4")

--- a/zinc-compile/src/test/scala/inc/DocSpec.scala
+++ b/zinc-compile/src/test/scala/inc/DocSpec.scala
@@ -4,11 +4,9 @@ package inc
 import java.io.File
 
 import sbt.io.IO
-import sbt.util.Logger
-import sbt.internal.util.UnitSpec
 import sbt.internal.inc.javac.{ JavaCompiler, JavaTools, Javadoc }
 import sbt.internal.inc.javac.JavaCompilerSpec
-import sbt.internal.inc.LoggerReporter
+import sbt.internal.inc.{ LoggerReporter, UnitSpec }
 import xsbti.compile.IncToolOptionsUtil
 import sbt.internal.util.DirectoryStoreFactory
 import scala.json.ast.unsafe.JValue
@@ -46,7 +44,6 @@ class DocSpec extends UnitSpec {
       JavaCompiler.local.getOrElse(sys.error("This test cannot be run on a JRE, but only a JDK.")),
       Javadoc.local.getOrElse(Javadoc.fork())
     )
-  lazy val log = Logger.Null
   lazy val reporter = new LoggerReporter(10, log)
   def knownSampleGoodFile =
     new File(classOf[JavaCompilerSpec].getResource("good.java").toURI)

--- a/zinc/src/test/resources/sources/Good.scala
+++ b/zinc/src/test/resources/sources/Good.scala
@@ -1,5 +1,6 @@
 package pkg
 
 object Good extends App {
+  1
   println("hello, world")
 }

--- a/zinc/src/test/scala/sbt/inc/IncrementalCompilerSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/IncrementalCompilerSpec.scala
@@ -8,7 +8,6 @@ import sbt.internal.inc._
 import sbt.io.IO
 import sbt.io.syntax._
 import sbt.util.{ Logger, InterfaceUtil }
-import sbt.internal.util.ConsoleLogger
 import xsbti.Maybe
 import xsbti.compile.{ CompileAnalysis, CompileOrder, DefinesClass, IncOptionsUtil, PreviousResult, PerClasspathEntryLookup }
 import sbt.internal.inc.classpath.ClassLoaderCache

--- a/zinc/src/test/scala/sbt/inc/MultiProjectIncrementalSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/MultiProjectIncrementalSpec.scala
@@ -4,7 +4,6 @@ import java.io.File
 import java.net.URLClassLoader
 
 import sbt.internal.inc.{ ScalaInstance => _, _ }
-import sbt.internal.util.ConsoleLogger
 import sbt.io.IO
 import sbt.io.syntax._
 import sbt.util.{ InterfaceUtil, Logger }
@@ -41,7 +40,6 @@ class MultiProjectIncrementalSpec extends BridgeProviderSpecification {
       val binarySampleFile = sub1Directory / "lib" / "sample-binary_2.11-0.1.jar"
       IO.copyFile(binarySampleFile0, binarySampleFile)
       val sources = Array(dependerFile)
-      val log = ConsoleLogger()
       // uncomment this to see the debug log
       // log.setLevel(Level.Debug)
       val compilerBridge = getCompilerBridge(sub1Directory, Logger.Null, scalaVersion)


### PR DESCRIPTION
This depends on https://github.com/sbt/util/pull/71

LoggerReporter now sends `xsbti.Problem` value to the logger using event logging, instead of crafting String in the DelegatingReporter. The end user would still see the same output because the old format is now carried over as `ShowLines[Problem]`.
