### PR TITLE
workaround Scala 2.12 not detecting *.jar changes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,8 @@ def commonSettings: Seq[Setting[_]] = Seq(
   crossScalaVersions := Seq(scala211, scala212),
   mimaPreviousArtifacts := Set(), // Some(organization.value %% moduleName.value % "1.0.0"),
   publishArtifact in Test := false,
-  commands ++= Seq(publishBridgesAndTest, publishBridges, crossTestBridges, scalafmtCheck)
+  commands ++= Seq(publishBridgesAndTest, publishBridges, crossTestBridges, scalafmtCheck),
+  scalacOptions += "-YdisableFlatCpCaching"
 )
 
 def relaxNon212: Seq[Setting[_]] = Seq(
@@ -46,7 +47,8 @@ def relaxNon212: Seq[Setting[_]] = Seq(
         old filterNot Set("-Xfatal-warnings",
                           "-deprecation",
                           "-Ywarn-unused",
-                          "-Ywarn-unused-import")
+                          "-Ywarn-unused-import",
+                          "-YdisableFlatCpCaching")
     }
   }
 )


### PR DESCRIPTION
Fixes sbt/zinc#282
Ref scala/bug#10295

exportJars := true exposes JAR file as subproject dependency.
Scala 2.12.2 fails to invalidate the source it's used. `-YdisableFlatCpCaching` works around this. (Thanks @smarter for letting me know)
