### PR TITLE
Add a scripted test for package private class

### DIFF
--- a/zinc/src/sbt-test/source-dependencies/pkg-private-class/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/pkg-private-class/A.scala
@@ -1,0 +1,4 @@
+package pkg1
+private class A {
+  def foo: Int = 1
+}

--- a/zinc/src/sbt-test/source-dependencies/pkg-private-class/B.scala
+++ b/zinc/src/sbt-test/source-dependencies/pkg-private-class/B.scala
@@ -1,0 +1,5 @@
+package pkg1
+
+class B {
+  def bar(a: A): Int = a.foo
+}

--- a/zinc/src/sbt-test/source-dependencies/pkg-private-class/changes/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/pkg-private-class/changes/A.scala
@@ -1,0 +1,4 @@
+package pkg1
+private class A {
+  //def foo: Int = 1
+}

--- a/zinc/src/sbt-test/source-dependencies/pkg-private-class/test
+++ b/zinc/src/sbt-test/source-dependencies/pkg-private-class/test
@@ -1,0 +1,5 @@
+> compile
+
+$ copy-file changes/A.scala A.scala
+
+-> compile


### PR DESCRIPTION
Add a test that shows package private classes are handled properly in
zinc now. This test doesn't pass in sbt 0.13.

@johnynek ran into this problem while working on Twitter's summingbird. I'm adding a test case to note that buggy dependency tracking of package private classes has been fixed in zinc 1.0.