### PR TITLE
[regression] Stackoverflow during compilation

### DIFF
--- a/zinc/src/sbt-test/apiinfo/circular-structure/build.sbt
+++ b/zinc/src/sbt-test/apiinfo/circular-structure/build.sbt
@@ -1,0 +1,16 @@
+// import sbt.inc.Analysis
+
+// logLevel := Level.Debug
+
+// incOptions ~= { _.withApiDebug(true) }
+
+// TaskKey[Unit]("show-apis") := {
+//   val a = (compile in Compile).value match { case a: Analysis => a }
+//   val scalaSrc = (scalaSource in Compile).value
+//   val javaSrc = (javaSource in Compile).value
+//   val aApi = a.apis.internalAPI(scalaSrc / "A.scala").api
+//   val jApi = a.apis.internalAPI(javaSrc / "test/J.java").api
+//   import xsbt.api.DefaultShowAPI
+//   DefaultShowAPI(aApi)
+//   DefaultShowAPI(jApi)
+// }

--- a/zinc/src/sbt-test/apiinfo/circular-structure/disabled
+++ b/zinc/src/sbt-test/apiinfo/circular-structure/disabled
@@ -1,0 +1,2 @@
+# test case for http://github.com/sbt/sbt/issues/676
+> compile

--- a/zinc/src/sbt-test/apiinfo/circular-structure/src/main/java/test/J.java
+++ b/zinc/src/sbt-test/apiinfo/circular-structure/src/main/java/test/J.java
@@ -1,0 +1,6 @@
+package test;
+
+public class J {
+  public static final class J2 extends J { }
+  public static final class J3 extends J { }
+}

--- a/zinc/src/sbt-test/apiinfo/circular-structure/src/main/scala/A.scala
+++ b/zinc/src/sbt-test/apiinfo/circular-structure/src/main/scala/A.scala
@@ -1,0 +1,6 @@
+package test
+
+class A {
+	class B extends A
+	class C extends A
+}

--- a/zinc/src/sbt-test/apiinfo/java-basic/disabled
+++ b/zinc/src/sbt-test/apiinfo/java-basic/disabled
@@ -1,0 +1,1 @@
+> compile

--- a/zinc/src/sbt-test/apiinfo/java-basic/src/main/java/test/O2.java
+++ b/zinc/src/sbt-test/apiinfo/java-basic/src/main/java/test/O2.java
@@ -1,0 +1,10 @@
+package test;
+
+public class O2 extends Outer {
+  public static class O3 extends O2 {}
+  public static class O4 extends Outer {}
+  public class O5 extends O4 {}
+  public class O6 extends O2 {}
+  public class O7 extends O5 {}
+}
+

--- a/zinc/src/sbt-test/apiinfo/java-basic/src/main/java/test/Outer.java
+++ b/zinc/src/sbt-test/apiinfo/java-basic/src/main/java/test/Outer.java
@@ -1,0 +1,7 @@
+package test;
+
+public class Outer {
+	public class Inner extends Outer {
+		public class InnerB extends Outer {}
+	}
+}

--- a/zinc/src/sbt-test/apiinfo/java-basic/src/main/java/test/R.java
+++ b/zinc/src/sbt-test/apiinfo/java-basic/src/main/java/test/R.java
@@ -1,0 +1,10 @@
+package test;
+
+public final class R {
+   public static final int y = 4;
+   public static int x = (new stest.S()).y();
+	public static void main(String[] args)
+	{
+		assert(args[0] == "1");
+	}
+}

--- a/zinc/src/sbt-test/apiinfo/java-basic/src/main/scala/S.scala
+++ b/zinc/src/sbt-test/apiinfo/java-basic/src/main/scala/S.scala
@@ -1,0 +1,7 @@
+package stest
+
+class S
+{
+	val x = test.R.y
+	val y = 5
+}

--- a/zinc/src/sbt-test/apiinfo/unstable-existential-names/changes/Foo1.scala
+++ b/zinc/src/sbt-test/apiinfo/unstable-existential-names/changes/Foo1.scala
@@ -1,0 +1,13 @@
+package test
+
+class Box[T]
+
+class Foo {
+	/**
+	 * This method shouldn't affect public API of Foo
+	 * but due to instability of synthesized names for
+	 * existentials causes change of `foo` method API.
+	 */
+	private def abc: Box[_] = null
+	def foo: Box[_] = null
+}

--- a/zinc/src/sbt-test/apiinfo/unstable-existential-names/src/main/scala/Bar.scala
+++ b/zinc/src/sbt-test/apiinfo/unstable-existential-names/src/main/scala/Bar.scala
@@ -1,0 +1,5 @@
+package test
+
+class Bar {
+	def f: Foo = null //we introduce dependency on Foo
+}

--- a/zinc/src/sbt-test/apiinfo/unstable-existential-names/src/main/scala/Foo.scala
+++ b/zinc/src/sbt-test/apiinfo/unstable-existential-names/src/main/scala/Foo.scala
@@ -1,0 +1,7 @@
+package test
+
+class Box[T]
+
+class Foo {
+	def foo: Box[_] = null
+}

--- a/zinc/src/sbt-test/apiinfo/unstable-existential-names/test
+++ b/zinc/src/sbt-test/apiinfo/unstable-existential-names/test
@@ -1,0 +1,12 @@
+# Tests if existential types are pickled correctly so they
+# do not introduce unnecessary compile iterations
+
+# introduces first compile iteration
+> compile
+# this change is local to a method and does not change the api so introduces
+# only one additional compile iteration
+$ copy-file changes/Foo1.scala src/main/scala/Foo.scala
+# second iteration
+> compile
+# check if there are only two compile iterations being performed
+> checkIterations 2


### PR DESCRIPTION
Ref https://github.com/sbt/zinc/issues/114, https://github.com/sbt/zinc/pull/280

I'm seeing some stackoverflow on Travis CI job on sbt/sbt trying the latest Zinc.
For example - https://gist.github.com/eed3si9n/eae2f52a5a9bbca8831b354086a6120d

This ports some of the apiinfo scripted tests from sbt/sbt some `disabled`. I'm guessing that this is a regression introduced in https://github.com/sbt/zinc/pull/280.
To test this I've added the tests on top of c3052d0f76ab3142081f7101a9631bf8642bf525, and locally the tests pass.  Travis here - https://travis-ci.org/eed3si9n/zinc/builds/221614826

/cc @zehkae 
