### PR TITLE
Add pending tests for changing inherited type in sealed trait children.

### DIFF
--- a/zinc/src/sbt-test/source-dependencies/changedTypeOfChildOfSealed/changed/Sealed1.scala
+++ b/zinc/src/sbt-test/source-dependencies/changedTypeOfChildOfSealed/changed/Sealed1.scala
@@ -1,0 +1,9 @@
+package foo
+
+sealed trait Sealed
+
+object Child1 extends Sealed with Base
+object Child2 extends Sealed with OtherBase
+
+trait Base
+trait OtherBase extends Base

--- a/zinc/src/sbt-test/source-dependencies/changedTypeOfChildOfSealed/changed/Sealed2.scala
+++ b/zinc/src/sbt-test/source-dependencies/changedTypeOfChildOfSealed/changed/Sealed2.scala
@@ -1,0 +1,9 @@
+package foo
+
+sealed trait Sealed
+
+object Child1 extends Sealed with Base
+object Child2 extends Sealed with OtherBase
+
+trait Base
+trait OtherBase

--- a/zinc/src/sbt-test/source-dependencies/changedTypeOfChildOfSealed/incOptions.properties
+++ b/zinc/src/sbt-test/source-dependencies/changedTypeOfChildOfSealed/incOptions.properties
@@ -1,0 +1,1 @@
+scalac.options = -Xfatal-warnings

--- a/zinc/src/sbt-test/source-dependencies/changedTypeOfChildOfSealed/pending
+++ b/zinc/src/sbt-test/source-dependencies/changedTypeOfChildOfSealed/pending
@@ -1,0 +1,10 @@
+# Compilation with warning should fail
+-> compile
+
+# Remove warning
+$ copy-file changed/Sealed1.scala src/main/scala/foo/Sealed.scala
+> compile
+
+# Add warning again without touching Child2 definition
+$ copy-file changed/Sealed2.scala src/main/scala/foo/Sealed.scala
+-> compile

--- a/zinc/src/sbt-test/source-dependencies/changedTypeOfChildOfSealed/src/main/scala/foo/Sealed.scala
+++ b/zinc/src/sbt-test/source-dependencies/changedTypeOfChildOfSealed/src/main/scala/foo/Sealed.scala
@@ -1,0 +1,9 @@
+package foo
+
+sealed trait Sealed
+
+object Child1 extends Sealed with Base
+object Child2 extends Sealed // 'with Base' will be added then removed
+
+trait Base
+trait OtherBase extends Base

--- a/zinc/src/sbt-test/source-dependencies/changedTypeOfChildOfSealed/src/main/scala/foo/Usage.scala
+++ b/zinc/src/sbt-test/source-dependencies/changedTypeOfChildOfSealed/src/main/scala/foo/Usage.scala
@@ -1,0 +1,8 @@
+package foo
+
+object Usage{
+  def ala(a: Sealed) = a match {
+    case _: Base =>
+      1
+  }
+}


### PR DESCRIPTION
IncHandler now understands scalac options.

Add pending tests for changing inherited type in sealed trait children.

This was found during #267 and is a problem also there.