### PR TITLE
Revert "Remove unnecessary use of lazy in classes defined by compiler-interface"

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/ExtractAPI.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ExtractAPI.scala
@@ -555,14 +555,14 @@ class ExtractAPI[GlobalType <: Global](
     val acc = getAccess(c)
     val name = classNameAsSeenIn(in, c)
     val tParams = typeParameters(in, sym) // look at class symbol
-    val selfType = this.selfType(in, sym)
-    def constructClass(structure: Structure): ClassLike = {
+    val selfType = lzy(this.selfType(in, sym))
+    def constructClass(structure: xsbti.api.Lazy[Structure]): ClassLike = {
       new xsbti.api.ClassLike(name, acc, modifiers, anns,
         defType, selfType, structure, emptyStringArray,
         childrenOfSealedClass, topLevel, tParams) // use original symbol (which is a term symbol when `c.isModule`) for `name` and other non-classy stuff
     }
     val info = viewer(in).memberInfo(sym)
-    val structure = structureWithInherited(info, sym)
+    val structure = lzy(structureWithInherited(info, sym))
     val classWithMembers = constructClass(structure)
 
     allNonLocalClassesInSrc += classWithMembers

--- a/internal/compiler-bridge/src/main/scala/xsbt/ExtractAPI.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ExtractAPI.scala
@@ -341,7 +341,7 @@ class ExtractAPI[GlobalType <: Global](
   def linearizedAncestorTypes(info: Type): List[Type] = info.baseClasses.tail.map(info.baseType)
 
   private def mkStructure(s: Symbol, bases: List[Type], declared: List[Symbol], inherited: List[Symbol]): xsbti.api.Structure = {
-    new xsbti.api.Structure(types(s, bases), processDefinitions(s, declared), lzy(processDefinitions(s, inherited)))
+    new xsbti.api.Structure(lzy(types(s, bases)), lzy(processDefinitions(s, declared)), lzy(processDefinitions(s, inherited)))
   }
   private def processDefinitions(in: Symbol, defs: List[Symbol]): Array[xsbti.api.ClassDefinition] =
     sort(defs.toArray).flatMap((d: Symbol) => definition(in, d))

--- a/internal/compiler-interface/src/main/contraband/definition.json
+++ b/internal/compiler-interface/src/main/contraband/definition.json
@@ -101,11 +101,11 @@
           "type": "record",
           "fields": [
             { "name": "definitionType",        "type": "DefinitionType" },
-            { "name": "selfType",              "type": "Type"           },
-            { "name": "structure",             "type": "Structure"      },
+            { "name": "selfType",              "type": "lazy Type"      },
+            { "name": "structure",             "type": "lazy Structure" },
             { "name": "savedAnnotations",      "type": "String*"        },
             { "name": "childrenOfSealedClass", "type": "Type*"          },
-            { "name": "topLevel",              "type": "boolean"        },
+            { "name": "topLevel",              "type": "Boolean"        },
             { "name": "typeParameters",        "type": "TypeParameter*" }
           ]
         }

--- a/internal/compiler-interface/src/main/contraband/definition.json
+++ b/internal/compiler-interface/src/main/contraband/definition.json
@@ -105,7 +105,7 @@
             { "name": "structure",             "type": "lazy Structure" },
             { "name": "savedAnnotations",      "type": "String*"        },
             { "name": "childrenOfSealedClass", "type": "Type*"          },
-            { "name": "topLevel",              "type": "Boolean"        },
+            { "name": "topLevel",              "type": "boolean"        },
             { "name": "typeParameters",        "type": "TypeParameter*" }
           ]
         }

--- a/internal/compiler-interface/src/main/contraband/type.json
+++ b/internal/compiler-interface/src/main/contraband/type.json
@@ -77,8 +77,8 @@
           "target": "Java",
           "type": "record",
           "fields": [
-            { "name": "parents",   "type": "Type*"                 },
-            { "name": "declared",  "type": "ClassDefinition*"      },
+            { "name": "parents",   "type": "lazy Type*"            },
+            { "name": "declared",  "type": "lazy ClassDefinition*" },
             { "name": "inherited", "type": "lazy ClassDefinition*" }
           ]
         },

