### PR TITLE
Make ExtractAPI#annotations phase travel to entering typer, again

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/ExtractAPI.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ExtractAPI.scala
@@ -209,7 +209,7 @@ class ExtractAPI[GlobalType <: Global](
     }
 
   private def annotations(in: Symbol, s: Symbol): Array[xsbti.api.Annotation] =
-    enteringPhase(currentRun.typerPhase.next) {
+    enteringPhase(currentRun.typerPhase) {
       val base = if (s.hasFlag(Flags.ACCESSOR)) s.accessed else NoSymbol
       val b = if (base == NoSymbol) s else base
       // annotations from bean methods are not handled because:


### PR DESCRIPTION
This is a revert of the change that was made in:

https://github.com/sbt/zinc/pull/86/commits/b0a8a91aaa5b6f55714986f7bf389ec8aa091ec0#diff-babf52667b7dd64d625e0bcddfd8da48R211

Here's my analysis of what happened.

Prior to creating this commit Greg was working on class-based
name-hashing in a branch in sbt/sbt, targeting sbt 0.13.  With this
commit Greg was re-syncing his changes with the changes that had
happened in the sbt/zinc repo, to be able to PR sbt/zinc.

However, there was an important difference in sources between sbt/sbt
and sbt/zinc. The Scala compiler/reflect APIs change over time, for
instance in scala 2.11 the "atPhase" method was deprecated in favour of
the brand-new, more precise, but otherwise identical "enteringPhase"
method.  But sbt/sbt didn't care about deprecations and just used
"atPhase" for all versions of Scala it supported (2.8/2.9/etc).  In
sbt/zinc, instead, the sources had been split into 2.10 and 2.11+
sources, and the 2.11+ sources had switched to the newer, non-deprecated
APIs. So "atPhase" had been replaced with "enteringPhase".

So when Greg was re-syncing the changes in his branch with the changes
in sbt/zinc he had to deal with (a) the sources being split and (b) the
compiler API differences. At this point I think 1 of the 2 following
plausible scenarios happened. Either:

1. For one reason or another Greg accidentally, and incorrectly, thought
it was the correct implementation, perhaps he forgot that atPhase and
enteringPhase are synonymous. So he made the 2.11+ code invoke
enteringPhase(currentRun.typerPhase.next) instead of
enteringPhase(currentRun.typerPhase), thinking it was the correct
equivalent to atPhase(currentRun.typerPhase) in the 2.10 code.

2. Greg intentionally, purposely, made, all of a sudden, a judgement
call, while syncing, dealing with merge conflicts and file path changes,
that ExtractAPI#annotations MUST phase travel to exiting the typer phase
(via enteringPhase(typer.next)). And then he (a) changed _only_ the
2.11+ code, leaving the the 2.10 code travel to the wrong place _and_
(b) didn't mention it in his "highlight of less obvious changes" in the
commit message.

I find 1 to be much, much more plausible, so let's revert to what has
worked since its inception in 2010:

https://github.com/sbt/sbt/commit/af4f41e052e6e077c2d590ba8ddbfda19769f280#diff-d31107a2fcd3c8482cbac4ee198375b6R311

and today in the latest stable release, 0.13.13:

https://github.com/sbt/sbt/blob/v0.13.13/compile/interface/src/main/scala/xsbt/ExtractAPI.scala#L189

---

/cc @gkossakowski @retronym