### PR TITLE
Add scalaVersion to zinc scripted

### DIFF
--- a/internal/zinc-scripted/src/main/contraband-scala/sbt/internal/inctest/Project.scala
+++ b/internal/zinc-scripted/src/main/contraband-scala/sbt/internal/inctest/Project.scala
@@ -7,22 +7,23 @@ package sbt.internal.inctest
 final class Project private (
   val name: String,
   val dependsOn: Vector[String],
-  val in: Option[java.io.File]) extends Serializable {
+  val in: Option[java.io.File],
+  val scalaVersion: Option[String]) extends Serializable {
   
-  private def this(name: String) = this(name, Vector(), None)
+  private def this(name: String) = this(name, Vector(), None, None)
   
   override def equals(o: Any): Boolean = o match {
-    case x: Project => (this.name == x.name) && (this.dependsOn == x.dependsOn) && (this.in == x.in)
+    case x: Project => (this.name == x.name) && (this.dependsOn == x.dependsOn) && (this.in == x.in) && (this.scalaVersion == x.scalaVersion)
     case _ => false
   }
   override def hashCode: Int = {
-    37 * (37 * (37 * (17 + name.##) + dependsOn.##) + in.##)
+    37 * (37 * (37 * (37 * (17 + name.##) + dependsOn.##) + in.##) + scalaVersion.##)
   }
   override def toString: String = {
-    "Project(" + name + ", " + dependsOn + ", " + in + ")"
+    "Project(" + name + ", " + dependsOn + ", " + in + ", " + scalaVersion + ")"
   }
-  protected[this] def copy(name: String = name, dependsOn: Vector[String] = dependsOn, in: Option[java.io.File] = in): Project = {
-    new Project(name, dependsOn, in)
+  protected[this] def copy(name: String = name, dependsOn: Vector[String] = dependsOn, in: Option[java.io.File] = in, scalaVersion: Option[String] = scalaVersion): Project = {
+    new Project(name, dependsOn, in, scalaVersion)
   }
   def withName(name: String): Project = {
     copy(name = name)
@@ -36,10 +37,16 @@ final class Project private (
   def withIn(in: java.io.File): Project = {
     copy(in = Option(in))
   }
+  def withScalaVersion(scalaVersion: Option[String]): Project = {
+    copy(scalaVersion = scalaVersion)
+  }
+  def withScalaVersion(scalaVersion: String): Project = {
+    copy(scalaVersion = Option(scalaVersion))
+  }
 }
 object Project {
   
-  def apply(name: String): Project = new Project(name, Vector(), None)
-  def apply(name: String, dependsOn: Vector[String], in: Option[java.io.File]): Project = new Project(name, dependsOn, in)
-  def apply(name: String, dependsOn: Vector[String], in: java.io.File): Project = new Project(name, dependsOn, Option(in))
+  def apply(name: String): Project = new Project(name, Vector(), None, None)
+  def apply(name: String, dependsOn: Vector[String], in: Option[java.io.File], scalaVersion: Option[String]): Project = new Project(name, dependsOn, in, scalaVersion)
+  def apply(name: String, dependsOn: Vector[String], in: java.io.File, scalaVersion: String): Project = new Project(name, dependsOn, Option(in), Option(scalaVersion))
 }

--- a/internal/zinc-scripted/src/main/contraband-scala/sbt/internal/inctest/ProjectFormats.scala
+++ b/internal/zinc-scripted/src/main/contraband-scala/sbt/internal/inctest/ProjectFormats.scala
@@ -14,8 +14,9 @@ implicit lazy val ProjectFormat: JsonFormat[sbt.internal.inctest.Project] = new 
       val name = unbuilder.readField[String]("name")
       val dependsOn = unbuilder.readField[Vector[String]]("dependsOn")
       val in = unbuilder.readField[Option[java.io.File]]("in")
+      val scalaVersion = unbuilder.readField[Option[String]]("scalaVersion")
       unbuilder.endObject()
-      sbt.internal.inctest.Project(name, dependsOn, in)
+      sbt.internal.inctest.Project(name, dependsOn, in, scalaVersion)
       case None =>
       deserializationError("Expected JsObject but found None")
     }
@@ -25,6 +26,7 @@ implicit lazy val ProjectFormat: JsonFormat[sbt.internal.inctest.Project] = new 
     builder.addField("name", obj.name)
     builder.addField("dependsOn", obj.dependsOn)
     builder.addField("in", obj.in)
+    builder.addField("scalaVersion", obj.scalaVersion)
     builder.endObject()
   }
 }

--- a/internal/zinc-scripted/src/main/contraband/scripted.contra
+++ b/internal/zinc-scripted/src/main/contraband/scripted.contra
@@ -11,4 +11,5 @@ type Project {
   name: String!
   dependsOn: [String] @since("0.1.0")
   in: java.io.File @since("0.1.0")
+  scalaVersion: String @since("0.1.0")
 }

--- a/zinc/src/sbt-test/source-dependencies/binary/build.json
+++ b/zinc/src/sbt-test/source-dependencies/binary/build.json
@@ -1,10 +1,12 @@
 {
   "projects": [
     {
-      "name": "use"
+      "name": "use",
+      "scalaVersion": "2.12.1"
     },
     {
-      "name": "dep"
+      "name": "dep",
+      "scalaVersion": "2.12.1"
     }
   ]
 }


### PR DESCRIPTION
This allows `build.json` file to specify `scalaVersion` that gets used by scripted.
Sending this as preliminary PR before the pending test to make sure this doesn't break the existing tests.

Ref #276
