### PR TITLE
Replace use of Scala collections by Java's

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/API.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/API.scala
@@ -10,6 +10,7 @@ package xsbt
 import scala.tools.nsc.Phase
 import scala.tools.nsc.symtab.Flags
 import xsbti.api._
+import java.util.{ HashMap => JavaMap }
 
 object API {
   val name = "xsbt-api"
@@ -33,26 +34,50 @@ final class API(val global: CallbackGlobal) extends Compat with GlobalHelpers {
 
     def apply(unit: global.CompilationUnit): Unit = processUnit(unit)
 
-    def processUnit(unit: CompilationUnit) = if (!unit.isJava) processScalaUnit(unit)
-    def processScalaUnit(unit: CompilationUnit): Unit = {
+    private def processUnit(unit: CompilationUnit) = if (!unit.isJava) processScalaUnit(unit)
+
+    private def debugOutput(map: JavaMap[String, Array[String]]): String = {
+      val stringBuffer = new StringBuffer()
+      // Optimized while loop that uses Java collection
+      val it = map.entrySet().iterator()
+      while (it.hasNext) {
+        val values = it.next()
+        stringBuffer.append(showUsedNames(values.getKey, values.getValue))
+      }
+
+      stringBuffer.toString
+    }
+
+    private def showUsedNames(className: String, names: Array[String]): String =
+      s"$className:\n\t${names.mkString(",")}"
+
+    private def register(allUsedNames: JavaMap[String, Array[String]]) = {
+      // Optimized while loop that uses Java collection
+      val it = allUsedNames.entrySet.iterator()
+      while (it.hasNext) {
+        val usedNameInfo = it.next()
+        val className = usedNameInfo.getKey
+        val namesIterator = usedNameInfo.getValue.iterator
+        while (namesIterator.hasNext) {
+          callback.usedName(className, namesIterator.next())
+        }
+      }
+    }
+
+    private def processScalaUnit(unit: CompilationUnit): Unit = {
       val sourceFile = unit.source.file.file
       debuglog("Traversing " + sourceFile)
       callback.startSource(sourceFile)
       val extractApi = new ExtractAPI[global.type](global, sourceFile)
       val traverser = new TopLevelHandler(extractApi)
       traverser.apply(unit.body)
+
       val extractUsedNames = new ExtractUsedNames[global.type](global)
       val allUsedNames = extractUsedNames.extract(unit)
-      def showUsedNames(className: String, names: Iterable[String]): String =
-        s"$className:\n\t${names.mkString(", ")}"
-      debuglog("The " + sourceFile + " contains the following used names:\n" +
-        allUsedNames.map((showUsedNames _).tupled).mkString("\n"))
-      allUsedNames foreach {
-        case (className: String, names: Iterable[String]) =>
-          names foreach { (name: String) => callback.usedName(className, name) }
-      }
-      val classApis = traverser.allNonLocalClasses
+      debuglog(s"The $sourceFile contains the following used names:\n ${debugOutput(allUsedNames)}")
+      register(allUsedNames)
 
+      val classApis = traverser.allNonLocalClasses
       classApis.foreach(callback.api(sourceFile, _))
     }
   }

--- a/internal/compiler-bridge/src/main/scala/xsbt/GlobalHelpers.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/GlobalHelpers.scala
@@ -8,6 +8,7 @@
 package xsbt
 
 import scala.tools.nsc.Global
+import java.util.HashSet
 
 trait GlobalHelpers { self: Compat =>
   val global: Global
@@ -57,7 +58,7 @@ trait GlobalHelpers { self: Compat =>
     }
 
     // Define cache and populate it with known types at initialization time
-    protected var visited = scala.collection.mutable.HashSet.empty[Type]
+    protected var visited = new HashSet[Type]()
 
     /** Clear the cache after every `traverse` invocation at the call-site. */
     protected def reinitializeVisited(): Unit = visited.clear()
@@ -70,7 +71,7 @@ trait GlobalHelpers { self: Compat =>
      */
     override def traverse(tpe: Type): Unit = {
       if ((tpe ne NoType) && !visited.contains(tpe)) {
-        visited += tpe
+        visited.add(tpe)
         tpe match {
           case singleRef: SingleType =>
             addTypeDependency(singleRef)

--- a/internal/compiler-bridge/src/test/scala/xsbt/ExtractUsedNamesSpecification.scala
+++ b/internal/compiler-bridge/src/test/scala/xsbt/ExtractUsedNamesSpecification.scala
@@ -13,6 +13,7 @@ class ExtractUsedNamesSpecification extends UnitSpec {
     val usedNames = compilerForTesting.extractUsedNamesFromSrc(src)
     val expectedNames = standardNames ++ Set("a", "A", "A2", "b")
     // names used at top level are attributed to the first class defined in a compilation unit
+
     assert(usedNames("a.A") === expectedNames)
   }
 


### PR DESCRIPTION
issue #245 

Tested on `Intel(R) Core(TM) i7-3610QM CPU @ 2.30GHz`

shapeless benchmark on `1.0`:
```
[info] Benchmark                                                                   (_tempDir)    Mode  Cnt           Score            Error   Units
[info] HotShapelessBenchmark.compile                                        /tmp/sbt_50a6156d  sample   18       18956.390 ±        470.882   ms/op
[info] HotShapelessBenchmark.compile:compile·p0.00                          /tmp/sbt_50a6156d  sample            18018.730                    ms/op
[info] HotShapelessBenchmark.compile:compile·p0.50                          /tmp/sbt_50a6156d  sample            19142.803                    ms/op
[info] HotShapelessBenchmark.compile:compile·p0.90                          /tmp/sbt_50a6156d  sample            19555.523                    ms/op
[info] HotShapelessBenchmark.compile:compile·p0.95                          /tmp/sbt_50a6156d  sample            19797.115                    ms/op
[info] HotShapelessBenchmark.compile:compile·p0.99                          /tmp/sbt_50a6156d  sample            19797.115                    ms/op
[info] HotShapelessBenchmark.compile:compile·p0.999                         /tmp/sbt_50a6156d  sample            19797.115                    ms/op
[info] HotShapelessBenchmark.compile:compile·p0.9999                        /tmp/sbt_50a6156d  sample            19797.115                    ms/op
[info] HotShapelessBenchmark.compile:compile·p1.00                          /tmp/sbt_50a6156d  sample            19797.115                    ms/op
[info] HotShapelessBenchmark.compile:·gc.alloc.rate                         /tmp/sbt_50a6156d  sample   18         176.279 ±          4.358  MB/sec
[info] HotShapelessBenchmark.compile:·gc.alloc.rate.norm                    /tmp/sbt_50a6156d  sample   18  3598116903.111 ±    8115563.410    B/op
[info] HotShapelessBenchmark.compile:·gc.churn.Compressed_Class_Space       /tmp/sbt_50a6156d  sample   18           0.005 ±          0.006  MB/sec
[info] HotShapelessBenchmark.compile:·gc.churn.Compressed_Class_Space.norm  /tmp/sbt_50a6156d  sample   18      110556.889 ±     121365.225    B/op
[info] HotShapelessBenchmark.compile:·gc.churn.Metaspace                    /tmp/sbt_50a6156d  sample   18           0.038 ±          0.042  MB/sec
[info] HotShapelessBenchmark.compile:·gc.churn.Metaspace.norm               /tmp/sbt_50a6156d  sample   18      796124.000 ±     874132.490    B/op
[info] HotShapelessBenchmark.compile:·gc.churn.PS_Eden_Space                /tmp/sbt_50a6156d  sample   18         176.622 ±         20.857  MB/sec
[info] HotShapelessBenchmark.compile:·gc.churn.PS_Eden_Space.norm           /tmp/sbt_50a6156d  sample   18  3611208362.667 ±  469187660.582    B/op
[info] HotShapelessBenchmark.compile:·gc.churn.PS_Old_Gen                   /tmp/sbt_50a6156d  sample   18           8.756 ±          9.432  MB/sec
[info] HotShapelessBenchmark.compile:·gc.churn.PS_Old_Gen.norm              /tmp/sbt_50a6156d  sample   18   181558790.222 ±  195372645.622    B/op
[info] HotShapelessBenchmark.compile:·gc.churn.PS_Survivor_Space            /tmp/sbt_50a6156d  sample   18           3.848 ±          2.094  MB/sec
[info] HotShapelessBenchmark.compile:·gc.churn.PS_Survivor_Space.norm       /tmp/sbt_50a6156d  sample   18    79276089.778 ±   44103533.796    B/op
[info] HotShapelessBenchmark.compile:·gc.count                              /tmp/sbt_50a6156d  sample   18          69.000                   counts
[info] HotShapelessBenchmark.compile:·gc.time                               /tmp/sbt_50a6156d  sample   18       11534.000                       ms
[info] WarmShapelessBenchmark.compile                                       /tmp/sbt_50a6156d  sample    3       53955.527 ±      89475.604   ms/op
[info] WarmShapelessBenchmark.compile:compile·p0.00                         /tmp/sbt_50a6156d  sample            49190.797                    ms/op
[info] WarmShapelessBenchmark.compile:compile·p0.50                         /tmp/sbt_50a6156d  sample            53687.091                    ms/op
[info] WarmShapelessBenchmark.compile:compile·p0.90                         /tmp/sbt_50a6156d  sample            58988.691                    ms/op
[info] WarmShapelessBenchmark.compile:compile·p0.95                         /tmp/sbt_50a6156d  sample            58988.691                    ms/op
[info] WarmShapelessBenchmark.compile:compile·p0.99                         /tmp/sbt_50a6156d  sample            58988.691                    ms/op
[info] WarmShapelessBenchmark.compile:compile·p0.999                        /tmp/sbt_50a6156d  sample            58988.691                    ms/op
[info] WarmShapelessBenchmark.compile:compile·p0.9999                       /tmp/sbt_50a6156d  sample            58988.691                    ms/op
[info] WarmShapelessBenchmark.compile:compile·p1.00                         /tmp/sbt_50a6156d  sample            58988.691                    ms/op
[info] WarmShapelessBenchmark.compile:·gc.alloc.rate                        /tmp/sbt_50a6156d  sample    3          69.162 ±        118.303  MB/sec
[info] WarmShapelessBenchmark.compile:·gc.alloc.rate.norm                   /tmp/sbt_50a6156d  sample    3  3964893128.000 ±  464895464.749    B/op
[info] WarmShapelessBenchmark.compile:·gc.churn.PS_Eden_Space               /tmp/sbt_50a6156d  sample    3          66.717 ±        172.841  MB/sec
[info] WarmShapelessBenchmark.compile:·gc.churn.PS_Eden_Space.norm          /tmp/sbt_50a6156d  sample    3  3813975968.000 ± 4155442809.041    B/op
[info] WarmShapelessBenchmark.compile:·gc.churn.PS_Survivor_Space           /tmp/sbt_50a6156d  sample    3           2.276 ±          3.402  MB/sec
[info] WarmShapelessBenchmark.compile:·gc.churn.PS_Survivor_Space.norm      /tmp/sbt_50a6156d  sample    3   130799010.667 ±  172919291.284    B/op
[info] WarmShapelessBenchmark.compile:·gc.count                             /tmp/sbt_50a6156d  sample    3          62.000                   counts
[info] WarmShapelessBenchmark.compile:·gc.time                              /tmp/sbt_50a6156d  sample    3        6208.000                       ms
[info] ColdShapelessBenchmark.compile                                       /tmp/sbt_50a6156d      ss   10       48121.431 ±       4706.772   ms/op
[info] ColdShapelessBenchmark.compile:·gc.alloc.rate                        /tmp/sbt_50a6156d      ss   10          81.244 ±          7.803  MB/sec
[info] ColdShapelessBenchmark.compile:·gc.alloc.rate.norm                   /tmp/sbt_50a6156d      ss   10  4169800629.600 ±   45813074.993    B/op
[info] ColdShapelessBenchmark.compile:·gc.churn.PS_Eden_Space               /tmp/sbt_50a6156d      ss   10          76.312 ±          9.530  MB/sec
[info] ColdShapelessBenchmark.compile:·gc.churn.PS_Eden_Space.norm          /tmp/sbt_50a6156d      ss   10  3915401249.600 ±  295384574.736    B/op
[info] ColdShapelessBenchmark.compile:·gc.churn.PS_Survivor_Space           /tmp/sbt_50a6156d      ss   10           2.624 ±          0.343  MB/sec
[info] ColdShapelessBenchmark.compile:·gc.churn.PS_Survivor_Space.norm      /tmp/sbt_50a6156d      ss   10   134746036.800 ±   13018312.058    B/op
[info] ColdShapelessBenchmark.compile:·gc.count                             /tmp/sbt_50a6156d      ss   10         217.000                   counts
[info] ColdShapelessBenchmark.compile:·gc.time                              /tmp/sbt_50a6156d      ss   10       20536.000                       ms
```

shapeless benchmark on `issue-245`:
```
[info] Benchmark                                                                   (_tempDir)    Mode  Cnt           Score            Error   Units
[info] HotShapelessBenchmark.compile                                        /tmp/sbt_f45f970f  sample   18       18440.025 ±        359.687   ms/op
[info] HotShapelessBenchmark.compile:compile·p0.00                          /tmp/sbt_f45f970f  sample            17750.295                    ms/op
[info] HotShapelessBenchmark.compile:compile·p0.50                          /tmp/sbt_f45f970f  sample            18522.046                    ms/op
[info] HotShapelessBenchmark.compile:compile·p0.90                          /tmp/sbt_f45f970f  sample            18911.278                    ms/op
[info] HotShapelessBenchmark.compile:compile·p0.95                          /tmp/sbt_f45f970f  sample            19092.472                    ms/op
[info] HotShapelessBenchmark.compile:compile·p0.99                          /tmp/sbt_f45f970f  sample            19092.472                    ms/op
[info] HotShapelessBenchmark.compile:compile·p0.999                         /tmp/sbt_f45f970f  sample            19092.472                    ms/op
[info] HotShapelessBenchmark.compile:compile·p0.9999                        /tmp/sbt_f45f970f  sample            19092.472                    ms/op
[info] HotShapelessBenchmark.compile:compile·p1.00                          /tmp/sbt_f45f970f  sample            19092.472                    ms/op
[info] HotShapelessBenchmark.compile:·gc.alloc.rate                         /tmp/sbt_f45f970f  sample   18         181.299 ±          3.589  MB/sec
[info] HotShapelessBenchmark.compile:·gc.alloc.rate.norm                    /tmp/sbt_f45f970f  sample   18  3603656596.889 ±   13617055.744    B/op
[info] HotShapelessBenchmark.compile:·gc.churn.Compressed_Class_Space       /tmp/sbt_f45f970f  sample   18           0.006 ±          0.006  MB/sec
[info] HotShapelessBenchmark.compile:·gc.churn.Compressed_Class_Space.norm  /tmp/sbt_f45f970f  sample   18      123574.667 ±     121374.571    B/op
[info] HotShapelessBenchmark.compile:·gc.churn.Metaspace                    /tmp/sbt_f45f970f  sample   18           0.044 ±          0.043  MB/sec
[info] HotShapelessBenchmark.compile:·gc.churn.Metaspace.norm               /tmp/sbt_f45f970f  sample   18      887152.444 ±     871235.644    B/op
[info] HotShapelessBenchmark.compile:·gc.churn.PS_Eden_Space                /tmp/sbt_f45f970f  sample   18         179.641 ±         24.247  MB/sec
[info] HotShapelessBenchmark.compile:·gc.churn.PS_Eden_Space.norm           /tmp/sbt_f45f970f  sample   18  3568843984.889 ±  463623900.493    B/op
[info] HotShapelessBenchmark.compile:·gc.churn.PS_Old_Gen                   /tmp/sbt_f45f970f  sample   18          10.104 ±          9.729  MB/sec
[info] HotShapelessBenchmark.compile:·gc.churn.PS_Old_Gen.norm              /tmp/sbt_f45f970f  sample   18   204088802.667 ±  196477548.292    B/op
[info] HotShapelessBenchmark.compile:·gc.churn.PS_Survivor_Space            /tmp/sbt_f45f970f  sample   18           4.046 ±          2.169  MB/sec
[info] HotShapelessBenchmark.compile:·gc.churn.PS_Survivor_Space.norm       /tmp/sbt_f45f970f  sample   18    81169088.889 ±   44090551.274    B/op
[info] HotShapelessBenchmark.compile:·gc.count                              /tmp/sbt_f45f970f  sample   18          69.000                   counts
[info] HotShapelessBenchmark.compile:·gc.time                               /tmp/sbt_f45f970f  sample   18       10385.000                       ms
[info] WarmShapelessBenchmark.compile                                       /tmp/sbt_f45f970f  sample    3       47624.924 ±      27981.257   ms/op
[info] WarmShapelessBenchmark.compile:compile·p0.00                         /tmp/sbt_f45f970f  sample            46640.660                    ms/op
[info] WarmShapelessBenchmark.compile:compile·p0.50                         /tmp/sbt_f45f970f  sample            46841.987                    ms/op
[info] WarmShapelessBenchmark.compile:compile·p0.90                         /tmp/sbt_f45f970f  sample            49392.124                    ms/op
[info] WarmShapelessBenchmark.compile:compile·p0.95                         /tmp/sbt_f45f970f  sample            49392.124                    ms/op
[info] WarmShapelessBenchmark.compile:compile·p0.99                         /tmp/sbt_f45f970f  sample            49392.124                    ms/op
[info] WarmShapelessBenchmark.compile:compile·p0.999                        /tmp/sbt_f45f970f  sample            49392.124                    ms/op
[info] WarmShapelessBenchmark.compile:compile·p0.9999                       /tmp/sbt_f45f970f  sample            49392.124                    ms/op
[info] WarmShapelessBenchmark.compile:compile·p1.00                         /tmp/sbt_f45f970f  sample            49392.124                    ms/op
[info] WarmShapelessBenchmark.compile:·gc.alloc.rate                        /tmp/sbt_f45f970f  sample    3          78.273 ±         46.764  MB/sec
[info] WarmShapelessBenchmark.compile:·gc.alloc.rate.norm                   /tmp/sbt_f45f970f  sample    3  3992337394.667 ±  248947971.262    B/op
[info] WarmShapelessBenchmark.compile:·gc.churn.PS_Eden_Space               /tmp/sbt_f45f970f  sample    3          75.365 ±         83.725  MB/sec
[info] WarmShapelessBenchmark.compile:·gc.churn.PS_Eden_Space.norm          /tmp/sbt_f45f970f  sample    3  3847142618.667 ± 4949482181.092    B/op
[info] WarmShapelessBenchmark.compile:·gc.churn.PS_Survivor_Space           /tmp/sbt_f45f970f  sample    3           2.590 ±          6.039  MB/sec
[info] WarmShapelessBenchmark.compile:·gc.churn.PS_Survivor_Space.norm      /tmp/sbt_f45f970f  sample    3   131857816.000 ±  240929409.334    B/op
[info] WarmShapelessBenchmark.compile:·gc.count                             /tmp/sbt_f45f970f  sample    3          61.000                   counts
[info] WarmShapelessBenchmark.compile:·gc.time                              /tmp/sbt_f45f970f  sample    3        5535.000                       ms
[info] ColdShapelessBenchmark.compile                                       /tmp/sbt_f45f970f      ss   10       44379.722 ±       3177.612   ms/op
[info] ColdShapelessBenchmark.compile:·gc.alloc.rate                        /tmp/sbt_f45f970f      ss   10          87.801 ±          5.691  MB/sec
[info] ColdShapelessBenchmark.compile:·gc.alloc.rate.norm                   /tmp/sbt_f45f970f      ss   10  4168487485.600 ±   58228600.899    B/op
[info] ColdShapelessBenchmark.compile:·gc.churn.PS_Eden_Space               /tmp/sbt_f45f970f      ss   10          81.738 ±          4.820  MB/sec
[info] ColdShapelessBenchmark.compile:·gc.churn.PS_Eden_Space.norm          /tmp/sbt_f45f970f      ss   10  3887614885.600 ±  360562942.522    B/op
[info] ColdShapelessBenchmark.compile:·gc.churn.PS_Survivor_Space           /tmp/sbt_f45f970f      ss   10           2.804 ±          0.359  MB/sec
[info] ColdShapelessBenchmark.compile:·gc.churn.PS_Survivor_Space.norm      /tmp/sbt_f45f970f      ss   10   133293604.800 ±   18777124.672    B/op
[info] ColdShapelessBenchmark.compile:·gc.count                             /tmp/sbt_f45f970f      ss   10         211.000                   counts
[info] ColdShapelessBenchmark.compile:·gc.time                              /tmp/sbt_f45f970f      ss   10       18743.000                       ms

```
