### PR TITLE
Bump lm, util, and io to the latest

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,9 +10,9 @@ object Dependencies {
   val scala212 = "2.12.1"
 
   val bootstrapSbtVersion = "0.13.8"
-  private val ioVersion = "1.0.0-M9"
-  private val utilVersion = "1.0.0-M20"
-  private val lmVersion = "1.0.0-X7"
+  private val ioVersion = "1.0.0-M10"
+  private val utilVersion = "1.0.0-M22"
+  private val lmVersion = "1.0.0-X8"
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.15


### PR DESCRIPTION
This bumps up the modules to forward port all sbt 0.13 bug fixes thus far.

- OverrideScalaMediator, dotty nightly builds https://github.com/sbt/librarymanagement/pull/79
- Maven version range improvement https://github.com/sbt/librarymanagement/pull/80 
- Fix version parsing https://github.com/sbt/librarymanagement/pull/81
- JLine 2.14.3 (Fixes Ctrl-C handling) https://github.com/sbt/util/pull/77
