### PR TITLE
ClassfileManagerType to ClassFileManagerType name refactoring

### DIFF
--- a/internal/compiler-interface/src/main/contraband/incremental.json
+++ b/internal/compiler-interface/src/main/contraband/incremental.json
@@ -1,7 +1,7 @@
 {
   "types": [
     {
-      "name": "ClassfileManagerType",
+      "name": "ClassFileManagerType",
       "namespace": "xsbti.compile",
       "target": "Java",
       "type": "interface",
@@ -82,7 +82,7 @@
         },
         {
           "name": "classfileManagerType",
-          "type": "xsbti.Maybe<ClassfileManagerType>",
+          "type": "xsbti.Maybe<ClassFileManagerType>",
           "doc": "ClassfileManager that will handle class file deletion and addition during a single incremental compilation run."
         },
         {

--- a/internal/compiler-interface/src/main/java/xsbti/compile/IncOptionsUtil.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/IncOptionsUtil.java
@@ -58,8 +58,8 @@ public class IncOptionsUtil {
     return Maybe.<File>nothing();
   }
 
-  public static Maybe<ClassfileManagerType> defaultClassfileManagerType() {
-    return Maybe.<ClassfileManagerType>nothing();
+  public static Maybe<ClassFileManagerType> defaultClassFileManagerType() {
+    return Maybe.<ClassFileManagerType>nothing();
   }
 
   public static Maybe<Boolean> defaultRecompileOnMacroDef() {
@@ -121,7 +121,7 @@ public class IncOptionsUtil {
       defaultTransitiveStep(), defaultRecompileAllFraction(),
       defaultRelationsDebug(), defaultApiDebug(),
       defaultApiDiffContextSize(), defaultApiDumpDirectory(),
-      defaultClassfileManagerType(), defaultUseCustomizedFileManager(),
+      defaultClassFileManagerType(), defaultUseCustomizedFileManager(),
       defaultRecompileOnMacroDef(), defaultStoreApis(), defaultEnabled(),
       defaultExtra(), defaultLogRecompileOnMacro(), defaultExternal());
     return retval;
@@ -161,9 +161,9 @@ public class IncOptionsUtil {
     // TODO: Figure out how to specify the class file manager type.
     // if (values.containsKey(CLASSFILE_MANAGER_TYPE_KEY)) {
     //   if (values.get(CLASSFILE_MANAGER_TYPE_KEY).equals(XSBTI_NOTHING)) {
-    //     base = base.withClassfileManagerType(xsbti.Maybe.nothing<ClassfileManagerType>());
+    //     base = base.withClassFileManagerType(xsbti.Maybe.nothing<ClassfileManagerType>());
     //   } else {
-    //     base = base.withClassfileManagerType(???)
+    //     base = base.withClassFileManagerType(???)
     //   }
     // }
 

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -333,7 +333,7 @@ case class ProjectStructure(name: String, dependsOn: Vector[String], baseDirecto
       val sources = scalaSources ++ javaSources
       val prev0 = prev
       val lookup = new PerClasspathEntryLookupImpl(lookupAnalysis, Locate.definesClass)
-      val transactional: xsbti.Maybe[xsbti.compile.ClassfileManagerType] =
+      val transactional: xsbti.Maybe[xsbti.compile.ClassFileManagerType] =
         Maybe.just(new xsbti.compile.TransactionalManagerType(targetDir / "classes.bak", sbt.util.Logger.Null))
       // you can't specify class file manager in the properties files so let's overwrite it to be the transactional
       // one (that's the default for sbt)


### PR DESCRIPTION
Fix remaining naming inconsistency described in #254 .