--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
@@ -109,8 +109,8 @@ object ClassToAPI {
     if (!Modifier.isPrivate(c.getModifiers))
       cmap.inherited ++= parentJavaTypes.collect { case parent: Class[_] => c -> parent }
     val parentTypes = types(parentJavaTypes)
-    val instanceStructure = new api.Structure(parentTypes, all.declared.toArray, lzyS(all.inherited.toArray))
-    val staticStructure = new api.Structure(emptyTypeArray, all.staticDeclared.toArray, lzyS(all.staticInherited.toArray))
+    val instanceStructure = new api.Structure(lzyS(parentTypes), lzyS(all.declared.toArray), lzyS(all.inherited.toArray))
+    val staticStructure = new api.Structure(lzyEmptyTpeArray, lzyS(all.staticDeclared.toArray), lzyS(all.staticInherited.toArray))
     (staticStructure, instanceStructure)
   }
 
@@ -130,9 +130,8 @@ object ClassToAPI {
   private val emptyTypeArray = new Array[xsbti.api.Type](0)
   private val emptyAnnotationArray = new Array[xsbti.api.Annotation](0)
   private val emptyTypeParameterArray = new Array[xsbti.api.TypeParameter](0)
-  private val emptyDefArray = new Array[xsbti.api.ClassDefinition](0)
   private val lzyEmptyTpeArray = lzyS(emptyTypeArray)
-  private val lzyEmptyDefArray = lzyS(emptyDefArray)
+  private val lzyEmptyDefArray = lzyS(new Array[xsbti.api.ClassDefinition](0))
 
   private def allSuperTypes(t: Type): Seq[Type] =
     {
@@ -161,7 +160,7 @@ object ClassToAPI {
   def parents(c: Class[_]): Seq[api.Type] = types(allSuperTypes(c))
   def types(ts: Seq[Type]): Array[api.Type] = (ts filter (_ ne null) map reference).toArray
   def upperBounds(ts: Array[Type]): api.Type =
-    new api.Structure(types(ts), emptyDefArray, lzyEmptyDefArray)
+    new api.Structure(lzy(types(ts)), lzyEmptyDefArray, lzyEmptyDefArray)
 
   @deprecated("Use fieldToDef[4] instead", "0.13.9")
   def fieldToDef(enclPkg: Option[String])(f: Field): api.FieldLike = {

--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
@@ -83,11 +83,11 @@ object ClassToAPI {
       val topLevel = c.getEnclosingClass == null
       val name = classCanonicalName(c)
       val tpe = if (Modifier.isInterface(c.getModifiers)) Trait else ClassDef
-      val (static, instance) = structure(c, enclPkg, cmap)
-      val cls = new api.ClassLike(name, acc, mods, annots, tpe, Empty, instance, emptyStringArray, children.toArray,
+      lazy val (static, instance) = structure(c, enclPkg, cmap)
+      val cls = new api.ClassLike(name, acc, mods, annots, tpe, lzyS(Empty), lzy(instance, cmap), emptyStringArray, children.toArray,
         topLevel, typeParameters(typeParameterTypes(c)))
       val clsDef = new api.ClassLikeDef(name, acc, mods, annots, typeParameters(typeParameterTypes(c)), tpe)
-      val stat = new api.ClassLike(name, acc, mods, annots, Module, Empty, static, emptyStringArray, emptyTypeArray,
+      val stat = new api.ClassLike(name, acc, mods, annots, Module, lzyS(Empty), lzy(static, cmap), emptyStringArray, emptyTypeArray,
         topLevel, emptyTypeParameterArray)
       val statDef = new api.ClassLikeDef(name, acc, mods, annots, emptyTypeParameterArray, Module)
       val defs = cls :: stat :: Nil
@@ -120,12 +120,18 @@ object ClassToAPI {
 
   @inline private[this] def lzyS[T <: AnyRef](t: T): xsbti.api.Lazy[T] = SafeLazyProxy.strict(t)
   @inline final def lzy[T <: AnyRef](t: => T): xsbti.api.Lazy[T] = SafeLazyProxy(t)
+  private[this] def lzy[T <: AnyRef](t: => T, cmap: ClassMap): xsbti.api.Lazy[T] = {
+    val s = lzy(t)
+    cmap.lz += s
+    s
+  }
 
   private val emptyStringArray = new Array[String](0)
   private val emptyTypeArray = new Array[xsbti.api.Type](0)
   private val emptyAnnotationArray = new Array[xsbti.api.Annotation](0)
   private val emptyTypeParameterArray = new Array[xsbti.api.TypeParameter](0)
   private val emptyDefArray = new Array[xsbti.api.ClassDefinition](0)
+  private val lzyEmptyTpeArray = lzyS(emptyTypeArray)
   private val lzyEmptyDefArray = lzyS(emptyDefArray)
 
   private def allSuperTypes(t: Type): Seq[Type] =

--- a/internal/zinc-apiinfo/src/main/scala/xsbt/api/APIUtil.scala
+++ b/internal/zinc-apiinfo/src/main/scala/xsbt/api/APIUtil.scala
@@ -64,9 +64,9 @@ object APIUtil {
     }
 
   def minimizeStructure(s: Structure, isModule: Boolean): Structure =
-    new Structure(s.parents, filterDefinitions(s.declared, isModule), lzy(filterDefinitions(s.inherited, isModule)))
-  def filterDefinitions(ds: Array[ClassDefinition], isModule: Boolean): Array[ClassDefinition] =
-    if (isModule) ds filter Discovery.isMainMethod else Array()
+    new Structure(lzy(s.parents), filterDefinitions(s.declared, isModule), filterDefinitions(s.inherited, isModule))
+  def filterDefinitions(ds: Array[ClassDefinition], isModule: Boolean): Lazy[Array[ClassDefinition]] =
+    lzy(if (isModule) ds filter Discovery.isMainMethod else Array())
 
   def isNonPrivate(d: Definition): Boolean = isNonPrivate(d.access)
   /** Returns false if the `access` is `Private` and qualified, true otherwise.*/
@@ -76,7 +76,7 @@ object APIUtil {
       case _ => true
     }
   private val emptyModifiers = new Modifiers(false, false, false, false, false, false, false, false)
-  private val emptyStructure = new Structure(Array.empty, Array.empty, lzy(Array.empty))
+  private val emptyStructure = new Structure(lzy(Array.empty), lzy(Array.empty), lzy(Array.empty))
   def emptyClassLike(name: String, definitionType: DefinitionType): ClassLike =
     new xsbti.api.ClassLike(name, new Public, emptyModifiers, Array.empty,
       definitionType, lzy(emptyType), lzy(emptyStructure), Array.empty, Array.empty, true, Array.empty)

--- a/internal/zinc-apiinfo/src/main/scala/xsbt/api/APIUtil.scala
+++ b/internal/zinc-apiinfo/src/main/scala/xsbt/api/APIUtil.scala
@@ -59,7 +59,7 @@ object APIUtil {
       val savedAnnotations = Discovery.defAnnotations(c.structure, (_: Any) => true).toArray[String]
       val struct = minimizeStructure(c.structure, c.definitionType == DefinitionType.Module)
       new ClassLike(c.name, c.access, c.modifiers, c.annotations,
-        c.definitionType, emptyType, struct, savedAnnotations, c.childrenOfSealedClass,
+        c.definitionType, lzy(emptyType), lzy(struct), savedAnnotations, c.childrenOfSealedClass,
         c.topLevel, c.typeParameters)
     }
 
@@ -79,7 +79,7 @@ object APIUtil {
   private val emptyStructure = new Structure(Array.empty, Array.empty, lzy(Array.empty))
   def emptyClassLike(name: String, definitionType: DefinitionType): ClassLike =
     new xsbti.api.ClassLike(name, new Public, emptyModifiers, Array.empty,
-      definitionType, emptyType, emptyStructure, Array.empty, Array.empty, true, Array.empty)
+      definitionType, lzy(emptyType), lzy(emptyStructure), Array.empty, Array.empty, true, Array.empty)
 
   private[this] def lzy[T <: AnyRef](t: T): Lazy[T] = SafeLazyProxy.strict(t)
 

--- a/internal/zinc-apiinfo/src/test/scala/xsbt/api/NameHashingSpecification.scala
+++ b/internal/zinc-apiinfo/src/test/scala/xsbt/api/NameHashingSpecification.scala
@@ -292,8 +292,8 @@ class NameHashingSpecification extends UnitSpec {
 
   private def simpleClassLike(name: String, structure: Structure,
     dt: DefinitionType = DefinitionType.ClassDef, topLevel: Boolean = true, access: Access = publicAccess): ClassLike = {
-    new ClassLike(name, access, defaultModifiers, Array.empty, dt, emptyType,
-      structure, Array.empty, Array.empty, topLevel, Array.empty)
+    new ClassLike(name, access, defaultModifiers, Array.empty, dt, lzy(emptyType),
+      lzy(structure), Array.empty, Array.empty, topLevel, Array.empty)
   }
 
   private val emptyType = new EmptyType

--- a/internal/zinc-apiinfo/src/test/scala/xsbt/api/NameHashingSpecification.scala
+++ b/internal/zinc-apiinfo/src/test/scala/xsbt/api/NameHashingSpecification.scala
@@ -156,11 +156,11 @@ class NameHashingSpecification extends UnitSpec {
     val barMethod = new Def("bar", publicAccess, defaultModifiers, Array.empty, Array.empty, Array.empty, intTpe)
     val parentB = simpleClass("Parent", barMethod)
     val childA = {
-      val structure = new Structure(Array[Type](parentA.structure), emptyMembers, lzyEmptyMembers)
+      val structure = new Structure(lzy(Array[Type](parentA.structure)), emptyMembers, emptyMembers)
       simpleClassLike("Child", structure)
     }
     val childB = {
-      val structure = new Structure(Array[Type](parentB.structure), emptyMembers, lzy(Array[ClassDefinition](barMethod)))
+      val structure = new Structure(lzy(Array[Type](parentB.structure)), emptyMembers, lzy(Array[ClassDefinition](barMethod)))
       simpleClassLike("Child", structure)
     }
     val parentANameHashes = nameHashesForClass(parentA)
@@ -278,7 +278,7 @@ class NameHashingSpecification extends UnitSpec {
   private def lzy[T](x: T): Lazy[T] = new Lazy[T] { def get: T = x }
 
   private def simpleStructure(defs: ClassDefinition*) =
-    new Structure(Array.empty[Type], defs.toArray, lzyEmptyMembers)
+    new Structure(lzy(Array.empty[Type]), lzy(defs.toArray), emptyMembers)
 
   private def simpleClass(name: String, defs: ClassDefinition*): ClassLike = {
     val structure = simpleStructure(defs: _*)
@@ -302,7 +302,6 @@ class NameHashingSpecification extends UnitSpec {
   private val publicAccess = new Public
   private val privateAccess = new Private(new Unqualified)
   private val defaultModifiers = new Modifiers(false, false, false, false, false, false, false, false)
-  private val emptyMembers = Array.empty[ClassDefinition]
-  private val lzyEmptyMembers = lzy(emptyMembers)
+  private val emptyMembers = lzy(Array.empty[ClassDefinition])
 
 }

--- a/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/javac/JavaCompilerSpec.scala
+++ b/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/javac/JavaCompilerSpec.scala
@@ -95,7 +95,7 @@ class JavaCompilerSpec extends UnitSpec {
         val (result, _) = compile(local, Seq(input), Seq("-d", out.getAbsolutePath))
         result shouldBe true
         val clazzz = new URLClassLoader(Array(out.toURI.toURL)).loadClass("hasstaticfinal")
-        ClassToAPI(Seq(clazzz)).sortBy(_.definitionType.hashCode)
+        ClassToAPI(Seq(clazzz))
       }
 
     // compile with two different primitive values, and confirm that they match if their

--- a/internal/zinc-persist/src/test/scala/sbt/inc/TestCaseGenerators.scala
+++ b/internal/zinc-persist/src/test/scala/sbt/inc/TestCaseGenerators.scala
@@ -76,7 +76,7 @@ object TestCaseGenerators {
   // We need "proper" definitions with specific class names, as groupBy use these to pick a representative top-level class when splitting.
   private[this] def makeClassLike(name: String, definitionType: DefinitionType): ClassLike =
     new ClassLike(name, new Public(), APIs.emptyModifiers, Array(),
-      definitionType, new EmptyType(), emptyStructure, Array(), Array(), true, Array())
+      definitionType, lzy(new EmptyType()), lzy(emptyStructure), Array(), Array(), true, Array())
 
   private[this] def makeCompanions(name: String): Companions =
     new Companions(makeClassLike(name, DefinitionType.ClassDef), makeClassLike(name, DefinitionType.Module))

--- a/internal/zinc-persist/src/test/scala/sbt/inc/TestCaseGenerators.scala
+++ b/internal/zinc-persist/src/test/scala/sbt/inc/TestCaseGenerators.scala
@@ -71,7 +71,7 @@ object TestCaseGenerators {
     } yield Stamps(zipMap(prod, prodStamps), zipMap(src, srcStamps), zipMap(bin, binStamps))
   }
 
-  private[this] val emptyStructure = new Structure(Array(), Array(), lzy(Array()))
+  private[this] val emptyStructure = new Structure(lzy(Array()), lzy(Array()), lzy(Array()))
 
   // We need "proper" definitions with specific class names, as groupBy use these to pick a representative top-level class when splitting.
   private[this] def makeClassLike(name: String, definitionType: DefinitionType): ClassLike =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   val bootstrapSbtVersion = "0.13.8"
   private val ioVersion = "1.0.0-M10"
   private val utilVersion = "1.0.0-M22"
-  private val lmVersion = "1.0.0-X8"
+  private val lmVersion = "1.0.0-X9"
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion
 

--- a/zinc/src/sbt-test/apiinfo/circular-structure/build.sbt
+++ b/zinc/src/sbt-test/apiinfo/circular-structure/build.sbt
@@ -1,0 +1,16 @@
+// import sbt.inc.Analysis
+
+// logLevel := Level.Debug
+
+// incOptions ~= { _.withApiDebug(true) }
+
+// TaskKey[Unit]("show-apis") := {
+//   val a = (compile in Compile).value match { case a: Analysis => a }
+//   val scalaSrc = (scalaSource in Compile).value
+//   val javaSrc = (javaSource in Compile).value
+//   val aApi = a.apis.internalAPI(scalaSrc / "A.scala").api
+//   val jApi = a.apis.internalAPI(javaSrc / "test/J.java").api
+//   import xsbt.api.DefaultShowAPI
+//   DefaultShowAPI(aApi)
+//   DefaultShowAPI(jApi)
+// }

--- a/zinc/src/sbt-test/apiinfo/circular-structure/src/main/java/test/J.java
+++ b/zinc/src/sbt-test/apiinfo/circular-structure/src/main/java/test/J.java
@@ -1,0 +1,6 @@
+package test;
+
+public class J {
+  public static final class J2 extends J { }
+  public static final class J3 extends J { }
+}

--- a/zinc/src/sbt-test/apiinfo/circular-structure/src/main/scala/A.scala
+++ b/zinc/src/sbt-test/apiinfo/circular-structure/src/main/scala/A.scala
@@ -1,0 +1,6 @@
+package test
+
+class A {
+	class B extends A
+	class C extends A
+}

--- a/zinc/src/sbt-test/apiinfo/circular-structure/test
+++ b/zinc/src/sbt-test/apiinfo/circular-structure/test
@@ -1,0 +1,2 @@
+# test case for http://github.com/sbt/sbt/issues/676
+> compile

--- a/zinc/src/sbt-test/apiinfo/java-basic/src/main/java/test/O2.java
+++ b/zinc/src/sbt-test/apiinfo/java-basic/src/main/java/test/O2.java
@@ -1,0 +1,10 @@
+package test;
+
+public class O2 extends Outer {
+  public static class O3 extends O2 {}
+  public static class O4 extends Outer {}
+  public class O5 extends O4 {}
+  public class O6 extends O2 {}
+  public class O7 extends O5 {}
+}
+

--- a/zinc/src/sbt-test/apiinfo/java-basic/src/main/java/test/Outer.java
+++ b/zinc/src/sbt-test/apiinfo/java-basic/src/main/java/test/Outer.java
@@ -1,0 +1,7 @@
+package test;
+
+public class Outer {
+	public class Inner extends Outer {
+		public class InnerB extends Outer {}
+	}
+}

--- a/zinc/src/sbt-test/apiinfo/java-basic/src/main/java/test/R.java
+++ b/zinc/src/sbt-test/apiinfo/java-basic/src/main/java/test/R.java
@@ -1,0 +1,10 @@
+package test;
+
+public final class R {
+   public static final int y = 4;
+   public static int x = (new stest.S()).y();
+	public static void main(String[] args)
+	{
+		assert(args[0] == "1");
+	}
+}

--- a/zinc/src/sbt-test/apiinfo/java-basic/src/main/scala/S.scala
+++ b/zinc/src/sbt-test/apiinfo/java-basic/src/main/scala/S.scala
@@ -1,0 +1,7 @@
+package stest
+
+class S
+{
+	val x = test.R.y
+	val y = 5
+}

--- a/zinc/src/sbt-test/apiinfo/java-basic/test
+++ b/zinc/src/sbt-test/apiinfo/java-basic/test
@@ -1,0 +1,1 @@
+> compile

--- a/zinc/src/sbt-test/apiinfo/unstable-existential-names/changes/Foo1.scala
+++ b/zinc/src/sbt-test/apiinfo/unstable-existential-names/changes/Foo1.scala
@@ -1,0 +1,13 @@
+package test
+
+class Box[T]
+
+class Foo {
+	/**
+	 * This method shouldn't affect public API of Foo
+	 * but due to instability of synthesized names for
+	 * existentials causes change of `foo` method API.
+	 */
+	private def abc: Box[_] = null
+	def foo: Box[_] = null
+}

--- a/zinc/src/sbt-test/apiinfo/unstable-existential-names/src/main/scala/Bar.scala
+++ b/zinc/src/sbt-test/apiinfo/unstable-existential-names/src/main/scala/Bar.scala
@@ -1,0 +1,5 @@
+package test
+
+class Bar {
+	def f: Foo = null //we introduce dependency on Foo
+}

--- a/zinc/src/sbt-test/apiinfo/unstable-existential-names/src/main/scala/Foo.scala
+++ b/zinc/src/sbt-test/apiinfo/unstable-existential-names/src/main/scala/Foo.scala
@@ -1,0 +1,7 @@
+package test
+
+class Box[T]
+
+class Foo {
+	def foo: Box[_] = null
+}

--- a/zinc/src/sbt-test/apiinfo/unstable-existential-names/test
+++ b/zinc/src/sbt-test/apiinfo/unstable-existential-names/test
@@ -1,0 +1,12 @@
+# Tests if existential types are pickled correctly so they
+# do not introduce unnecessary compile iterations
+
+# introduces first compile iteration
+> compile
+# this change is local to a method and does not change the api so introduces
+# only one additional compile iteration
+$ copy-file changes/Foo1.scala src/main/scala/Foo.scala
+# second iteration
+> compile
+# check if there are only two compile iterations being performed
+> checkIterations 2

--- a/zinc/src/sbt-test/source-dependencies/lazy-inherited/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/lazy-inherited/A.scala
@@ -1,1 +1,0 @@
-class A { class B extends A }

--- a/zinc/src/sbt-test/source-dependencies/lazy-inherited/test
+++ b/zinc/src/sbt-test/source-dependencies/lazy-inherited/test
@@ -1,1 +1,0 @@
-> compile


### PR DESCRIPTION
This reverts #114 and adds integration tests from sbt/sbt that uncovered stackoverflow errors.

Ref #280
Subsumes #290
