### PR TITLE
Rename ClassfileManager to ClassFileManager for consistency

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,3 +1,7 @@
 - Support for Scala 2.7, 2.8 and 2.9 has been dropped. [#86][86]
 
   [86]: https://github.com/sbt/zinc/pull/86
+  
+- sbt.internal.inc.ClassfileManager has been renamed to sbt.internal.inc.ClassFileManager for consistency. [#87][87]
+
+  [87]: https://github.com/sbt/zinc/pull/86

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/ClassFileManager.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/ClassFileManager.scala
@@ -16,9 +16,9 @@ import collection.mutable
 import xsbti.compile.{ DeleteImmediatelyManagerType, IncOptions, TransactionalManagerType }
 import xsbti.compile.ClassFileManager
 
-object ClassfileManager {
+object ClassFileManager {
 
-  private case class WrappedClassfileManager(internal: ClassFileManager, external: Option[ClassFileManager])
+  private case class WrappedClassFileManager(internal: ClassFileManager, external: Option[ClassFileManager])
     extends ClassFileManager {
 
     override def delete(classes: Array[File]): Unit = {
@@ -37,7 +37,7 @@ object ClassfileManager {
     }
   }
 
-  def getClassfileManager(options: IncOptions): ClassFileManager = {
+  def getClassFileManager(options: IncOptions): ClassFileManager = {
     val internal =
       if (options.classfileManagerType.isDefined)
         options.classfileManagerType.get match {
@@ -52,10 +52,10 @@ object ClassfileManager {
         case manager: ClassFileManager => manager
       }
 
-    WrappedClassfileManager(internal, external)
+    WrappedClassFileManager(internal, external)
   }
 
-  /** Constructs a minimal ClassfileManager implementation that immediately deletes class files when requested. */
+  /** Constructs a minimal ClassFileManager implementation that immediately deletes class files when requested. */
   val deleteImmediately: () => ClassFileManager = () => new ClassFileManager {
     override def delete(classes: Array[File]): Unit = IO.deleteFilesEmptyDirs(classes)
     override def generated(classes: Array[File]): Unit = ()
@@ -66,12 +66,12 @@ object ClassfileManager {
   def transactional(tempDir0: File): () => ClassFileManager =
     transactional(tempDir0, sbt.util.Logger.Null)
 
-  /** When compilation fails, this ClassfileManager restores class files to the way they were before compilation. */
+  /** When compilation fails, this ClassFileManager restores class files to the way they were before compilation. */
   def transactional(tempDir0: File, logger: sbt.util.Logger): () => ClassFileManager = () => new ClassFileManager {
     val tempDir = tempDir0.getCanonicalFile
     IO.delete(tempDir)
     IO.createDirectory(tempDir)
-    logger.debug(s"Created transactional ClassfileManager with tempDir = $tempDir")
+    logger.debug(s"Created transactional ClassFileManager with tempDir = $tempDir")
 
     private[this] val generatedClasses = new mutable.HashSet[File]
     private[this] val movedClasses = new mutable.HashMap[File, File]

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -102,7 +102,7 @@ object Incremental {
   private[inc] def apiDebug(options: IncOptions): Boolean = options.apiDebug || java.lang.Boolean.getBoolean(apiDebugProp)
 
   private[sbt] def prune(invalidatedSrcs: Set[File], previous: CompileAnalysis): Analysis =
-    prune(invalidatedSrcs, previous, ClassfileManager.deleteImmediately())
+    prune(invalidatedSrcs, previous, ClassFileManager.deleteImmediately())
 
   private[sbt] def prune(invalidatedSrcs: Set[File], previous0: CompileAnalysis, classfileManager: ClassFileManager): Analysis =
     {
@@ -113,7 +113,7 @@ object Incremental {
 
   private[this] def manageClassfiles[T](options: IncOptions)(run: ClassFileManager => T): T =
     {
-      val classfileManager = ClassfileManager.getClassfileManager(options)
+      val classfileManager = ClassFileManager.getClassFileManager(options)
       val result = try run(classfileManager) catch {
         case e: Throwable =>
           classfileManager.complete(false)


### PR DESCRIPTION
Fix naming inconsistency described in #230 