### PR TITLE
Replace use of Scala collections by Java's - alternative version

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/API.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/API.scala
@@ -10,8 +10,8 @@ package xsbt
 import scala.tools.nsc.Phase
 import scala.tools.nsc.symtab.Flags
 import xsbti.api._
-import java.util.HashMap
-import java.util.ArrayList
+import java.util.{ArrayList, Map}
+import java.lang.Iterable
 
 object API {
   val name = "xsbt-api"
@@ -38,7 +38,7 @@ final class API(val global: CallbackGlobal) extends Compat with GlobalHelpers {
     def processUnit(unit: CompilationUnit) = if (!unit.isJava) processScalaUnit(unit)
     def processScalaUnit(unit: CompilationUnit): Unit = {
 
-      def debugOutput(map: HashMap[String, ArrayList[String]]): String = {
+      def debugOutput(map: Map[String, ArrayList[String]]): String = {
         val stringBuffer = new StringBuffer()
         val it = map.entrySet().iterator()
 
@@ -62,10 +62,10 @@ final class API(val global: CallbackGlobal) extends Compat with GlobalHelpers {
       val extractUsedNames = new ExtractUsedNames[global.type](global)
       val allUsedNames = extractUsedNames.extract(unit)
 
-      debuglog("The " + sourceFile + " contains the following used names:\n " + debugOutput(allUsedNames))
+      debuglog(s"The $sourceFile contains the following used names:\n ${debugOutput(allUsedNames)}")
 
       allUsedNames.forEach {
-        case (className: String, names: ArrayList[String]) =>
+        case (className: String, names: Iterable[String]) =>
           names.forEach { (name: String) => callback.usedName(className, name) }
       }
 

--- a/internal/compiler-bridge/src/main/scala/xsbt/API.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/API.scala
@@ -10,8 +10,9 @@ package xsbt
 import scala.tools.nsc.Phase
 import scala.tools.nsc.symtab.Flags
 import xsbti.api._
-import java.util.{ArrayList, Map}
+import java.util.Map
 import java.lang.Iterable
+import scala.language.existentials
 
 object API {
   val name = "xsbt-api"
@@ -38,7 +39,7 @@ final class API(val global: CallbackGlobal) extends Compat with GlobalHelpers {
     def processUnit(unit: CompilationUnit) = if (!unit.isJava) processScalaUnit(unit)
     def processScalaUnit(unit: CompilationUnit): Unit = {
 
-      def debugOutput(map: Map[String, ArrayList[String]]): String = {
+      def debugOutput(map: Map[String, _ <: Iterable[String]]): String = {
         val stringBuffer = new StringBuffer()
         val it = map.entrySet().iterator()
 
@@ -50,7 +51,7 @@ final class API(val global: CallbackGlobal) extends Compat with GlobalHelpers {
         stringBuffer.toString
       }
 
-      def showUsedNames(className: String, names: ArrayList[String]): String =
+      def showUsedNames(className: String, names: Iterable[String]): String =
         s"$className:\n\t${String.join(",", names)}"
 
       val sourceFile = unit.source.file.file
@@ -66,7 +67,7 @@ final class API(val global: CallbackGlobal) extends Compat with GlobalHelpers {
 
       allUsedNames.forEach {
         case (className: String, names: Iterable[String]) =>
-          names.forEach { (name: String) => callback.usedName(className, name) }
+          names.forEach { case (name: String) => callback.usedName(className, name) }
       }
 
       val classApis = traverser.allNonLocalClasses

--- a/internal/compiler-bridge/src/main/scala/xsbt/API.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/API.scala
@@ -10,6 +10,8 @@ package xsbt
 import scala.tools.nsc.Phase
 import scala.tools.nsc.symtab.Flags
 import xsbti.api._
+import java.util.HashMap
+import java.util.ArrayList
 
 object API {
   val name = "xsbt-api"
@@ -36,7 +38,7 @@ final class API(val global: CallbackGlobal) extends Compat with GlobalHelpers {
     def processUnit(unit: CompilationUnit) = if (!unit.isJava) processScalaUnit(unit)
     def processScalaUnit(unit: CompilationUnit): Unit = {
 
-      def debugOutput(map: => java.util.HashMap[String, java.util.ArrayList[String]]): String = {
+      def debugOutput(map: HashMap[String, ArrayList[String]]): String = {
         val stringBuffer = new StringBuffer()
         val it = map.entrySet().iterator()
 
@@ -48,7 +50,7 @@ final class API(val global: CallbackGlobal) extends Compat with GlobalHelpers {
         stringBuffer.toString
       }
 
-      def showUsedNames(className: String, names: java.util.ArrayList[String]): String =
+      def showUsedNames(className: String, names: ArrayList[String]): String =
         s"$className:\n\t${String.join(",", names)}"
 
       val sourceFile = unit.source.file.file
@@ -63,7 +65,7 @@ final class API(val global: CallbackGlobal) extends Compat with GlobalHelpers {
       debuglog("The " + sourceFile + " contains the following used names:\n " + debugOutput(allUsedNames))
 
       allUsedNames.forEach {
-        case (className: String, names: java.util.ArrayList[String]) =>
+        case (className: String, names: ArrayList[String]) =>
           names.forEach { (name: String) => callback.usedName(className, name) }
       }
 

--- a/internal/compiler-bridge/src/main/scala/xsbt/Dependency.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/Dependency.scala
@@ -15,6 +15,9 @@ import DependencyContext._
 import scala.tools.nsc.io.{ PlainFile, ZipArchive }
 import scala.tools.nsc.Phase
 
+import java.util.HashSet
+import java.util.HashMap
+
 object Dependency {
   def name = "xsbt-dependency"
 }
@@ -145,10 +148,10 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile with 
     private var inImportNode = false
 
     // Define caches for dependencies that have already been processed
-    private val _memberRefCache = new java.util.HashSet[ClassDependency]()
-    private val _inheritanceCache = new java.util.HashSet[ClassDependency]()
-    private val _localInheritanceCache = new java.util.HashSet[ClassDependency]()
-    private val _topLevelImportCache = new java.util.HashSet[Symbol]()
+    private val _memberRefCache = new HashSet[ClassDependency]()
+    private val _inheritanceCache = new HashSet[ClassDependency]()
+    private val _localInheritanceCache = new HashSet[ClassDependency]()
+    private val _topLevelImportCache = new HashSet[Symbol]()
 
     private var _currentDependencySource: Symbol = _
     private var _currentNonLocalClass: Symbol = _
@@ -215,7 +218,7 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile with 
      *   3. Inheritance.
      */
     private def addClassDependency(
-      cache: java.util.HashSet[ClassDependency],
+      cache: HashSet[ClassDependency],
       process: ClassDependency => Unit,
       fromClass: Symbol,
       dep: Symbol
@@ -274,7 +277,7 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile with 
         }
       }
 
-      val cache = new java.util.HashMap[Symbol, (Handler, java.util.HashSet[Type])]()
+      val cache = new HashMap[Symbol, (Handler, HashSet[Type])]()
       private var handler: Handler = _
       private var visitedOwner: Symbol = _
       def setOwner(owner: Symbol) = {
@@ -284,7 +287,7 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile with 
             visited = ts
             handler = h
           } else {
-            val newVisited = new java.util.HashSet[Type]()
+            val newVisited = new HashSet[Type]()
             handler = createHandler(owner)
             cache.put(owner, handler -> newVisited)
             visited = newVisited
@@ -318,7 +321,7 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile with 
      *     https://github.com/sbt/sbt/issues/1237
      *     https://github.com/sbt/sbt/issues/1544
      */
-    private val inspectedOriginalTrees = new java.util.HashSet[Tree]()
+    private val inspectedOriginalTrees = new HashSet[Tree]()
 
     override def traverse(tree: Tree): Unit = tree match {
       case Import(expr, selectors) =>

--- a/internal/compiler-bridge/src/main/scala/xsbt/Dependency.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/Dependency.scala
@@ -8,7 +8,6 @@
 package xsbt
 
 import java.io.File
-import java.util
 
 import xsbti.api.DependencyContext
 import DependencyContext._
@@ -146,10 +145,10 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile with 
     private var inImportNode = false
 
     // Define caches for dependencies that have already been processed
-    private val _memberRefCache = new util.HashSet[ClassDependency]()
-    private val _inheritanceCache = new util.HashSet[ClassDependency]()
-    private val _localInheritanceCache = new util.HashSet[ClassDependency]()
-    private val _topLevelImportCache = new util.HashSet[Symbol]()
+    private val _memberRefCache = new java.util.HashSet[ClassDependency]()
+    private val _inheritanceCache = new java.util.HashSet[ClassDependency]()
+    private val _localInheritanceCache = new java.util.HashSet[ClassDependency]()
+    private val _topLevelImportCache = new java.util.HashSet[Symbol]()
 
     private var _currentDependencySource: Symbol = _
     private var _currentNonLocalClass: Symbol = _
@@ -216,7 +215,7 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile with 
      *   3. Inheritance.
      */
     private def addClassDependency(
-      cache: util.HashSet[ClassDependency],
+      cache: java.util.HashSet[ClassDependency],
       process: ClassDependency => Unit,
       fromClass: Symbol,
       dep: Symbol
@@ -275,7 +274,7 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile with 
         }
       }
 
-      val cache = new util.HashMap[Symbol, (Handler, util.HashSet[Type])]()
+      val cache = new java.util.HashMap[Symbol, (Handler, java.util.HashSet[Type])]()
       private var handler: Handler = _
       private var visitedOwner: Symbol = _
       def setOwner(owner: Symbol) = {
@@ -285,7 +284,7 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile with 
             visited = ts
             handler = h
           } else {
-            val newVisited = new util.HashSet[Type]()
+            val newVisited = new java.util.HashSet[Type]()
             handler = createHandler(owner)
             cache.put(owner, handler -> newVisited)
             visited = newVisited
@@ -319,7 +318,7 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile with 
      *     https://github.com/sbt/sbt/issues/1237
      *     https://github.com/sbt/sbt/issues/1544
      */
-    private val inspectedOriginalTrees = new util.HashSet[Tree]()
+    private val inspectedOriginalTrees = new java.util.HashSet[Tree]()
 
     override def traverse(tree: Tree): Unit = tree match {
       case Import(expr, selectors) =>

--- a/internal/compiler-bridge/src/main/scala/xsbt/Dependency.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/Dependency.scala
@@ -282,16 +282,16 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile with 
       private var visitedOwner: Symbol = _
       def setOwner(owner: Symbol) = {
         if (visitedOwner != owner) {
-          if (cache.containsKey(owner)) {
-            val (h, ts) = cache.get(owner)
-            visited = ts
-            handler = h
-          } else {
-            val newVisited = new HashSet[Type]()
-            handler = createHandler(owner)
-            cache.put(owner, handler -> newVisited)
-            visited = newVisited
-            visitedOwner = owner
+          cache.get(owner) match {
+            case null =>
+              val newVisited = new HashSet[Type]()
+              handler = createHandler(owner)
+              cache.put(owner, handler -> newVisited)
+              visited = newVisited
+              visitedOwner = owner
+            case (h, ts) =>
+              visited = ts
+              handler = h
           }
         }
       }

--- a/internal/compiler-bridge/src/main/scala/xsbt/ExtractUsedNames.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ExtractUsedNames.scala
@@ -7,6 +7,10 @@
 
 package xsbt
 
+import java.util.ArrayList
+import java.util.HashMap
+import java.util.HashSet
+
 import Compat._
 
 /**
@@ -48,7 +52,7 @@ import Compat._
 class ExtractUsedNames[GlobalType <: CallbackGlobal](val global: GlobalType) extends Compat with ClassName with GlobalHelpers {
   import global._
 
-  def extract(unit: CompilationUnit): java.util.HashMap[String, java.util.ArrayList[String]] = {
+  def extract(unit: CompilationUnit): HashMap[String, ArrayList[String]] = {
     val tree = unit.body
     val traverser = new ExtractUsedNamesTraverser
     traverser.traverse(tree)
@@ -67,14 +71,14 @@ class ExtractUsedNames[GlobalType <: CallbackGlobal](val global: GlobalType) ext
       }
     }
 
-    val result = new java.util.HashMap[String, java.util.ArrayList[String]]()
+    val result = new HashMap[String, ArrayList[String]]()
 
     val it = traverser.usedNamesFromClasses.entrySet().iterator()
     while (it.hasNext) {
       val usedName = it.next()
       val usedNameKey = usedName.getKey.toString.trim
       val usedNameValues = usedName.getValue.iterator()
-      val uses = new java.util.ArrayList[String]()
+      val uses = new ArrayList[String]()
       while (usedNameValues.hasNext) {
         uses + usedNameValues.next().decode.trim
       }
@@ -92,8 +96,8 @@ class ExtractUsedNames[GlobalType <: CallbackGlobal](val global: GlobalType) ext
   }
 
   private class ExtractUsedNamesTraverser extends Traverser {
-    val usedNamesFromClasses = new java.util.HashMap[Name, java.util.HashSet[Name]]()
-    val namesUsedAtTopLevel = new java.util.HashSet[Name]()
+    val usedNamesFromClasses = new HashMap[Name, HashSet[Name]]()
+    val namesUsedAtTopLevel = new HashSet[Name]()
 
     override def traverse(tree: Tree): Unit = {
       handleClassicTreeNode(tree)
@@ -102,7 +106,7 @@ class ExtractUsedNames[GlobalType <: CallbackGlobal](val global: GlobalType) ext
     }
 
     val addSymbol = {
-      (names: java.util.HashSet[Name], symbol: Symbol) =>
+      (names: HashSet[Name], symbol: Symbol) =>
         if (!ignoredSymbol(symbol)) {
           val name = symbol.name
           // Synthetic names are no longer included. See https://github.com/sbt/sbt/issues/2537
@@ -113,11 +117,11 @@ class ExtractUsedNames[GlobalType <: CallbackGlobal](val global: GlobalType) ext
     }
 
     /** Returns mutable set with all names from given class used in current context */
-    def usedNamesFromClass(className: Name): java.util.HashSet[Name] = {
+    def usedNamesFromClass(className: Name): HashSet[Name] = {
       if (usedNamesFromClasses.containsKey(className)) {
         usedNamesFromClasses.get(className)
       } else {
-        val emptySet = new java.util.HashSet[Name]()
+        val emptySet = new HashSet[Name]()
         usedNamesFromClasses.put(className, emptySet)
         emptySet
       }
@@ -130,8 +134,8 @@ class ExtractUsedNames[GlobalType <: CallbackGlobal](val global: GlobalType) ext
      *     https://github.com/sbt/sbt/issues/1237
      *     https://github.com/sbt/sbt/issues/1544
      */
-    private val inspectedOriginalTrees = new java.util.HashSet[Tree]()
-    private val inspectedTypeTrees = new java.util.HashSet[Tree]()
+    private val inspectedOriginalTrees = new HashSet[Tree]()
+    private val inspectedTypeTrees = new HashSet[Tree]()
 
     private val handleMacroExpansion: Tree => Unit = { original =>
       if (!inspectedOriginalTrees.contains(original)) {
@@ -141,17 +145,17 @@ class ExtractUsedNames[GlobalType <: CallbackGlobal](val global: GlobalType) ext
     }
 
     private object TypeDependencyTraverser extends TypeDependencyTraverser {
-      private var ownersCache = new java.util.HashMap[Symbol, java.util.HashSet[Type]]()
-      private var nameCache: java.util.HashSet[Name] = _
+      private var ownersCache = new HashMap[Symbol, HashSet[Type]]()
+      private var nameCache: HashSet[Name] = _
       private var ownerVisited: Symbol = _
 
-      def setCacheAndOwner(cache: java.util.HashSet[Name], owner: Symbol) = {
+      def setCacheAndOwner(cache: HashSet[Name], owner: Symbol) = {
         if (ownerVisited != owner) {
           if (ownersCache.containsKey(owner)) {
             val ts = ownersCache.get(owner)
             visited = ts
           } else {
-            val newVisited = new java.util.HashSet[Type]()
+            val newVisited = new HashSet[Type]()
             visited = newVisited
             ownersCache.put(owner, newVisited)
           }
@@ -205,7 +209,7 @@ class ExtractUsedNames[GlobalType <: CallbackGlobal](val global: GlobalType) ext
 
     private var _currentOwner: Symbol = _
     private var _currentNonLocalClass: Symbol = _
-    private var _currentNamesCache: java.util.HashSet[Name] = _
+    private var _currentNamesCache: HashSet[Name] = _
 
     @inline private def resolveNonLocal(from: Symbol): Symbol = {
       val fromClass = enclOrModuleClass(from)
@@ -213,7 +217,7 @@ class ExtractUsedNames[GlobalType <: CallbackGlobal](val global: GlobalType) ext
       else localToNonLocalClass.resolveNonLocal(fromClass)
     }
 
-    @inline private def getNames(nonLocalClass: Symbol): java.util.HashSet[Name] = {
+    @inline private def getNames(nonLocalClass: Symbol): HashSet[Name] = {
       if (nonLocalClass == NoSymbol) namesUsedAtTopLevel
       else usedNamesFromClass(ExtractUsedNames.this.className(nonLocalClass))
     }
@@ -233,7 +237,7 @@ class ExtractUsedNames[GlobalType <: CallbackGlobal](val global: GlobalType) ext
      *        `_currentNonLocalClass`.
      *   2. Otherwise, overwrite all the pertinent fields to be consistent.
      */
-    private def getNamesOfEnclosingScope: java.util.HashSet[Name] = {
+    private def getNamesOfEnclosingScope: HashSet[Name] = {
       if (_currentOwner == null) {
         // Set the first state for the enclosing non-local class
         _currentOwner = currentOwner

--- a/internal/compiler-bridge/src/main/scala/xsbt/ExtractUsedNames.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ExtractUsedNames.scala
@@ -8,6 +8,7 @@
 package xsbt
 
 import java.util.ArrayList
+import java.util.Map
 import java.util.HashMap
 import java.util.HashSet
 
@@ -52,7 +53,7 @@ import Compat._
 class ExtractUsedNames[GlobalType <: CallbackGlobal](val global: GlobalType) extends Compat with ClassName with GlobalHelpers {
   import global._
 
-  def extract(unit: CompilationUnit): HashMap[String, ArrayList[String]] = {
+  def extract(unit: CompilationUnit): Map[String, ArrayList[String]] = {
     val tree = unit.body
     val traverser = new ExtractUsedNamesTraverser
     traverser.traverse(tree)
@@ -75,14 +76,14 @@ class ExtractUsedNames[GlobalType <: CallbackGlobal](val global: GlobalType) ext
 
     val it = traverser.usedNamesFromClasses.entrySet().iterator()
     while (it.hasNext) {
-      val usedName = it.next()
-      val usedNameKey = usedName.getKey.toString.trim
-      val usedNameValues = usedName.getValue.iterator()
-      val uses = new ArrayList[String]()
+      val usedNamePair = it.next()
+      val usedName = usedNamePair.getKey.toString.trim
+      val usedNameValues = usedNamePair.getValue.iterator()
+      val usesForName = new ArrayList[String](usedNamePair.getValue.size)
       while (usedNameValues.hasNext) {
-        uses.add(usedNameValues.next().decode.trim)
+        usesForName.add(usedNameValues.next().decode.trim)
       }
-      result.put(usedNameKey, uses)
+      result.put(usedName, usesForName)
     }
     result
   }

--- a/internal/compiler-bridge/src/main/scala/xsbt/ExtractUsedNames.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ExtractUsedNames.scala
@@ -80,7 +80,7 @@ class ExtractUsedNames[GlobalType <: CallbackGlobal](val global: GlobalType) ext
       val usedNameValues = usedName.getValue.iterator()
       val uses = new ArrayList[String]()
       while (usedNameValues.hasNext) {
-        uses + usedNameValues.next().decode.trim
+        uses.add(usedNameValues.next().decode.trim)
       }
       result.put(usedNameKey, uses)
     }

--- a/internal/compiler-bridge/src/main/scala/xsbt/ExtractUsedNames.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ExtractUsedNames.scala
@@ -8,10 +8,8 @@
 package xsbt
 
 import java.util.ArrayList
-import java.util.Map
 import java.util.HashMap
 import java.util.HashSet
-import java.lang.Iterable
 
 import Compat._
 
@@ -54,7 +52,7 @@ import Compat._
 class ExtractUsedNames[GlobalType <: CallbackGlobal](val global: GlobalType) extends Compat with ClassName with GlobalHelpers {
   import global._
 
-  def extract(unit: CompilationUnit): Map[String, _ <: Iterable[String]] = {
+  def extract(unit: CompilationUnit): HashMap[String, ArrayList[String]] = {
     val tree = unit.body
     val traverser = new ExtractUsedNamesTraverser
     traverser.traverse(tree)

--- a/internal/compiler-bridge/src/main/scala/xsbt/ExtractUsedNames.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ExtractUsedNames.scala
@@ -118,12 +118,13 @@ class ExtractUsedNames[GlobalType <: CallbackGlobal](val global: GlobalType) ext
 
     /** Returns mutable set with all names from given class used in current context */
     def usedNamesFromClass(className: Name): HashSet[Name] = {
-      if (usedNamesFromClasses.containsKey(className)) {
-        usedNamesFromClasses.get(className)
-      } else {
+      val ts = usedNamesFromClasses.get(className)
+      if (ts == null) {
         val emptySet = new HashSet[Name]()
         usedNamesFromClasses.put(className, emptySet)
         emptySet
+      } else {
+        ts
       }
     }
 
@@ -151,14 +152,16 @@ class ExtractUsedNames[GlobalType <: CallbackGlobal](val global: GlobalType) ext
 
       def setCacheAndOwner(cache: HashSet[Name], owner: Symbol) = {
         if (ownerVisited != owner) {
-          if (ownersCache.containsKey(owner)) {
-            val ts = ownersCache.get(owner)
-            visited = ts
-          } else {
+          val ts = ownersCache.get(owner)
+
+          if (ts == null) {
             val newVisited = new HashSet[Type]()
             visited = newVisited
             ownersCache.put(owner, newVisited)
+          } else {
+            visited = ts
           }
+
           nameCache = cache
           ownerVisited = owner
         }

--- a/internal/compiler-bridge/src/main/scala/xsbt/ExtractUsedNames.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ExtractUsedNames.scala
@@ -11,6 +11,7 @@ import java.util.ArrayList
 import java.util.Map
 import java.util.HashMap
 import java.util.HashSet
+import java.lang.Iterable
 
 import Compat._
 
@@ -53,7 +54,7 @@ import Compat._
 class ExtractUsedNames[GlobalType <: CallbackGlobal](val global: GlobalType) extends Compat with ClassName with GlobalHelpers {
   import global._
 
-  def extract(unit: CompilationUnit): Map[String, ArrayList[String]] = {
+  def extract(unit: CompilationUnit): Map[String, _ <: Iterable[String]] = {
     val tree = unit.body
     val traverser = new ExtractUsedNamesTraverser
     traverser.traverse(tree)

--- a/internal/compiler-bridge/src/main/scala/xsbt/GlobalHelpers.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/GlobalHelpers.scala
@@ -8,6 +8,7 @@
 package xsbt
 
 import scala.tools.nsc.Global
+import java.util.HashSet
 
 trait GlobalHelpers { self: Compat =>
   val global: Global
@@ -57,7 +58,7 @@ trait GlobalHelpers { self: Compat =>
     }
 
     // Define cache and populate it with known types at initialization time
-    protected var visited = new java.util.HashSet[Type]()
+    protected var visited = new HashSet[Type]()
 
     /** Clear the cache after every `traverse` invocation at the call-site. */
     protected def reinitializeVisited(): Unit = visited.clear()

--- a/internal/compiler-bridge/src/main/scala/xsbt/GlobalHelpers.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/GlobalHelpers.scala
@@ -7,8 +7,6 @@
 
 package xsbt
 
-import java.util
-
 import scala.tools.nsc.Global
 
 trait GlobalHelpers { self: Compat =>
@@ -59,7 +57,7 @@ trait GlobalHelpers { self: Compat =>
     }
 
     // Define cache and populate it with known types at initialization time
-    protected var visited = new util.HashSet[Type]()
+    protected var visited = new java.util.HashSet[Type]()
 
     /** Clear the cache after every `traverse` invocation at the call-site. */
     protected def reinitializeVisited(): Unit = visited.clear()

--- a/internal/compiler-bridge/src/main/scala/xsbt/GlobalHelpers.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/GlobalHelpers.scala
@@ -7,6 +7,8 @@
 
 package xsbt
 
+import java.util
+
 import scala.tools.nsc.Global
 
 trait GlobalHelpers { self: Compat =>
@@ -57,7 +59,7 @@ trait GlobalHelpers { self: Compat =>
     }
 
     // Define cache and populate it with known types at initialization time
-    protected var visited = scala.collection.mutable.HashSet.empty[Type]
+    protected var visited = new util.HashSet[Type]()
 
     /** Clear the cache after every `traverse` invocation at the call-site. */
     protected def reinitializeVisited(): Unit = visited.clear()
@@ -70,7 +72,7 @@ trait GlobalHelpers { self: Compat =>
      */
     override def traverse(tpe: Type): Unit = {
       if ((tpe ne NoType) && !visited.contains(tpe)) {
-        visited += tpe
+        visited.add(tpe)
         tpe match {
           case singleRef: SingleType =>
             addTypeDependency(singleRef)

--- a/internal/compiler-bridge/src/test/scala/xsbt/ExtractUsedNamesSpecification.scala
+++ b/internal/compiler-bridge/src/test/scala/xsbt/ExtractUsedNamesSpecification.scala
@@ -13,6 +13,8 @@ class ExtractUsedNamesSpecification extends UnitSpec {
     val usedNames = compilerForTesting.extractUsedNamesFromSrc(src)
     val expectedNames = standardNames ++ Set("a", "A", "A2", "b")
     // names used at top level are attributed to the first class defined in a compilation unit
+
+    println(usedNames)
     assert(usedNames("a.A") === expectedNames)
   }
 

--- a/internal/compiler-bridge/src/test/scala/xsbt/ExtractUsedNamesSpecification.scala
+++ b/internal/compiler-bridge/src/test/scala/xsbt/ExtractUsedNamesSpecification.scala
@@ -14,7 +14,6 @@ class ExtractUsedNamesSpecification extends UnitSpec {
     val expectedNames = standardNames ++ Set("a", "A", "A2", "b")
     // names used at top level are attributed to the first class defined in a compilation unit
 
-    println(usedNames)
     assert(usedNames("a.A") === expectedNames)
   }
 


### PR DESCRIPTION
Alternative to: https://github.com/sbt/zinc/pull/253

In this PR I'm using `allUsedNames.asScala.foreach{....}`