### PR TITLE
Fix #101: Remove SimpleType

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -198,8 +198,10 @@ lazy val zincBenchmarks = (project in internalPath / "zinc-benchmarks").
   enablePlugins(JmhPlugin).
   settings(
     name := "Benchmarks of Zinc and the compiler bridge",
-    libraryDependencies +=
+    libraryDependencies ++= Seq(
       "org.eclipse.jgit" % "org.eclipse.jgit" % "4.6.0.201612231935-r",
+      "net.openhft" % "affinity" % "3.0.6"
+    ),
     scalaVersion := scala212,
     crossScalaVersions := Seq(scala211, scala212),
     publish := {},

--- a/internal/compiler-bridge/src/main/scala/xsbt/ExtractAPI.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ExtractAPI.scala
@@ -174,11 +174,6 @@ class ExtractAPI[GlobalType <: Global](
       if (sym == NoSymbol || sym.isRoot || sym.isEmptyPackageClass || sym.isRootPackage) postfix
       else pathComponents(sym.owner, new xsbti.api.Id(simpleName(sym)) :: postfix)
     }
-  private def simpleType(in: Symbol, t: Type): SimpleType =
-    processType(in, t) match {
-      case s: SimpleType => s
-      case x             => log("Not a simple type:\n\tType: " + t + " (" + t.getClass + ")\n\tTransformed: " + x.getClass); Constants.emptyType
-    }
   private def types(in: Symbol, t: List[Type]): Array[xsbti.api.Type] = t.toArray[Type].map(processType(in, _))
   private def projectionType(in: Symbol, pre: Type, sym: Symbol) =
     {
@@ -192,7 +187,7 @@ class ExtractAPI[GlobalType <: Global](
           reference(sym)
         }
       } else if (sym.isRoot || sym.isRootPackage) Constants.emptyType
-      else new xsbti.api.Projection(simpleType(in, pre), simpleName(sym))
+      else new xsbti.api.Projection(processType(in, pre), simpleName(sym))
     }
   private def reference(sym: Symbol): xsbti.api.ParameterRef = new xsbti.api.ParameterRef(tparamID(sym))
 

--- a/internal/compiler-interface/src/main/contraband/type.json
+++ b/internal/compiler-interface/src/main/contraband/type.json
@@ -35,7 +35,12 @@
             { "name": "path", "type": "Path" }
           ]
         },
