### PR TITLE
Fix ConsoleInterface binding things properly.

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/ConsoleInterface.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ConsoleInterface.scala
@@ -54,7 +54,7 @@ class ConsoleInterface {
           super.createInterpreter()
 
         for ((id, value) <- bindNames zip bindValues)
-          intp.beQuietDuring(intp.bind(id, value))
+          intp.beQuietDuring(intp.bind(id, value.asInstanceOf[AnyRef].getClass.getName, value))
 
         if (!initialCommands.isEmpty)
           intp.interpret(initialCommands)


### PR DESCRIPTION
In reference to https://github.com/sbt/sbt/issues/2884 I'm seeing the
console helpers (cpHelpers) being statically 'Object', and therefore not
being that helpful:

    scala> cpHelpers
    res0: Object = sbt.internal.ConsoleProject$Imports@610be000

    scala> cpHelpers.taskKeyEvaluate
    <console>:37: error: value taskKeyEvaluate is not a member of Object
           cpHelpers.taskKeyEvaluate
                     ^

    scala> cpHelpers.asInstanceOf[sbt.internal.ConsoleProject.Imports].taskKeyEvaluate _
    res3: sbt.TaskKey[Nothing] => sbt.internal.ConsoleProject.Evaluate[Nothing] = $$Lambda$4294/1575143649@5a54d62c

This is because I misinterpreted the Scala 2.8 compatibility layer I
tore out in 1abf6ca3bfe0628321e1562a9b4cfe58e19ab7b7.