### PR TITLE
Open up display to sbt

### DIFF
--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/LoggerReporter.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/LoggerReporter.scala
@@ -100,7 +100,8 @@ class LoggerReporter(maximumErrors: Int, logger: ManagedLogger, sourcePositionMa
 
   private def inc(sev: Severity) = count.put(sev, count.get(sev) + 1)
 
-  private def display(p: Problem): Unit =
+  // this is used by sbt
+  private[sbt] def display(p: Problem): Unit =
     {
       import problemFormats._
       inc(p.severity)


### PR DESCRIPTION
def display was made private prematurely in https://github.com/eed3si9n/zinc/commit/8fef6c8146e45c8fd84ca3f0d8ed9493c0b45711#diff-fd05ba9656dc1940ed6cd16050471ea1R103 but when I compiled it with sbt I realized it was being used by it.