-        { "name": "EmptyType", "namespace": "xsbti.api", "target": "Java", "type": "record" },
+        {
+          "name": "EmptyType",
+          "namespace": "xsbti.api",
+          "target": "Java",
+          "type": "record"
+        },
         {
           "name": "Parameterized",
           "namespace": "xsbti.api",

--- a/internal/compiler-interface/src/main/contraband/type.json
+++ b/internal/compiler-interface/src/main/contraband/type.json
@@ -8,51 +8,42 @@
 
       "types": [
         {
-          "name": "SimpleType",
+          "name": "Projection",
           "namespace": "xsbti.api",
           "target": "Java",
-          "type": "interface",
-
-          "types": [
-            {
-              "name": "Projection",
-              "namespace": "xsbti.api",
-              "target": "Java",
-              "type": "record",
-              "fields": [
-                { "name": "prefix", "type": "SimpleType" },
-                { "name": "id",     "type": "String"     }
-              ]
-            },
-            {
-              "name": "ParameterRef",
-              "namespace": "xsbti.api",
-              "target": "Java",
-              "type": "record",
-              "fields": [
-                { "name": "id", "type": "String" }
-              ]
-            },
-            {
-              "name": "Singleton",
-              "namespace": "xsbti.api",
-              "target": "Java",
-              "type": "record",
-              "fields": [
-                { "name": "path", "type": "Path" }
-              ]
-            },
-            { "name": "EmptyType", "namespace": "xsbti.api", "target": "Java", "type": "record" },
-            {
-              "name": "Parameterized",
-              "namespace": "xsbti.api",
-              "target": "Java",
-              "type": "record",
-              "fields": [
-                { "name": "baseType",      "type": "SimpleType" },
-                { "name": "typeArguments", "type": "Type*"      }
-              ]
-            }
+          "type": "record",
+          "fields": [
+            { "name": "prefix", "type": "Type" },
+            { "name": "id",     "type": "String"     }
+          ]
+        },
+        {
+          "name": "ParameterRef",
+          "namespace": "xsbti.api",
+          "target": "Java",
+          "type": "record",
+          "fields": [
+            { "name": "id", "type": "String" }
+          ]
+        },
+        {
+          "name": "Singleton",
+          "namespace": "xsbti.api",
+          "target": "Java",
+          "type": "record",
+          "fields": [
+            { "name": "path", "type": "Path" }
+          ]
+        },
+        { "name": "EmptyType", "namespace": "xsbti.api", "target": "Java", "type": "record" },
+        {
+          "name": "Parameterized",
+          "namespace": "xsbti.api",
+          "target": "Java",
+          "type": "record",
+          "fields": [
+            { "name": "baseType",      "type": "Type" },
+            { "name": "typeArguments", "type": "Type*"      }
           ]
         },
         {

--- a/internal/zinc-apiinfo/src/main/scala/xsbt/api/SameAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/xsbt/api/SameAPI.scala
@@ -262,14 +262,14 @@ class SameAPI(includePrivate: Boolean, includeParamNames: Boolean) {
       (a, b) match {
         case (pa: Projection, pb: Projection)       => debug(sameProjection(pa, pb), "Different projection")
         case (pa: ParameterRef, pb: ParameterRef)   => debug(sameParameterRef(pa, pb), "Different parameter ref")
-        case (sa: Singleton, sb: Singleton)         => debug(sameSingleton(sa, sb), "Different singleton")
-        case (_: EmptyType, _: EmptyType)           => true
+        case (pa: Polymorphic, pb: Polymorphic)     => debug(samePolymorphicType(pa, pb), "Different polymorphic type")
         case (pa: Parameterized, pb: Parameterized) => debug(sameParameterized(pa, pb), "Different parameterized")
+        case (sa: Singleton, sb: Singleton)         => debug(sameSingleton(sa, sb), "Different singleton")
         case (ca: Constant, cb: Constant)           => debug(sameConstantType(ca, cb), "Different constant types: " + DefaultShowAPI(ca) + " and " + DefaultShowAPI(cb))
         case (aa: Annotated, ab: Annotated)         => debug(sameAnnotatedType(aa, ab), "Different annotated types")
         case (sa: Structure, sb: Structure)         => debug(sameStructureDirect(sa, sb), "Different structure type")
         case (ea: Existential, eb: Existential)     => debug(sameExistentialType(ea, eb), "Different existential type")
-        case (pa: Polymorphic, pb: Polymorphic)     => debug(samePolymorphicType(pa, pb), "Different polymorphic type")
+        case (_: EmptyType, _: EmptyType)           => true
         case _                                      => differentCategory("type", a, b)
       }
     }

--- a/internal/zinc-apiinfo/src/main/scala/xsbt/api/SameAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/xsbt/api/SameAPI.scala
@@ -258,14 +258,20 @@ class SameAPI(includePrivate: Boolean, includeParamNames: Boolean) {
   def sameType(a: Type, b: Type): Boolean =
     samePending(a, b)(sameTypeDirect)
   def sameTypeDirect(a: Type, b: Type): Boolean =
-    (a, b) match {
-      case (sa: SimpleType, sb: SimpleType)   => debug(sameSimpleTypeDirect(sa, sb), "Different simple types: " + DefaultShowAPI(sa) + " and " + DefaultShowAPI(sb))
-      case (ca: Constant, cb: Constant)       => debug(sameConstantType(ca, cb), "Different constant types: " + DefaultShowAPI(ca) + " and " + DefaultShowAPI(cb))
-      case (aa: Annotated, ab: Annotated)     => debug(sameAnnotatedType(aa, ab), "Different annotated types")
-      case (sa: Structure, sb: Structure)     => debug(sameStructureDirect(sa, sb), "Different structure type")
-      case (ea: Existential, eb: Existential) => debug(sameExistentialType(ea, eb), "Different existential type")
-      case (pa: Polymorphic, pb: Polymorphic) => debug(samePolymorphicType(pa, pb), "Different polymorphic type")
-      case _                                  => differentCategory("type", a, b)
+    {
+      (a, b) match {
+        case (pa: Projection, pb: Projection)       => debug(sameProjection(pa, pb), "Different projection")
+        case (pa: ParameterRef, pb: ParameterRef)   => debug(sameParameterRef(pa, pb), "Different parameter ref")
+        case (sa: Singleton, sb: Singleton)         => debug(sameSingleton(sa, sb), "Different singleton")
+        case (_: EmptyType, _: EmptyType)           => true
+        case (pa: Parameterized, pb: Parameterized) => debug(sameParameterized(pa, pb), "Different parameterized")
+        case (ca: Constant, cb: Constant)           => debug(sameConstantType(ca, cb), "Different constant types: " + DefaultShowAPI(ca) + " and " + DefaultShowAPI(cb))
+        case (aa: Annotated, ab: Annotated)         => debug(sameAnnotatedType(aa, ab), "Different annotated types")
+        case (sa: Structure, sb: Structure)         => debug(sameStructureDirect(sa, sb), "Different structure type")
+        case (ea: Existential, eb: Existential)     => debug(sameExistentialType(ea, eb), "Different existential type")
+        case (pa: Polymorphic, pb: Polymorphic)     => debug(samePolymorphicType(pa, pb), "Different polymorphic type")
+        case _                                      => differentCategory("type", a, b)
+      }
     }
 
   def sameConstantType(ca: Constant, cb: Constant): Boolean =
@@ -296,28 +302,17 @@ class SameAPI(includePrivate: Boolean, includeParamNames: Boolean) {
   def sameMembers(a: Seq[Definition], b: Seq[Definition]): Boolean =
     sameDefinitions(a, b, topLevel = false)
 
-  def sameSimpleType(a: SimpleType, b: SimpleType): Boolean =
-    samePending(a, b)(sameSimpleTypeDirect)
-  def sameSimpleTypeDirect(a: SimpleType, b: SimpleType): Boolean =
-    (a, b) match {
-      case (pa: Projection, pb: Projection)       => debug(sameProjection(pa, pb), "Different projection")
-      case (pa: ParameterRef, pb: ParameterRef)   => debug(sameParameterRef(pa, pb), "Different parameter ref")
-      case (sa: Singleton, sb: Singleton)         => debug(sameSingleton(sa, sb), "Different singleton")
-      case (_: EmptyType, _: EmptyType)           => true
-      case (pa: Parameterized, pb: Parameterized) => debug(sameParameterized(pa, pb), "Different parameterized")
-      case _                                      => differentCategory("simple type", a, b)
-    }
   def differentCategory(label: String, a: AnyRef, b: AnyRef): Boolean =
     debug(flag = false, "Different category of " + label + " (" + a.getClass.getName + " and " + b.getClass.getName + ") for (" + a + " and " + b + ")")
 
   def sameParameterized(a: Parameterized, b: Parameterized): Boolean =
-    sameSimpleType(a.baseType, b.baseType) &&
+    sameType(a.baseType, b.baseType) &&
       sameSeq(a.typeArguments, b.typeArguments)(sameType)
   def sameParameterRef(a: ParameterRef, b: ParameterRef): Boolean = sameTags(a.id, b.id)
   def sameSingleton(a: Singleton, b: Singleton): Boolean =
     samePath(a.path, b.path)
   def sameProjection(a: Projection, b: Projection): Boolean =
-    sameSimpleType(a.prefix, b.prefix) &&
+    sameType(a.prefix, b.prefix) &&
       (a.id == b.id)
 
   def samePath(a: Path, b: Path): Boolean =

--- a/internal/zinc-benchmarks/src/main/scala/xsbt/BenchmarkBase.scala
+++ b/internal/zinc-benchmarks/src/main/scala/xsbt/BenchmarkBase.scala
@@ -1,5 +1,6 @@
 package xsbt
 
+import net.openhft.affinity.AffinityLock
 import org.openjdk.jmh.annotations._
 import java.io.File
 
@@ -18,8 +19,13 @@ class BenchmarkBase {
   var _setup: ProjectSetup = _
   var _subprojectsSetup: List[ProjectSetup] = _
 
+  /* Java thread affinity (install JNA to run this benchmark). */
+  var _lock: AffinityLock = _
+
   @Setup(Level.Trial)
   def setUpCompilerRuns(): Unit = {
+    _lock = AffinityLock.acquireLock()
+
     assert(_project != null, "_project is null, set it.")
     assert(_subprojectToRun != null, "_subprojectToRun is null, set it.")
 
@@ -48,6 +54,7 @@ class BenchmarkBase {
 
   @TearDown(Level.Trial)
   def tearDown(): Unit = {
+    _lock.release()
     // Remove the directory where all the class files have been compiled
     sbt.io.IO.delete(_setup.at)
   }

--- a/internal/zinc-benchmarks/src/main/scala/xsbt/BenchmarkProjects.scala
+++ b/internal/zinc-benchmarks/src/main/scala/xsbt/BenchmarkProjects.scala
@@ -7,4 +7,11 @@ object BenchmarkProjects {
       "fb109614dd6efbb97c5b4f164b7adfc284982b25",
       List("coreJVM")
     )
+
+  object Scalac
+    extends BenchmarkProject(
+      "scala/scala",
+      "827d69d48e96d9add75ce19e06b374610784c936",
+      List("library")
+    )
 }

--- a/internal/zinc-benchmarks/src/main/scala/xsbt/GlobalBenchmarkSetup.scala
+++ b/internal/zinc-benchmarks/src/main/scala/xsbt/GlobalBenchmarkSetup.scala
@@ -2,12 +2,12 @@ package xsbt
 
 import java.io.File
 
-import xsbt.BenchmarkProjects.Shapeless
+import xsbt.BenchmarkProjects.{ Scalac, Shapeless }
 
 object GlobalBenchmarkSetup {
 
   /** Update this list every time you add a new benchmark. */
-  val projects = List(Shapeless)
+  val projects = List(Scalac)
 
   def runSetup(setupDir: File): (Int, String) = {
     val projectsPreparation = projects.map { project =>

--- a/internal/zinc-benchmarks/src/main/scala/xsbt/ScalacBenchmark.scala
+++ b/internal/zinc-benchmarks/src/main/scala/xsbt/ScalacBenchmark.scala
@@ -1,18 +1,18 @@
-/*package xsbt
+package xsbt
 
 import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._
 
-class ShapelessBenchmark extends BenchmarkBase {
-  _project = BenchmarkProjects.Shapeless
+class ScalacBenchmark extends BenchmarkBase {
+  _project = BenchmarkProjects.Scalac
 }
 
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(Mode.SingleShotTime))
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Fork(value = 10, jvmArgs = Array("-XX:CICompilerCount=2"))
-class ColdShapelessBenchmark extends ShapelessBenchmark {
-  _subprojectToRun = _project.subprojects.head // CoreJVM
+class ColdScalacBenchmark extends ScalacBenchmark {
+  _subprojectToRun = _project.subprojects.head
   @Benchmark
   override def compile(): Unit = {
     super.compile()
@@ -25,8 +25,8 @@ class ColdShapelessBenchmark extends ShapelessBenchmark {
 @Warmup(iterations = 0)
 @Measurement(iterations = 1, time = 30, timeUnit = TimeUnit.SECONDS)
 @Fork(value = 3)
-class WarmShapelessBenchmark extends ShapelessBenchmark {
-  _subprojectToRun = _project.subprojects.head // CoreJVM
+class WarmScalacBenchmark extends ScalacBenchmark {
+  _subprojectToRun = _project.subprojects.head
   @Benchmark
   override def compile(): Unit = {
     super.compile()
@@ -39,10 +39,10 @@ class WarmShapelessBenchmark extends ShapelessBenchmark {
 @Warmup(iterations = 6, time = 10, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 6, time = 10, timeUnit = TimeUnit.SECONDS)
 @Fork(value = 3)
-class HotShapelessBenchmark extends ShapelessBenchmark {
-  _subprojectToRun = _project.subprojects.head // CoreJVM
+class HotScalacBenchmark extends ScalacBenchmark {
+  _subprojectToRun = _project.subprojects.head
   @Benchmark
   override def compile(): Unit = {
     super.compile()
   }
-}*/
+}

--- a/zinc/src/sbt-test/source-dependencies/struct-projection/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/struct-projection/A.scala
@@ -1,0 +1,3 @@
+object A {
+  def m: ({type T <: Int})#T = ???
+}

--- a/zinc/src/sbt-test/source-dependencies/struct-projection/B.scala
+++ b/zinc/src/sbt-test/source-dependencies/struct-projection/B.scala
@@ -1,0 +1,3 @@
+object B {
+  val x: Int = A.m
+}

--- a/zinc/src/sbt-test/source-dependencies/struct-projection/changes/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/struct-projection/changes/A.scala
@@ -1,0 +1,3 @@
+object A {
+  def m: ({type T <: String})#T = ???
+}

--- a/zinc/src/sbt-test/source-dependencies/struct-projection/test
+++ b/zinc/src/sbt-test/source-dependencies/struct-projection/test
@@ -1,0 +1,4 @@
+> compile
+$ copy-file changes/A.scala A.scala
+# Compilation of B.scala should fail because type of A.m changed
+-> compile


### PR DESCRIPTION
`SimpleType` has been removed from sbt and a test has been added to show that projection on structure are correctly invalidated by sbt now.