### PR TITLE
Fix compiler warnings

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/Analyzer.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/Analyzer.scala
@@ -7,14 +7,7 @@
 
 package xsbt
 
-import scala.tools.nsc.{ io, plugins, symtab, Global, Phase }
-import io.{ AbstractFile, PlainFile, ZipArchive }
-import plugins.{ Plugin, PluginComponent }
-import scala.collection.mutable.{ HashMap, HashSet, Map, Set }
-
-import java.io.File
-import java.util.zip.ZipFile
-import xsbti.AnalysisCallback
+import scala.tools.nsc.Phase
 
 object Analyzer {
   def name = "xsbt-analyzer"

--- a/internal/compiler-bridge/src/main/scala/xsbt/Command.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/Command.scala
@@ -20,8 +20,8 @@ object Command {
     try {
       constr(classOf[List[_]], classOf[Settings]).newInstance(arguments, settings)
     } catch {
-      case e: NoSuchMethodException =>
-        constr(classOf[List[_]], classOf[Settings], classOf[Function1[_, _]], classOf[Boolean]).newInstance(arguments, settings, (s: String) => throw new RuntimeException(s), false.asInstanceOf[AnyRef])
+      case _: NoSuchMethodException =>
+        constr(classOf[List[_]], classOf[Settings], classOf[(_) => _], classOf[Boolean]).newInstance(arguments, settings, (s: String) => throw new RuntimeException(s), false.asInstanceOf[AnyRef])
     }
   }
 

--- a/internal/compiler-bridge/src/main/scala/xsbt/CompilerInterface.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CompilerInterface.scala
@@ -10,7 +10,6 @@ package xsbt
 import xsbti.{ AnalysisCallback, Logger, Problem, Reporter, Severity }
 import xsbti.compile._
 import scala.tools.nsc.{ io, reporters, Phase, Global, Settings, SubComponent }
-import scala.tools.nsc.util.ClassPath
 import io.AbstractFile
 import scala.collection.mutable
 import Log.debug

--- a/internal/compiler-bridge/src/main/scala/xsbt/ConsoleInterface.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ConsoleInterface.scala
@@ -8,10 +8,9 @@
 package xsbt
 
 import xsbti.Logger
-import scala.tools.nsc.{ GenericRunnerCommand, Interpreter, ObjectRunner, Settings }
+import scala.tools.nsc.{ GenericRunnerCommand, Settings }
 import scala.tools.nsc.interpreter.{ IMain, InteractiveReader, ILoop }
 import scala.tools.nsc.reporters.Reporter
-import scala.tools.nsc.util.ClassPath
 
 class ConsoleInterface {
   def commandArguments(args: Array[String], bootClasspathString: String, classpathString: String, log: Logger): Array[String] =

--- a/internal/compiler-bridge/src/main/scala/xsbt/DelegatingReporter.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/DelegatingReporter.scala
@@ -77,8 +77,8 @@ private final class DelegatingReporter(warnFatal: Boolean, noWarn: Boolean, priv
       val posOpt =
         Option(posIn) match {
           case None | Some(NoPosition) => None
-          case Some(x: FakePos)        => None
-          case x                       => Option(posIn.finalPosition)
+          case Some(_: FakePos)        => None
+          case _                       => Option(posIn.finalPosition)
         }
       posOpt match {
         case None      => new PositionImpl(None, None, None, "", None, None, None)
@@ -94,7 +94,7 @@ private final class DelegatingReporter(warnFatal: Boolean, noWarn: Boolean, priv
       val lineContent = pos.lineContent.stripLineEnd
       val offset = pos.point
       val pointer = offset - src.lineToOffset(src.offsetToLine(offset))
-      val pointerSpace = ((lineContent: Seq[Char]).take(pointer).map { case '\t' => '\t'; case x => ' ' }).mkString
+      val pointerSpace = (lineContent: Seq[Char]).take(pointer).map { case '\t' => '\t'; case x => ' ' }.mkString
       new PositionImpl(Option(sourcePath), Option(sourceFile), Option(line), lineContent, Option(offset), Option(pointer), Option(pointerSpace))
     }
 

--- a/internal/compiler-bridge/src/main/scala/xsbt/ExtractUsedNames.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ExtractUsedNames.scala
@@ -162,6 +162,7 @@ class ExtractUsedNames[GlobalType <: CallbackGlobal](val global: GlobalType) ext
         def usedNameInImportSelector(name: Name): Unit = {
           if (!isEmptyName(name) && (name != nme.WILDCARD) && !names.contains(name)) {
             names += name
+            ()
           }
         }
         selectors foreach { selector =>

--- a/internal/compiler-bridge/src/main/scala/xsbt/LocateClassFile.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/LocateClassFile.scala
@@ -8,7 +8,6 @@
 package xsbt
 
 import scala.reflect.io.NoAbstractFile
-import scala.tools.nsc.symtab.Flags
 import scala.tools.nsc.io.AbstractFile
 
 import java.io.File

--- a/internal/compiler-bridge/src/main/scala/xsbt/ScaladocInterface.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ScaladocInterface.scala
@@ -21,7 +21,6 @@ private class Runner(args: Array[String], log: Logger, delegate: xsbti.Reporter)
   val reporter = DelegatingReporter(docSettings, delegate)
   def noErrors = !reporter.hasErrors && command.ok
 
-  import forScope._
   def run(): Unit = {
     debug(log, "Calling Scaladoc with arguments:\n\t" + args.mkString("\n\t"))
     if (noErrors) {
@@ -59,7 +58,6 @@ private class Runner(args: Array[String], log: Logger, delegate: xsbti.Reporter)
 
         val generator =
           {
-            import doc._
             new DefaultDocDriver {
               lazy val global: compiler.type = compiler
               lazy val settings = docSettings

--- a/internal/compiler-bridge/src/test/scala/xsbt/ClassNameSpecification.scala
+++ b/internal/compiler-bridge/src/test/scala/xsbt/ClassNameSpecification.scala
@@ -1,9 +1,5 @@
 package xsbt
 
-import xsbti.api.ClassLike
-import xsbti.api.Def
-import xsbt.api.SameAPI
-
 import sbt.internal.util.UnitSpec
 
 class ClassNameSpecification extends UnitSpec {

--- a/internal/compiler-bridge/src/test/scala/xsbt/ExtractUsedNamesPerformanceSpecification.scala
+++ b/internal/compiler-bridge/src/test/scala/xsbt/ExtractUsedNamesPerformanceSpecification.scala
@@ -34,10 +34,10 @@ class ExtractUsedNamesPerformanceSpecification extends UnitSpec {
       zipfs = initFileSystem(fileUri)
       new String(Files.readAllBytes(Paths.get(fileUri)))
     } finally
-      zipfs.foreach { fs => try fs.close catch { case _: Throwable => /*ignore*/ } }
+      zipfs.foreach { fs => try fs.close() catch { case _: Throwable => /*ignore*/ } }
     import org.scalatest.concurrent.Timeouts._
     import org.scalatest.time.SpanSugar._
-    val usedNames = failAfter(20 seconds) {
+    val usedNames = failAfter(30 seconds) {
       val compilerForTesting = new ScalaCompilerForUnitTesting
       compilerForTesting.extractUsedNamesFromSrc(src)
     }
@@ -93,7 +93,7 @@ class ExtractUsedNamesPerformanceSpecification extends UnitSpec {
                  |  def bar[Out] = macro Foo.foo_impl[Out]
                  |}""".stripMargin
     val compilerForTesting = new ScalaCompilerForUnitTesting
-    val (_, analysis) = compilerForTesting.compileSrcs(List(List(ext), List(cod)), true)
+    val (_, analysis) = compilerForTesting.compileSrcs(List(List(ext), List(cod)), reuseCompilerInstance = true)
     val usedNames = analysis.usedNames.toMap
 
     val expectedNamesForFoo = Set("TypeApplyExtractor", "mkIdent", "package", "<repeated>", "tpe", "in", "$u", "internal", "reify", "WeakTypeTag", "Name", "empty", "collection", "ThisType", "staticModule", "staticPackage", "Singleton", "T", "asInstanceOf", "ReificationSupportApi", "U", "Expr", "Universe", "TypeApply", "A", "Tree", "Nothing", "acme", "ClassSymbol", "blackbox", "AnyRef", "Context", "mkTypeTree", "immutable", "SelectExtractor", "<init>", "$treecreator1", "apply", "Object", "macros", "moduleClass", "Foo", "T0", "Symbol", "Predef", "scala", "asModule", "Internal", "$m", "TypeCreator", "TermNameExtractor", "ModuleSymbol", "staticClass", "universe", "c", "<refinement>", "TypeTree", "List", "Select", "TermName", "Mirror", "atag", "reificationSupport", "rootMirror", "reflect", "TypeRef", "Ident", "Any", "TreeCreator", "$typecreator2", "$m$untyped", "String", "Type")

--- a/internal/compiler-bridge/src/test/scala/xsbt/ScalaCompilerForUnitTesting.scala
+++ b/internal/compiler-bridge/src/test/scala/xsbt/ScalaCompilerForUnitTesting.scala
@@ -3,7 +3,6 @@ package xsbt
 import xsbti.TestCallback.ExtractedClassDependencies
 import xsbti.compile.SingleOutput
 import java.io.File
-import _root_.scala.tools.nsc.reporters.ConsoleReporter
 import xsbti._
 import sbt.io.IO.withTemporaryDirectory
 import xsbti.api.ClassLike
@@ -138,7 +137,7 @@ class ScalaCompilerForUnitTesting {
         val compiler = if (reuseCompilerInstance) commonCompilerInstance else
           prepareCompiler(classesDir, analysisCallback, classesDir.toString)
         val run = new compiler.Run
-        val srcFiles = compilationUnit.toSeq.zipWithIndex map {
+        val srcFiles = compilationUnit.zipWithIndex map {
           case (src, i) =>
             val fileName = s"Test-$unitId-$i.scala"
             prepareSrcFile(temp, fileName, src)
@@ -150,7 +149,7 @@ class ScalaCompilerForUnitTesting {
         srcFilePaths.foreach(f => new File(f).delete)
         srcFiles
       }
-      (files.flatten.toSeq, analysisCallback)
+      (files.flatten, analysisCallback)
     }
   }
 
@@ -175,7 +174,6 @@ class ScalaCompilerForUnitTesting {
     val settings = cachedCompiler.settings
     settings.classpath.value = classpath
     settings.usejavacp.value = true
-    val scalaReporter = new ConsoleReporter(settings)
     val delegatingReporter = DelegatingReporter(settings, ConsoleReporter)
     val compiler = cachedCompiler.compiler
     compiler.set(analysisCallback, delegatingReporter)

--- a/internal/compiler-interface/src/main/java/xsbti/compile/ScalaInstance.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/ScalaInstance.java
@@ -32,12 +32,15 @@ public interface ScalaInstance {
 	ClassLoader loader();
 
 	/** @deprecated Only `jars` can be reliably provided for modularized Scala (since 0.13.0). */
+	@Deprecated
 	File libraryJar();
 
 	/** @deprecated Only `jars` can be reliably provided for modularized Scala (since 0.13.0). */
+	@Deprecated
 	File compilerJar();
 
 	/** @deprecated Only `jars` can be reliably provided for modularized Scala (since 0.13.0). */
+	@Deprecated
 	File[] otherJars();
 
 	/** All jar files provided by this Scala instance. */

--- a/internal/zinc-apiinfo/src/main/scala/xsbt/api/APIUtil.scala
+++ b/internal/zinc-apiinfo/src/main/scala/xsbt/api/APIUtil.scala
@@ -8,7 +8,6 @@
 package xsbt.api
 
 import xsbti.api._
-import scala.collection.mutable.HashSet
 
 object APIUtil {
   val modifiersToByte = (m: Modifiers) => {

--- a/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/ClassToAPISpecification.scala
+++ b/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/ClassToAPISpecification.scala
@@ -78,7 +78,7 @@ class ClassToAPISpecification extends UnitSpec {
     val (apis, inherits) = ClassToAPI.process(classes)
     apis.foreach(callback.api(source, _))
     inherits.map {
-      case (from: Class[_], to: Class[_]) => (from.getName, to.getName)
+      case (from, to) => (from.getName, to.getName)
     }
   }
 

--- a/internal/zinc-apiinfo/src/test/scala/xsbt/api/NameHashingSpecification.scala
+++ b/internal/zinc-apiinfo/src/test/scala/xsbt/api/NameHashingSpecification.scala
@@ -220,11 +220,6 @@ class NameHashingSpecification extends UnitSpec {
     simpleClassLike(name, structure)
   }
 
-  private def simpleClassDef(name: String, dt: DefinitionType = DefinitionType.ClassDef,
-    access: Access = publicAccess): ClassLikeDef = {
-    new ClassLikeDef(name, access, defaultModifiers, Array.empty, Array.empty, dt)
-  }
-
   private def simpleObject(name: String, defs: ClassDefinition*): ClassLike = {
     val structure = simpleStructure(defs: _*)
     simpleClassLike(name, structure, dt = DefinitionType.Module)

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/ClassFile.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/ClassFile.scala
@@ -11,7 +11,6 @@ package inc
 package classfile
 
 import Constants._
-import java.io.File
 
 private[sbt] trait ClassFile {
   val majorVersion: Int

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Parser.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Parser.scala
@@ -75,14 +75,14 @@ private[sbt] object Parser {
             else Some(toUTF8(index))
           }
         private def parseFieldOrMethodInfo() =
-          new FieldOrMethodInfo(in.readUnsignedShort(), toString(in.readUnsignedShort()), toString(in.readUnsignedShort()),
+          FieldOrMethodInfo(in.readUnsignedShort(), toString(in.readUnsignedShort()), toString(in.readUnsignedShort()),
             array(in.readUnsignedShort())(parseAttribute()))
         private def parseAttribute() =
           {
             val nameIndex = in.readUnsignedShort()
             val name = if (nameIndex == -1) None else Some(toUTF8(nameIndex))
             val value = array(in.readInt())(in.readByte())
-            new AttributeInfo(name, value)
+            AttributeInfo(name, value)
           }
 
         def types = (classConstantReferences ++ fieldTypes ++ methodTypes).toSet
@@ -143,7 +143,7 @@ private[sbt] object Parser {
       val tag = in.readByte()
 
       // No switch for byte scrutinees! Stupid compiler.
-      ((tag.toInt): @switch) match {
+      (tag.toInt: @switch) match {
         case ConstantClass | ConstantString => new Constant(tag, in.readUnsignedShort())
         case ConstantField | ConstantMethod | ConstantInterfaceMethod | ConstantNameAndType =>
           new Constant(tag, in.readUnsignedShort(), in.readUnsignedShort())
@@ -154,16 +154,16 @@ private[sbt] object Parser {
         case ConstantUTF8    => new Constant(tag, in.readUTF())
         // TODO: proper support
         case ConstantMethodHandle =>
-          val kind = in.readByte()
-          val ref = in.readUnsignedShort()
-          new Constant(tag, -1, -1, None)
+          in.readByte()
+          in.readUnsignedShort()
+          Constant(tag, -1, -1, None)
         case ConstantMethodType =>
-          val descriptorIndex = in.readUnsignedShort()
-          new Constant(tag, -1, -1, None)
+          in.readUnsignedShort()
+          Constant(tag, -1, -1, None)
         case ConstantInvokeDynamic =>
-          val bootstrapIndex = in.readUnsignedShort()
-          val nameAndTypeIndex = in.readUnsignedShort()
-          new Constant(tag, -1, -1, None)
+          in.readUnsignedShort()
+          in.readUnsignedShort()
+          Constant(tag, -1, -1, None)
         case _ => sys.error("Unknown constant: " + tag)
       }
     }

--- a/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/ParserSpecification.scala
+++ b/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/ParserSpecification.scala
@@ -3,8 +3,6 @@ package internal
 package inc
 package classfile
 
-import scala.util.Try
-
 import org.scalacheck._
 import Prop._
 

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala
@@ -12,7 +12,7 @@ package inc
 import xsbti.ArtifactInfo
 import scala.util
 import java.io.File
-import CompilerArguments.{ abs, absString, BootClasspathOption }
+import CompilerArguments.{ absString, BootClasspathOption }
 import sbt.io.IO
 import sbt.io.syntax._
 

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/ForkedJava.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/ForkedJava.scala
@@ -17,7 +17,7 @@ import sbt.io.syntax._
 import sbt.io.IO
 import sbt.util.Logger
 import xsbti.{ Reporter, Logger => XLogger }
-import xsbti.compile.{ ClassFileManager, IncToolOptions, JavaCompiler => XJavaCompiler, Javadoc => XJavadoc }
+import xsbti.compile.{ IncToolOptions, JavaCompiler => XJavaCompiler, Javadoc => XJavadoc }
 
 import scala.sys.process.Process
 
@@ -65,7 +65,6 @@ object ForkedJava {
   private def escapeSpaces(s: String): String = '\"' + normalizeSlash(s) + '\"'
   private def normalizeSlash(s: String) = s.replace(File.separatorChar, '/')
 
-  import sbt.io.Path._
   /** create the executable name for java */
   private[javac] def getJavaExecutable(javaHome: Option[File], name: String): String =
     javaHome match {

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavaErrorParser.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavaErrorParser.scala
@@ -15,7 +15,7 @@ import java.io.File
 
 import java.util.Optional
 import sbt.util.InterfaceUtil.o2jo
-import xsbti.{ Problem, Severity, Maybe, Position }
+import xsbti.{ Problem, Severity, Position }
 
 /** A wrapper around xsbti.Position so we can pass in Java input. */
 final case class JavaPosition(_sourceFilePath: String, _line: Int, _contents: String, _offset: Int) extends Position {
@@ -52,7 +52,6 @@ class JavaErrorParser(relativeDir: File = new File(new File(".").getAbsolutePath
   // Here we track special handlers to catch "Note:" and "Warning:" lines.
   private val NOTE_LINE_PREFIXES = Array("Note: ", "\u6ce8: ", "\u6ce8\u610f\uff1a ")
   private val WARNING_PREFIXES = Array("warning", "\u8b66\u544a", "\u8b66\u544a\uff1a")
-  private val END_OF_LINE = System.getProperty("line.separator")
 
   override val skipWhitespace = false
 

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavacProcessLogger.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavacProcessLogger.scala
@@ -11,8 +11,6 @@ package internal
 package inc
 package javac
 
-import java.util.StringTokenizer
-
 import xsbti._
 import java.io.File
 import scala.sys.process.ProcessLogger
@@ -28,7 +26,7 @@ import scala.sys.process.ProcessLogger
  */
 final class JavacLogger(log: sbt.util.Logger, reporter: Reporter, cwd: File) extends ProcessLogger {
   import scala.collection.mutable.ListBuffer
-  import sbt.util.Level.{ Info, Warn, Error, Value => LogLevel }
+  import sbt.util.Level.{ Info, Error, Value => LogLevel }
 
   private val msgs: ListBuffer[(LogLevel, String)] = new ListBuffer()
 
@@ -39,11 +37,6 @@ final class JavacLogger(log: sbt.util.Logger, reporter: Reporter, cwd: File) ext
     synchronized { msgs += ((Error, s)); () }
 
   def buffer[T](f: => T): T = f
-
-  private def print(desiredLevel: LogLevel)(t: (LogLevel, String)) = t match {
-    case (Info, msg)  => log.info(msg)
-    case (Error, msg) => log.log(desiredLevel, msg)
-  }
 
   // Helper method to dump all semantic errors.
   private def parseAndDumpSemanticErrors(): Unit = {
@@ -59,7 +52,6 @@ final class JavacLogger(log: sbt.util.Logger, reporter: Reporter, cwd: File) ext
 
   def flush(exitCode: Int): Unit = {
     parseAndDumpSemanticErrors()
-    val level = if (exitCode == 0) Warn else Error
     // Here we only display things that wouldn't otherwise be output by the error reporter.
     // TODO - NOTES may not be displayed correctly!
     msgs collect {

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/LocalJava.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/LocalJava.scala
@@ -73,14 +73,14 @@ final class LocalJavadoc() extends XJavadoc {
   override def run(sources: Array[File], options: Array[String], incToolOptions: IncToolOptions,
     reporter: Reporter, log: XLogger): Boolean = {
     val cwd = new File(new File(".").getAbsolutePath).getCanonicalFile
-    val (jArgs, nonJArgs) = options.partition(_.startsWith("-J"))
+    val nonJArgs = options.filterNot(_.startsWith("-J"))
     val allArguments = nonJArgs ++ sources.map(_.getAbsolutePath)
     val javacLogger = new JavacLogger(log, reporter, cwd)
     val warnOrError = new PrintWriter(new ProcessLoggerWriter(javacLogger, Level.Error))
     val infoWriter = new PrintWriter(new ProcessLoggerWriter(javacLogger, Level.Info))
     var exitCode = -1
     try {
-      exitCode = LocalJava.unsafeJavadoc(allArguments.toArray, warnOrError, warnOrError, infoWriter)
+      exitCode = LocalJava.unsafeJavadoc(allArguments, warnOrError, warnOrError, infoWriter)
     } finally {
       warnOrError.close()
       infoWriter.close()

--- a/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/javac/JavaCompilerSpec.scala
+++ b/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/javac/JavaCompilerSpec.scala
@@ -6,12 +6,11 @@ package javac
 import java.io.File
 import java.net.URLClassLoader
 
-import sbt._
 import xsbt.api.SameAPI
 import xsbti.{ Maybe, Problem, Severity }
 import xsbti.compile.{ IncToolOptions, IncToolOptionsUtil, JavaTools => XJavaTools }
 import sbt.io.IO
-import sbt.util.{ Logger, LogExchange }
+import sbt.util.LogExchange
 import sbt.internal.util.UnitSpec
 import org.scalatest.matchers._
 
@@ -33,15 +32,15 @@ class JavaCompilerSpec extends UnitSpec {
   it should "\"safe\" singleton type names " in analyzeStaticDifference("float", "0.123456789f", "0.123456789f")
 
   def docWorks(compiler: XJavaTools) = IO.withTemporaryDirectory { out =>
-    val (result, problems) = doc(compiler, Seq(knownSampleGoodFile), Seq("-d", out.getAbsolutePath))
+    val (result, _) = doc(compiler, Seq(knownSampleGoodFile), Seq("-d", out.getAbsolutePath))
     result shouldBe true
-    (new File(out, "index.html")).exists shouldBe true
-    (new File(out, "good.html")).exists shouldBe true
+    new File(out, "index.html").exists shouldBe true
+    new File(out, "good.html").exists shouldBe true
   }
 
   def works(compiler: XJavaTools, forked: Boolean = false) = IO.withTemporaryDirectory { out =>
     val classfileManager = new CollectingClassFileManager()
-    val (result, problems) = compile(compiler, Seq(knownSampleGoodFile), Seq("-deprecation", "-d", out.getAbsolutePath),
+    val (result, _) = compile(compiler, Seq(knownSampleGoodFile), Seq("-deprecation", "-d", out.getAbsolutePath),
       incToolOptions = IncToolOptionsUtil.defaultIncToolOptions()
         .withClassFileManager(Maybe.just(classfileManager)).withUseCustomizedFileManager(true))
 
@@ -59,7 +58,7 @@ class JavaCompilerSpec extends UnitSpec {
   def findsErrors(compiler: XJavaTools) = {
     val (result, problems) = compile(compiler, Seq(knownSampleErrorFile), Seq("-deprecation"))
     result shouldBe false
-    problems should have size (5)
+    problems should have size 5
     val importWarn = warnOnLine(lineno = 1, lineContent = Some("java.rmi.RMISecurityException"))
     val beAnExpectedError = List(importWarn, errorOnLine(3), errorOnLine(4), warnOnLine(7)) reduce (_ or _)
     problems foreach (_ should beAnExpectedError)
@@ -68,7 +67,7 @@ class JavaCompilerSpec extends UnitSpec {
   def findsDocErrors(compiler: XJavaTools) = IO.withTemporaryDirectory { out =>
     val (result, problems) = doc(compiler, Seq(knownSampleErrorFile), Seq("-d", out.getAbsolutePath))
     result shouldBe true
-    problems should have size (2)
+    problems should have size 2
     val beAnExpectedError = List(errorOnLine(3), errorOnLine(4)) reduce (_ or _)
     problems foreach (_ should beAnExpectedError)
   }
@@ -84,7 +83,7 @@ class JavaCompilerSpec extends UnitSpec {
     def compileWithPrimitive(templateType: String, templateValue: String) =
       IO.withTemporaryDirectory { out =>
         // copy the input file to a temporary location and change the templateValue
-        val input = new File(out, hasStaticFinalFile.getName())
+        val input = new File(out, hasStaticFinalFile.getName)
         IO.writeLines(
           input,
           IO.readLines(hasStaticFinalFile).map { line =>
@@ -93,7 +92,7 @@ class JavaCompilerSpec extends UnitSpec {
         )
 
         // then compile it
-        val (result, problems) = compile(local, Seq(input), Seq("-d", out.getAbsolutePath))
+        val (result, _) = compile(local, Seq(input), Seq("-d", out.getAbsolutePath))
         result shouldBe true
         val clazzz = new URLClassLoader(Array(out.toURI.toURL)).loadClass("hasstaticfinal")
         ClassToAPI(Seq(clazzz))
@@ -146,7 +145,7 @@ class JavaCompilerSpec extends UnitSpec {
     (fproblems zip lproblems) foreach {
       case (f, l) =>
         // TODO - We should check to see if the levenshtein distance of the messages is close...
-        if (f.position.sourcePath.isPresent) (f.position.sourcePath.get shouldBe l.position.sourcePath.get)
+        if (f.position.sourcePath.isPresent) f.position.sourcePath.get shouldBe l.position.sourcePath.get
         else l.position.sourcePath.isPresent shouldBe false
 
         if (f.position.line.isPresent) f.position.line.get shouldBe l.position.line.get
@@ -182,7 +181,7 @@ class JavaCompilerSpec extends UnitSpec {
     )
 
   def cwd =
-    (new File(new File(".").getAbsolutePath)).getCanonicalFile
+    new File(new File(".").getAbsolutePath).getCanonicalFile
 
   def knownSampleErrorFile =
     new java.io.File(getClass.getResource("test1.java").toURI)

--- a/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/javac/javaErrorParserSpec.scala
+++ b/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/javac/javaErrorParserSpec.scala
@@ -3,8 +3,6 @@ package internal
 package inc
 package javac
 
-import java.io.File
-
 import sbt.util.Logger
 import sbt.internal.util.UnitSpec
 

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/APIDiff.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/APIDiff.scala
@@ -13,7 +13,7 @@ import xsbt.api.DefaultShowAPI
 import java.lang.reflect.Method
 import java.util.{ List => JList }
 
-import xsbti.api.{ Companions, AnalyzedClass, ClassLike }
+import xsbti.api.Companions
 
 /**
  * A class which computes diffs (unified diffs) between two textual representations of an API.

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Compile.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Compile.scala
@@ -64,7 +64,7 @@ object IncrementalCompile {
           new AnalysisCallback.Builder(internalBinaryToSourceClassName, internalSourceToClassNamesMap, externalAPI, current, output, options),
           log, options)
       } catch {
-        case e: xsbti.CompileCancelled =>
+        case _: xsbti.CompileCancelled =>
           log.info("Compilation has been cancelled")
           // in case compilation got cancelled potential partial compilation results (e.g. produced classs files) got rolled back
           // and we can report back as there was no change (false) and return a previous Analysis which is still up-to-date
@@ -72,7 +72,7 @@ object IncrementalCompile {
       }
     }
   def getExternalAPI(lookup: Lookup): (File, String) => Option[AnalyzedClass] =
-    (file: File, binaryClassName: String) =>
+    (_: File, binaryClassName: String) =>
       lookup.lookupAnalysis(binaryClassName) flatMap {
         case (analysis: Analysis) =>
           val sourceClassName = analysis.relations.productClassName.reverse(binaryClassName).headOption
@@ -214,9 +214,6 @@ private final class AnalysisCallback(
     add(localClasses, source, classFile)
     ()
   }
-
-  // empty value used when name hashing algorithm is disabled
-  private val emptyNameHashes = new xsbti.api.NameHashes(Array.empty, Array.empty)
 
   def api(sourceFile: File, classApi: ClassLike): Unit = {
     import xsbt.api.{ APIUtil, HashAPI }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -12,7 +12,7 @@ package inc
 import java.io.File
 import sbt.util.{ Level, Logger }
 import xsbti.compile.ClassFileManager
-import xsbti.compile.{ CompileAnalysis, DependencyChanges, IncOptions, Output }
+import xsbti.compile.{ CompileAnalysis, DependencyChanges, IncOptions }
 
 /**
  * Define helpers to run incremental compilation algorithm with name hashing.

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
@@ -11,7 +11,7 @@ package inc
 
 import java.io.File
 
-import xsbti.api.{ AnalyzedClass, Compilation }
+import xsbti.api.AnalyzedClass
 import xsbti.compile.ClassFileManager
 import xsbti.compile.{ CompileAnalysis, DependencyChanges, IncOptions, IncOptionsUtil }
 

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalNameHashing.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalNameHashing.scala
@@ -11,7 +11,7 @@ package inc
 
 import xsbti.compile.IncOptions
 import xsbti.api.AnalyzedClass
-import xsbt.api.{ APIUtil, SameAPI }
+import xsbt.api.SameAPI
 
 /**
  * Implementation of incremental algorithm known as "name hashing". It differs from the default implementation

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Locate.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Locate.scala
@@ -14,8 +14,6 @@ import java.util.zip.{ ZipException, ZipFile }
 
 import xsbti.compile.{ DefinesClass, PerClasspathEntryLookup }
 
-import Function.const
-
 object Locate {
   /**
    * Right(src) provides the value for the found class
@@ -68,14 +66,14 @@ object Locate {
   }
 
   private class JarDefinesClass(entry: File) extends DefinesClass {
-    import collection.JavaConversions._
+    import collection.JavaConverters._
     private val entries = {
       val jar = try { new ZipFile(entry, ZipFile.OPEN_READ) } catch {
         // ZipException doesn't include the file name :(
         case e: ZipException => throw new RuntimeException("Error opening zip file: " + entry.getName, e)
       }
       try {
-        jar.entries.map(e => toClassName(e.getName)).toSet
+        jar.entries.asScala.map(e => toClassName(e.getName)).toSet
       } finally {
         jar.close()
       }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/MemberRefInvalidator.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/MemberRefInvalidator.scala
@@ -10,9 +10,7 @@ package internal
 package inc
 
 import sbt.internal.util.Relation
-import java.io.File
 import sbt.util.Logger
-import xsbt.api.APIUtil
 
 /**
  * Implements various strategies for invalidating dependencies introduced by member reference.

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Relations.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Relations.scala
@@ -13,7 +13,6 @@ import java.io.File
 import sbt.internal.util.Relation
 import xsbti.api.{ InternalDependency, ExternalDependency, DependencyContext }
 import xsbti.api.DependencyContext._
-import xsbti.compile.IncOptionsUtil
 import Relations.ClassDependencies
 
 /**

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
@@ -11,7 +11,6 @@ package inc
 
 import java.io.{ File, IOException }
 import Stamp.getStamp
-import scala.util.matching.Regex
 import sbt.io.{ Hash => IOHash }
 
 trait ReadStamps {

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/AnalysisMappers.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/AnalysisMappers.scala
@@ -10,7 +10,7 @@ package sbt.internal.inc
 import java.io.File
 import java.nio.file.Path
 
-import xsbti.compile.{ MiniOptions, MiniSetup }
+import xsbti.compile.MiniSetup
 
 import scala.util.Try
 

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/TextAnalysisFormat.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/TextAnalysisFormat.scala
@@ -11,7 +11,6 @@ package inc
 
 import java.io._
 
-import sbt.internal.util.Relation
 import xsbti.T2
 import xsbti.api._
 import xsbti.compile._
@@ -35,9 +34,9 @@ class TextAnalysisFormat(override val mappers: AnalysisMappers) extends FormatCo
   private implicit val compilationF: Format[Compilation] = xsbt.api.CompilationFormat
   private implicit val nameHashesFormat: Format[NameHashes] = xsbt.api.NameHashesFormat
   private implicit val companionsFomrat: Format[Companions] = xsbt.api.CompanionsFormat
-  private implicit def problemFormat: Format[Problem] = asProduct4(problem _)(p => (p.category, p.position, p.message, p.severity))
+  private implicit def problemFormat: Format[Problem] = asProduct4(problem)(p => (p.category, p.position, p.message, p.severity))
   private implicit def positionFormat: Format[Position] =
-    asProduct7(position _)(p => (jo2o(p.line), p.lineContent, jo2o(p.offset), jo2o(p.pointer), jo2o(p.pointerSpace), jo2o(p.sourcePath), jo2o(p.sourceFile)))
+    asProduct7(position)(p => (jo2o(p.line), p.lineContent, jo2o(p.offset), jo2o(p.pointer), jo2o(p.pointerSpace), jo2o(p.sourcePath), jo2o(p.sourceFile)))
   private implicit val severityFormat: Format[Severity] =
     wrap[Severity, Byte](_.ordinal.toByte, b => Severity.values.apply(b.toInt))
   private implicit val integerFormat: Format[Integer] = wrap[Integer, Int](_.toInt, Integer.valueOf)

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -5,7 +5,7 @@ package inc
 import java.io.{ File, FileInputStream }
 import java.net.URLClassLoader
 import java.util.jar.Manifest
-import sbt.util.{ Logger, LogExchange }
+import sbt.util.Logger
 import sbt.util.InterfaceUtil._
 import xsbt.api.Discovery
 import xsbti.{ Maybe, Problem, Severity }

--- a/internal/zinc-testing/src/main/scala/sbt/internal/inc/UnitSpec.scala
+++ b/internal/zinc-testing/src/main/scala/sbt/internal/inc/UnitSpec.scala
@@ -10,7 +10,7 @@ package internal
 package inc
 
 import org.scalatest._
-import sbt.util.{ Logger, LogExchange, Level }
+import sbt.util.{ LogExchange, Level }
 import sbt.internal.util.{ ManagedLogger, ConsoleOut, MainAppender }
 import java.util.concurrent.atomic.AtomicInteger
 

--- a/zinc-compile/src/test/scala/inc/DocSpec.scala
+++ b/zinc-compile/src/test/scala/inc/DocSpec.scala
@@ -9,12 +9,10 @@ import sbt.internal.inc.javac.JavaCompilerSpec
 import sbt.internal.inc.{ LoggerReporter, UnitSpec }
 import xsbti.compile.IncToolOptionsUtil
 import sbt.internal.util.DirectoryStoreFactory
-import sbt.inc.Doc
 
 import scala.json.ast.unsafe.JValue
 import sjsonnew.IsoString
 import sjsonnew.support.scalajson.unsafe.{ CompactPrinter, Converter, FixedParser }
-// import org.scalatest.matchers._
 
 class DocSpec extends UnitSpec {
   implicit val isoString: IsoString[JValue] = IsoString.iso(CompactPrinter.apply, FixedParser.parseUnsafe)

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -226,7 +226,6 @@ object MixedAnalyzingCompiler {
     cache: GlobalsCache,
     incrementalCompilerOptions: IncOptions
   ): CompileConfiguration = {
-    import MiniSetupUtil._
     new CompileConfiguration(
       sources,
       classpath,

--- a/zinc/src/main/scala/sbt/internal/inc/javac/AnalyzingJavaCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/javac/AnalyzingJavaCompiler.scala
@@ -154,7 +154,7 @@ final class AnalyzingJavaCompiler private[sbt] (
       }
 
       // Report that we reached the end
-      progressOpt.map { progress =>
+      progressOpt.foreach { progress =>
         progress.advance(2, 2)
       }
     }

--- a/zinc/src/test/scala/sbt/inc/SourceFiles.scala
+++ b/zinc/src/test/scala/sbt/inc/SourceFiles.scala
@@ -7,8 +7,6 @@
 
 package sbt.inc
 
-import java.nio.file.Paths
-
 object SourceFiles {
   val Good = "Good.scala"
   val Foo = "Foo.scala"

--- a/zinc/src/test/scala/sbt/inc/cached/CommonCachedCompilation.scala
+++ b/zinc/src/test/scala/sbt/inc/cached/CommonCachedCompilation.scala
@@ -65,6 +65,7 @@ abstract class CommonCachedCompilation(name: String) extends BaseCompilerSpec wi
 
     val result = remoteCompilerSetup.doCompileWithStore(remoteAnalysisStore)
     assert(result.hasModified)
+    ()
   }
 
   override protected def afterAll(): Unit =

--- a/zinc/src/test/scala/sbt/inc/cached/ExportedCacheSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/cached/ExportedCacheSpec.scala
@@ -13,7 +13,6 @@ import java.nio.file.Path
 import sbt.internal.inc.cached._
 import sbt.io.IO
 import xsbti.compile.{ MiniSetup, CompileAnalysis }
-import org.scalatest._
 
 class ExportedCacheSpec extends CommonCachedCompilation("Exported Cache") {
 

--- a/zinc/src/test/scala/sbt/inc/cached/ProjectRebaseCacheSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/cached/ProjectRebaseCacheSpec.scala
@@ -7,14 +7,8 @@
 
 package sbt.inc.cached
 
-import java.io.File
-import java.nio.file.{ Files, Path, Paths }
+import sbt.internal.inc.cached.{ CacheProvider, CompilationCache, ProjectRebasedCache }
 
-import org.scalatest.{ BeforeAndAfter, BeforeAndAfterAll }
-import sbt.internal.inc.cached.{ CacheAwareStore, CacheProvider, CompilationCache, ProjectRebasedCache }
-import sbt.internal.inc.{ Analysis, AnalysisStore, BridgeProviderSpecification, FileBasedStore }
-import sbt.io.IO
-import sbt.inc.BaseCompilerSpec
 import xsbti.compile.{ CompileAnalysis, MiniSetup }
 
 class ProjectRebaseCacheSpec extends CommonCachedCompilation("Project based cache") {


### PR DESCRIPTION
I noticed that there are a lot of compiler warnings during build, this PR attempts to fix (a large) portion of them:
* unused imports
* unused private methods
* unused vals