### PR TITLE
Improve Zinc logging API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -445,6 +445,7 @@ addCommandAlias(
 )
 
 lazy val otherRootSettings = Seq(
+  Scripted.scriptedBufferLog := true,
   Scripted.scriptedPrescripted := { addSbtAlternateResolver _ },
   Scripted.scripted := scriptedTask.evaluated,
   Scripted.scriptedUnpublished := scriptedUnpublishedTask.evaluated,
@@ -467,6 +468,7 @@ def scriptedTask: Def.Initialize[InputTask[Unit]] = Def.inputTask {
     (scalaInstance in zincScripted).value,
     scriptedSource.value,
     result,
+    scriptedBufferLog.value,
     scriptedPrescripted.value
   )
 }
@@ -498,6 +500,7 @@ def scriptedUnpublishedTask: Def.Initialize[InputTask[Unit]] = Def.inputTask {
     (scalaInstance in zincScripted).value,
     scriptedSource.value,
     result,
+    scriptedBufferLog.value,
     scriptedPrescripted.value
   )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -252,6 +252,7 @@ lazy val zincIvyIntegration = (project in internalPath / "zinc-ivy-integration")
 
 // sbt-side interface to compiler.  Calls compiler-side interface reflectively
 lazy val zincCompileCore = (project in internalPath / "zinc-compile-core")
+  .enablePlugins(ContrabandPlugin)
   .dependsOn(
     compilerInterface % "compile;test->test",
     zincClasspath,

--- a/build.sbt
+++ b/build.sbt
@@ -332,7 +332,6 @@ lazy val compilerBridge: Project = (project in internalPath / "compiler-bridge")
     }.toList),
     altPublishSettings
   )
-  .configure(addSbtIO, addSbtUtilLogging)
 
 val scalaPartialVersion = Def setting (CrossVersion partialVersion scalaVersion.value)
 

--- a/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
@@ -157,7 +157,6 @@ sealed class ZincCompiler(settings: Settings, dreporter: DelegatingReporter, out
 
   // Scala 2.10.x and later
   private[xsbt] def logUnreportedWarnings(seq: Seq[(String, List[(Position, String)])]): Unit = {
-    val drep = reporter.asInstanceOf[DelegatingReporter]
     for ((what, warnings) <- seq; (pos, msg) <- warnings)
       yield callback.problem(what, DelegatingReporter.convert(pos), msg, Severity.Warn, false)
     ()

--- a/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
@@ -159,7 +159,7 @@ sealed class ZincCompiler(settings: Settings, dreporter: DelegatingReporter, out
   private[xsbt] def logUnreportedWarnings(seq: Seq[(String, List[(Position, String)])]): Unit = {
     val drep = reporter.asInstanceOf[DelegatingReporter]
     for ((what, warnings) <- seq; (pos, msg) <- warnings)
-      yield callback.problem(what, drep.convert(pos), msg, Severity.Warn, false)
+      yield callback.problem(what, DelegatingReporter.convert(pos), msg, Severity.Warn, false)
     ()
   }
 }

--- a/internal/compiler-bridge/src/main/scala/xsbt/DelegatingReporter.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/DelegatingReporter.scala
@@ -9,6 +9,8 @@ package xsbt
 
 import java.io.File
 import java.util.Optional
+
+import scala.reflect.internal.util.{ FakePos, NoPosition, Position }
 import Compat._
 
 private object DelegatingReporter {
@@ -38,85 +40,112 @@ private object DelegatingReporter {
       }
   }
 
+  object PositionImpl {
+    def empty: PositionImpl = new PositionImpl(None, None, None, "", None, None, None)
+  }
+
   import java.lang.{ Integer => I }
-  private[xsbt] def o2oi(opt: Option[Int]): Optional[I] =
+  private[xsbt] def o2oi(opt: Option[Int]): Optional[I] = {
     opt match {
       case Some(s) => Optional.ofNullable[I](s: I)
       case None    => Optional.empty[I]
     }
-  private[xsbt] def o2jo[A](o: Option[A]): Optional[A] =
+  }
+
+  private[xsbt] def o2jo[A](o: Option[A]): Optional[A] = {
     o match {
       case Some(v) => Optional.ofNullable(v)
       case None    => Optional.empty[A]()
     }
+  }
+
+  private[xsbt] def convert(dirtyPos: Position): xsbti.Position = {
+    def cleanPos(pos: Position) = {
+      Option(pos) match {
+        case None | Some(NoPosition) => None
+        case Some(_: FakePos)        => None
+        case _                       => Option(pos.finalPosition)
+      }
+    }
+
+    def makePosition(pos: Position): xsbti.Position = {
+      val src = pos.source
+      val sourcePath = src.file.path
+      val sourceFile = src.file.file
+      val line = pos.line
+      val lineContent = pos.lineContent.stripLineEnd
+      val offset = pos.point
+      val pointer = offset - src.lineToOffset(src.offsetToLine(offset))
+      val pointerSpace = lineContent.toList.take(pointer).map {
+        case '\t' => '\t'
+        case x    => ' '
+      }
+      new PositionImpl(Option(sourcePath),
+                       Option(sourceFile),
+                       Option(line),
+                       lineContent,
+                       Option(offset),
+                       Option(pointer),
+                       Option(pointerSpace.mkString))
+    }
+
+    cleanPos(dirtyPos) match {
+      case None           => PositionImpl.empty
+      case Some(cleanPos) => makePosition(cleanPos)
+    }
+  }
 }
 
-// The following code is based on scala.tools.nsc.reporters.{AbstractReporter, ConsoleReporter}
 // Copyright 2002-2009 LAMP/EPFL
 // Original author: Martin Odersky
-private final class DelegatingReporter(warnFatal: Boolean,
-                                       noWarn: Boolean,
-                                       private[this] var delegate: xsbti.Reporter)
-    extends scala.tools.nsc.reporters.Reporter {
-  import scala.reflect.internal.util.{ FakePos, NoPosition, Position }
-  import DelegatingReporter._
+// Based on scala.tools.nsc.reporters.{AbstractReporter, ConsoleReporter}
+private final class DelegatingReporter(
+    warnFatal: Boolean,
+    noWarn: Boolean,
+    private[this] var delegate: xsbti.Reporter
+) extends scala.tools.nsc.reporters.Reporter {
   def dropDelegate(): Unit = { delegate = null }
   def error(msg: String): Unit = error(FakePos("scalac"), msg)
-
   def printSummary(): Unit = delegate.printSummary()
 
+  def problems = delegate.problems
   override def hasErrors = delegate.hasErrors
   override def hasWarnings = delegate.hasWarnings
-  def problems = delegate.problems
-  override def comment(pos: Position, msg: String): Unit = delegate.comment(convert(pos), msg)
-
+  override def comment(pos: Position, msg: String): Unit =
+    delegate.comment(DelegatingReporter.convert(pos), msg)
   override def reset(): Unit = {
-    super.reset
+    super.reset()
     delegate.reset()
   }
+
   protected def info0(pos: Position, msg: String, rawSeverity: Severity, force: Boolean): Unit = {
     val skip = rawSeverity == WARNING && noWarn
     if (!skip) {
       val severity = if (warnFatal && rawSeverity == WARNING) ERROR else rawSeverity
-      delegate.log(convert(pos), msg, convert(severity))
+      delegate.log(new CompileProblem(DelegatingReporter.convert(pos), msg, convert(severity)))
     }
-  }
-  def convert(posIn: Position): xsbti.Position = {
-    val posOpt =
-      Option(posIn) match {
-        case None | Some(NoPosition) => None
-        case Some(_: FakePos)        => None
-        case _                       => Option(posIn.finalPosition)
-      }
-    posOpt match {
-      case None      => new PositionImpl(None, None, None, "", None, None, None)
-      case Some(pos) => makePosition(pos)
-    }
-  }
-  private[this] def makePosition(pos: Position): xsbti.Position = {
-    val src = pos.source
-    val sourcePath = src.file.path
-    val sourceFile = src.file.file
-    val line = pos.line
-    val lineContent = pos.lineContent.stripLineEnd
-    val offset = pos.point
-    val pointer = offset - src.lineToOffset(src.offsetToLine(offset))
-    val pointerSpace =
-      (lineContent: Seq[Char]).take(pointer).map { case '\t' => '\t'; case x => ' ' }.mkString
-    new PositionImpl(Option(sourcePath),
-                     Option(sourceFile),
-                     Option(line),
-                     lineContent,
-                     Option(offset),
-                     Option(pointer),
-                     Option(pointerSpace))
   }
 
   import xsbti.Severity.{ Info, Warn, Error }
-  private[this] def convert(sev: Severity): xsbti.Severity =
+  private[this] def convert(sev: Severity): xsbti.Severity = {
     sev match {
       case INFO    => Info
       case WARNING => Warn
       case ERROR   => Error
     }
+  }
+
+  // Define our own problem because the bridge should not depend on sbt util-logging.
+  import xsbti.{ Problem => XProblem, Position => XPosition, Severity => XSeverity }
+  private final class CompileProblem(
+      pos: XPosition,
+      msg: String,
+      sev: XSeverity
+  ) extends XProblem {
+    override val category = ""
+    override val position = pos
+    override val message = msg
+    override val severity = sev
+    override def toString = s"[$severity] $pos: $message"
+  }
 }

--- a/internal/compiler-bridge/src/test/scala/xsbt/ScalaCompilerForUnitTesting.scala
+++ b/internal/compiler-bridge/src/test/scala/xsbt/ScalaCompilerForUnitTesting.scala
@@ -205,7 +205,7 @@ class ScalaCompilerForUnitTesting {
     def hasWarnings: Boolean = false
     def printWarnings(): Unit = ()
     def problems: Array[Problem] = Array.empty
-    def log(pos: Position, msg: String, sev: Severity): Unit = println(msg)
+    def log(problem: Problem): Unit = println(problem.message())
     def comment(pos: Position, msg: String): Unit = ()
     def printSummary(): Unit = ()
   }

--- a/internal/compiler-interface/src/main/java/xsbti/Reporter.java
+++ b/internal/compiler-interface/src/main/java/xsbti/Reporter.java
@@ -31,7 +31,7 @@ public interface Reporter {
 	Problem[] problems();
 
 	/** Log a message at a concrete position and with a concrete severity. */
-	void log(Position pos, String msg, Severity sev);
+	void log(Problem problem);
 
 	/** Report a comment. */
 	void comment(Position pos, String msg);

--- a/internal/zinc-benchmarks/src/main/scala/xsbt/ZincBenchmark.scala
+++ b/internal/zinc-benchmarks/src/main/scala/xsbt/ZincBenchmark.scala
@@ -148,7 +148,7 @@ private[xsbt] object ZincBenchmark {
     def hasWarnings: Boolean = false
     def printWarnings(): Unit = ()
     def problems: Array[Problem] = Array.empty
-    def log(pos: Position, msg: String, sev: Severity): Unit = println(msg)
+    def log(problem: Problem): Unit = println(problem.message())
     def comment(pos: Position, msg: String): Unit = ()
     def printSummary(): Unit = ()
   }

--- a/internal/zinc-compile-core/src/main/contraband/reporter.json
+++ b/internal/zinc-compile-core/src/main/contraband/reporter.json
@@ -1,0 +1,17 @@
+{
+  "types": [
+    {
+      "name": "ReporterConfig",
+      "namespace": "xsbti",
+      "target": "Java",
+      "type": "record",
+      "fields": [
+        { "name": "loggerName",        "type": "String"                                           },
+        { "name": "maximumErrors",     "type": "int"                                              },
+        { "name": "useColor",          "type": "boolean"                                          },
+        { "name": "logLevel",          "type": "java.util.logging.Level"                           },
+        { "name": "positionMapper",    "type": "java.util.function.Function<Position, Position>"  }
+      ]
+    }
+  ]
+}

--- a/internal/zinc-compile-core/src/main/contraband/reporter.json
+++ b/internal/zinc-compile-core/src/main/contraband/reporter.json
@@ -9,7 +9,9 @@
         { "name": "loggerName",        "type": "String"                                           },
         { "name": "maximumErrors",     "type": "int"                                              },
         { "name": "useColor",          "type": "boolean"                                          },
-        { "name": "logLevel",          "type": "java.util.logging.Level"                           },
+        { "name": "msgFilters",        "type": "java.util.regex.Pattern*"                         },
+        { "name": "fileFilters",       "type": "java.util.regex.Pattern*"                         },
+        { "name": "logLevel",          "type": "java.util.logging.Level"                          },
         { "name": "positionMapper",    "type": "java.util.function.Function<Position, Position>"  }
       ]
     }

--- a/internal/zinc-compile-core/src/main/contraband/reporter.json
+++ b/internal/zinc-compile-core/src/main/contraband/reporter.json
@@ -6,13 +6,13 @@
       "target": "Java",
       "type": "record",
       "fields": [
-        { "name": "loggerName",        "type": "String"                                           },
-        { "name": "maximumErrors",     "type": "int"                                              },
-        { "name": "useColor",          "type": "boolean"                                          },
-        { "name": "msgFilters",        "type": "java.util.regex.Pattern*"                         },
-        { "name": "fileFilters",       "type": "java.util.regex.Pattern*"                         },
-        { "name": "logLevel",          "type": "java.util.logging.Level"                          },
-        { "name": "positionMapper",    "type": "java.util.function.Function<Position, Position>"  }
+        { "name": "loggerName",        "type": "String"                                                    },
+        { "name": "maximumErrors",     "type": "int"                                                       },
+        { "name": "useColor",          "type": "boolean"                                                   },
+        { "name": "msgFilters",        "type": "java.util.function.Function<String, Boolean>*"                         },
+        { "name": "fileFilters",       "type": "java.util.function.Function<java.nio.file.Path, Boolean>*" },
+        { "name": "logLevel",          "type": "java.util.logging.Level"                                   },
+        { "name": "positionMapper",    "type": "java.util.function.Function<Position, Position>"           }
       ]
     }
   ]

--- a/internal/zinc-compile-core/src/main/java/xsbti/ReporterUtil.java
+++ b/internal/zinc-compile-core/src/main/java/xsbti/ReporterUtil.java
@@ -21,4 +21,8 @@ public interface ReporterUtil {
     public static Reporter getReporter(PrintStream stream, ReporterConfig config) {
         return ReporterManager.getReporter(stream, config);
     }
+
+    public static Reporter getReporter(xsbti.Logger logger, ReporterConfig config) {
+        return ReporterManager.getReporter(logger, config);
+    }
 }

--- a/internal/zinc-compile-core/src/main/java/xsbti/ReporterUtil.java
+++ b/internal/zinc-compile-core/src/main/java/xsbti/ReporterUtil.java
@@ -1,0 +1,18 @@
+package xsbti;
+
+import sbt.internal.inc.LoggerReporter;
+import sbt.internal.inc.ReporterManager;
+import sbt.internal.util.ManagedLogger;
+import sbt.util.Level$;
+
+import java.util.function.Function;
+
+public interface ReporterUtil {
+    public static ReporterConfig getDefaultReporterConfig() {
+        return ReporterManager.getDefaultReporterConfig();
+    }
+
+    public static Reporter getDefault(ReporterConfig config) {
+        return ReporterManager.getReporter(System.out, config);
+    }
+}

--- a/internal/zinc-compile-core/src/main/java/xsbti/ReporterUtil.java
+++ b/internal/zinc-compile-core/src/main/java/xsbti/ReporterUtil.java
@@ -1,11 +1,9 @@
 package xsbti;
 
-import sbt.internal.inc.LoggerReporter;
 import sbt.internal.inc.ReporterManager;
-import sbt.internal.util.ManagedLogger;
-import sbt.util.Level$;
 
-import java.util.function.Function;
+import java.io.PrintStream;
+import java.io.PrintWriter;
 
 public interface ReporterUtil {
     public static ReporterConfig getDefaultReporterConfig() {
@@ -14,5 +12,13 @@ public interface ReporterUtil {
 
     public static Reporter getDefault(ReporterConfig config) {
         return ReporterManager.getReporter(System.out, config);
+    }
+
+    public static Reporter getReporter(PrintWriter writer, ReporterConfig config) {
+        return ReporterManager.getReporter(writer, config);
+    }
+
+    public static Reporter getReporter(PrintStream stream, ReporterConfig config) {
+        return ReporterManager.getReporter(stream, config);
     }
 }

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala
@@ -67,7 +67,7 @@ final class AnalyzingCompiler(
     val compArgs = new CompilerArguments(scalaInstance, classpathOptions)
     val arguments = compArgs(Nil, classpath, None, options)
     val output = CompileOutput(singleOutput)
-    val reporter = new LoggerReporter(maximumErrors, log, p => p)
+    val reporter = new LoggerReporter(maximumErrors, log)
     val progress = Optional.empty[CompileProgress]
     compile(sources, changes, arguments.toArray, output, callback, reporter, cache, log, progress)
   }

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala
@@ -18,7 +18,7 @@ import sbt.util.Logger
 import sbt.io.syntax._
 import sbt.internal.inc.classpath.ClassLoaderCache
 import sbt.internal.util.ManagedLogger
-import xsbti.{ AnalysisCallback, Reporter, Logger => xLogger }
+import xsbti.{ AnalysisCallback, Reporter, ReporterUtil, Logger => xLogger }
 import xsbti.compile._
 
 /**
@@ -67,7 +67,9 @@ final class AnalyzingCompiler(
     val compArgs = new CompilerArguments(scalaInstance, classpathOptions)
     val arguments = compArgs(Nil, classpath, None, options)
     val output = CompileOutput(singleOutput)
-    val reporter = new LoggerReporter(maximumErrors, log)
+    val basicReporterConfig = ReporterUtil.getDefaultReporterConfig()
+    val reporterConfig = basicReporterConfig.withMaximumErrors(maximumErrors)
+    val reporter = ReporterManager.getReporter(log, reporterConfig)
     val progress = Optional.empty[CompileProgress]
     compile(sources, changes, arguments.toArray, output, callback, reporter, cache, log, progress)
   }

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala
@@ -143,7 +143,7 @@ final class AnalyzingCompiler(
       maximumErrors: Int,
       log: ManagedLogger
   ): Unit = {
-    val reporter = new LoggerReporter(maximumErrors, log)
+    val reporter = new ManagedLoggerReporter(maximumErrors, log)
     doc(sources, classpath, outputDirectory, options, log, reporter)
   }
 

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala
@@ -143,7 +143,7 @@ final class AnalyzingCompiler(
       maximumErrors: Int,
       log: ManagedLogger
   ): Unit = {
-    val reporter = new ManagedLoggerReporter(maximumErrors, log)
+    val reporter = new ManagedLoggedReporter(maximumErrors, log)
     doc(sources, classpath, outputDirectory, options, log, reporter)
   }
 

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/FilteredReporter.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/FilteredReporter.scala
@@ -1,0 +1,45 @@
+package sbt.internal.inc
+
+import sbt.internal.util.ManagedLogger
+import xsbti.{ Position, Problem, Severity }
+
+import scala.util.matching.Regex
+
+/**
+ * Defines a filtered reporter as Pants Zinc's fork does letting users control which messages
+ * are reported or not. This implementation has been adapted from the Pants repository.
+ *
+ * @link https://github.com/pantsbuild/pants/blob/master/src/scala/org/pantsbuild/zinc/logging/Reporters.scala#L28
+ *
+ * This reporter may be useful to companies that have domain-specific knowledge
+ * about compile messages that are not relevant and can be filtered out, or users
+ * that hold similar knowledge about the piece of code that they compile.
+ */
+class FilteredReporter(
+    fileFilters: Array[Regex],
+    msgFilters: Array[Regex],
+    maximumErrors: Int,
+    logger: ManagedLogger,
+    positionMapper: Position => Position
+) extends LoggerReporter(maximumErrors, logger, positionMapper) {
+  private final def isFiltered(filters: Seq[Regex], str: String): Boolean =
+    filters.exists(_.findFirstIn(str).isDefined)
+
+  private final def isFiltered(pos: Position, msg: String, severity: Severity): Boolean = {
+    severity != Severity.Error && (
+      (pos.sourceFile.isPresent && isFiltered(fileFilters, pos.sourceFile.get.getPath)) ||
+      (isFiltered(msgFilters, msg))
+    )
+  }
+
+  /**
+   * Redefines display so that non-error messages whose paths match a regex in `fileFilters`
+   * or whose messages' content match `msgFilters` are not reported to the user.
+   */
+  override def display(problem: Problem): Unit = {
+    val severity = problem.severity()
+    val dontShow = isFiltered(problem.position(), problem.message(), severity)
+    if (dontShow) inc(severity)
+    else super.display(problem)
+  }
+}

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/FilteredReporter.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/FilteredReporter.scala
@@ -1,7 +1,6 @@
 package sbt.internal.inc
 
-import sbt.internal.util.ManagedLogger
-import xsbti.{ Position, Problem, Severity }
+import xsbti.{ Logger, Position, Problem, Severity }
 
 import scala.util.matching.Regex
 
@@ -19,7 +18,7 @@ class FilteredReporter(
     fileFilters: Array[Regex],
     msgFilters: Array[Regex],
     maximumErrors: Int,
-    logger: ManagedLogger,
+    logger: Logger,
     positionMapper: Position => Position
 ) extends LoggerReporter(maximumErrors, logger, positionMapper) {
   private final def isFiltered(pos: Position, msg: String, severity: Severity): Boolean = {

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/FilteredReporter.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/FilteredReporter.scala
@@ -20,7 +20,7 @@ class FilteredReporter(
     maximumErrors: Int,
     logger: Logger,
     positionMapper: Position => Position
-) extends LoggerReporter(maximumErrors, logger, positionMapper) {
+) extends LoggedReporter(maximumErrors, logger, positionMapper) {
   private final def isFiltered(pos: Position, msg: String, severity: Severity): Boolean = {
     def isFiltered(filters: Seq[Regex], str: String): Boolean =
       filters.exists(_.findFirstIn(str).isDefined)

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/LoggedReporter.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/LoggedReporter.scala
@@ -18,12 +18,12 @@ import xsbti.{ Logger, Position, Problem, Reporter, Severity }
 import java.util.EnumMap
 
 import scala.collection.mutable
-import LoggerReporter._
+import LoggedReporter._
 import sbt.internal.util.ManagedLogger
 import sbt.internal.util.codec._
 import Severity.{ Error, Warn, Info => SInfo }
 
-object LoggerReporter {
+object LoggedReporter {
   final class PositionKey(pos: Position) {
     import sbt.util.InterfaceUtil.jo2o
     def offset = pos.offset
@@ -61,7 +61,7 @@ object LoggerReporter {
  * This functionality can be use by anyone that wants to get support for event
  * logging and use an underlying, controlled logger under the hood.
  *
- * The [[ManagedLoggerReporter]] exists for those users that do not want to set
+ * The [[ManagedLoggedReporter]] exists for those users that do not want to set
  * up the passed logger. Event logging requires registration of codects to
  * serialize and deserialize [[Problem]]s. This reporter makes sure to initialize
  * the managed logger so that users do not need to take care of this cumbersome process.
@@ -70,11 +70,11 @@ object LoggerReporter {
  * @param logger The event managed logger.
  * @param sourcePositionMapper The position mapper.
  */
-class ManagedLoggerReporter(
+class ManagedLoggedReporter(
     maximumErrors: Int,
     logger: ManagedLogger,
     sourcePositionMapper: Position => Position = identity[Position]
-) extends LoggerReporter(maximumErrors, logger, sourcePositionMapper) {
+) extends LoggedReporter(maximumErrors, logger, sourcePositionMapper) {
   import problemFormats._
   import problemStringFormats._
   logger.registerStringCodec[Problem]
@@ -95,7 +95,7 @@ class ManagedLoggerReporter(
  * @param logger The logger interface provided by the user.
  * @param sourcePositionMapper The position mapper.
  */
-class LoggerReporter(
+class LoggedReporter(
     maximumErrors: Int,
     logger: Logger,
     sourcePositionMapper: Position => Position = identity[Position]

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/LoggerReporter.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/LoggerReporter.scala
@@ -54,12 +54,11 @@ object LoggerReporter {
   lazy val problemStringFormats: ProblemStringFormats = new ProblemStringFormats {}
 }
 
-class LoggerReporter(maximumErrors: Int,
-                     logger: ManagedLogger,
-                     sourcePositionMapper: Position => Position = { p =>
-                       p
-                     })
-    extends Reporter {
+class LoggerReporter(
+    maximumErrors: Int,
+    logger: ManagedLogger,
+    sourcePositionMapper: Position => Position = identity[Position]
+) extends Reporter {
   val positions = new mutable.HashMap[PositionKey, Severity]
   val count = new EnumMap[Severity, Int](classOf[Severity])
   private[this] val allProblems = new mutable.ListBuffer[Problem]
@@ -75,6 +74,7 @@ class LoggerReporter(maximumErrors: Int,
     positions.clear()
     allProblems.clear()
   }
+
   def hasWarnings = count.get(Warn) > 0
   def hasErrors = count.get(Error) > 0
   def problems: Array[Problem] = allProblems.toArray

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/LoggerReporter.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/LoggerReporter.scala
@@ -103,7 +103,7 @@ class LoggerReporter(
       logger.error(countElementsAsString(errors, "error") + " found")
   }
 
-  private def inc(sev: Severity) = count.put(sev, count.get(sev) + 1)
+  protected def inc(sev: Severity) = count.put(sev, count.get(sev) + 1)
 
   // this is used by sbt
   private[sbt] def display(p: Problem): Unit = {

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/LoggerReporter.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/LoggerReporter.scala
@@ -86,10 +86,9 @@ class LoggerReporter(
     val p = problem("", mappedPos, msg, severity)
     allProblems += p
     severity match {
-      case Warn | Error => {
-        if (!testAndLog(mappedPos, severity))
-          display(p)
-      }
+      case Warn | Error =>
+        if (!testAndLog(mappedPos, severity)) display(p)
+        else ()
       case _ => display(p)
     }
   }
@@ -108,9 +107,10 @@ class LoggerReporter(
   // this is used by sbt
   private[sbt] def display(p: Problem): Unit = {
     import problemFormats._
-    inc(p.severity)
-    if (p.severity != Error || maximumErrors <= 0 || count.get(p.severity) <= maximumErrors) {
-      p.severity match {
+    val severity = p.severity()
+    inc(severity)
+    if (severity != Error || maximumErrors <= 0 || count.get(severity) <= maximumErrors) {
+      severity match {
         case Error => logger.errorEvent(p)
         case Warn  => logger.warnEvent(p)
         case SInfo => logger.infoEvent(p)

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/LoggerReporter.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/LoggerReporter.scala
@@ -39,7 +39,7 @@ object LoggerReporter {
       jo2o(pos.offset).hashCode * 31 + jo2o(pos.sourceFile).hashCode
   }
 
-  def countElementsAsString(n: Int, elements: String): String =
+  def countElementsAsString(n: Int, elements: String): String = {
     n match {
       case 0 => "no " + elements + "s"
       case 1 => "one " + elements
@@ -48,6 +48,7 @@ object LoggerReporter {
       case 4 => "four " + elements + "s"
       case _ => "" + n + " " + elements + "s"
     }
+  }
 
   lazy val problemFormats: ProblemFormats = new ProblemFormats with SeverityFormats
   with PositionFormats with sjsonnew.BasicJsonProtocol {}

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/LoggerReporter.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/LoggerReporter.scala
@@ -62,7 +62,7 @@ class LoggerReporter(
 ) extends Reporter {
   val positions = new mutable.HashMap[PositionKey, Severity]
   val count = new EnumMap[Severity, Int](classOf[Severity])
-  private[this] val allProblems = new mutable.ListBuffer[Problem]
+  protected val allProblems = new mutable.ListBuffer[Problem]
 
   import problemStringFormats._
   logger.registerStringCodec[Problem]
@@ -83,11 +83,11 @@ class LoggerReporter(
 
   override def log(problem0: Problem): Unit = {
     import sbt.util.InterfaceUtil
-    val (category, position, msg, severity) =
-      (problem0.category(), problem0.position, problem0.message, problem0.severity)
+    val (category, position, message, severity) =
+      (problem0.category, problem0.position, problem0.message, problem0.severity)
     // Note: positions in reported errors can be fixed with `sourcePositionMapper`.
     val transformedPos: Position = sourcePositionMapper(position)
-    val problem = InterfaceUtil.problem(category, transformedPos, msg, severity)
+    val problem = InterfaceUtil.problem(category, transformedPos, message, severity)
     allProblems += problem
     severity match {
       case Warn | Error =>
@@ -106,10 +106,8 @@ class LoggerReporter(
       logger.error(countElementsAsString(errors, "error") + " found")
   }
 
-  protected def inc(sev: Severity) = count.put(sev, count.get(sev) + 1)
-
-  // this is used by sbt
-  private[sbt] def display(p: Problem): Unit = {
+  private def inc(sev: Severity) = count.put(sev, count.get(sev) + 1)
+  private def display(p: Problem): Unit = {
     import problemFormats._
     val severity = p.severity()
     inc(severity)

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/ProblemStringFormats.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/ProblemStringFormats.scala
@@ -15,7 +15,7 @@ import sbt.util.InterfaceUtil.jo2o
 
 /**
  * Represent a string that contains the compiler output (warnings and error
- * messages, etc) that have been reported by [[LoggerReporter]] and the logger.
+ * messages, etc) that have been reported by [[LoggedReporter]] and the logger.
  */
 trait ProblemStringFormats {
   implicit lazy val ProblemStringFormat: ShowLines[Problem] = new ShowLines[Problem] {

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/ProblemStringFormats.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/ProblemStringFormats.scala
@@ -26,10 +26,8 @@ trait ProblemStringFormats {
         case _ =>
           val pos = p.position
           val sourcePrefix = jo2o(pos.sourcePath).getOrElse("")
-          val columnNumber = jo2o(pos.pointer).map(_.toInt + 1).getOrElse(1)
-          val lineNumberString = jo2o(pos.line)
-            .map(":" + _ + ":" + columnNumber + ":")
-            .getOrElse(":") + " "
+          val columnNumber = jo2o(pos.pointer).fold(1)(_.toInt + 1)
+          val lineNumberString = jo2o(pos.line).fold(":")(":" + _ + ":" + columnNumber + ":") + " "
           val line1 = sourcePrefix + lineNumberString + p.message
           val lineContent = pos.lineContent
           if (!lineContent.isEmpty) {

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/ReporterManager.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/ReporterManager.scala
@@ -65,7 +65,7 @@ object ReporterManager {
     val maxErrors = config.maximumErrors()
     val posMapper = config.positionMapper().toScala
     if (config.fileFilters().isEmpty && config.msgFilters.isEmpty)
-      new ManagedLoggerReporter(maxErrors, logger, posMapper)
+      new ManagedLoggedReporter(maxErrors, logger, posMapper)
     else {
       implicit def scalaPatterns(patterns: Array[java.util.regex.Pattern]): Array[Regex] =
         patterns.map(_.pattern().r)

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/ReporterManager.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/ReporterManager.scala
@@ -65,7 +65,7 @@ object ReporterManager {
     val maxErrors = config.maximumErrors()
     val posMapper = config.positionMapper().toScala
     if (config.fileFilters().isEmpty && config.msgFilters.isEmpty)
-      new LoggerReporter(maxErrors, logger, posMapper)
+      new ManagedLoggerReporter(maxErrors, logger, posMapper)
     else {
       implicit def scalaPatterns(patterns: Array[java.util.regex.Pattern]): Array[Regex] =
         patterns.map(_.pattern().r)

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/ReporterManager.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/ReporterManager.scala
@@ -69,7 +69,8 @@ object ReporterManager {
     else {
       implicit def scalaPatterns(patterns: Array[java.util.regex.Pattern]): Array[Regex] =
         patterns.map(_.pattern().r)
-      new FilteredReporter(config.fileFilters, config.msgFilters, maxErrors, logger, posMapper)
+      val (fileRegexes, msgRegexes) = (config.fileFilters, config.msgFilters)
+      new ManagedFilteredReporter(fileRegexes, msgRegexes, maxErrors, logger, posMapper)
     }
   }
 

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/DiagnosticsReporter.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/DiagnosticsReporter.scala
@@ -54,16 +54,19 @@ final class DiagnosticsReporter(reporter: Reporter) extends DiagnosticListener[J
   }
 
   override def report(d: Diagnostic[_ <: JavaFileObject]): Unit = {
-    val severity =
+    val severity: Severity = {
       d.getKind match {
         case Diagnostic.Kind.ERROR                                       => Severity.Error
         case Diagnostic.Kind.WARNING | Diagnostic.Kind.MANDATORY_WARNING => Severity.Warn
         case _                                                           => Severity.Info
       }
+    }
+
+    import sbt.util.InterfaceUtil.problem
     val msg = fixedDiagnosticMessage(d)
     val pos: xsbti.Position = new PositionImpl(d)
     if (severity == Severity.Error) errorEncountered = true
-    reporter.log(pos, msg, severity)
+    reporter.log(problem("", pos, msg, severity))
   }
 
   private class PositionImpl(d: Diagnostic[_ <: JavaFileObject]) extends xsbti.Position {

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavacProcessLogger.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavacProcessLogger.scala
@@ -46,9 +46,7 @@ final class JavacLogger(log: sbt.util.Logger, reporter: Reporter, cwd: File)
         case (Error, msg) => msg
       } mkString "\n"
     val parser = new JavaErrorParser(cwd)
-    parser.parseProblems(input, log) foreach { e =>
-      reporter.log(e.position, e.message, e.severity)
-    }
+    parser.parseProblems(input, log).foreach(reporter.log)
   }
 
   def flush(exitCode: Int): Unit = {

--- a/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/javac/JavaCompilerSpec.scala
+++ b/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/javac/JavaCompilerSpec.scala
@@ -185,7 +185,7 @@ class JavaCompilerSpec extends UnitSpec {
               incToolOptions: IncToolOptions = IncToolOptionsUtil.defaultIncToolOptions())
     : (Boolean, Array[Problem]) = {
     val log = LogExchange.logger("JavaCompilerSpec")
-    val reporter = new LoggerReporter(10, log)
+    val reporter = new ManagedLoggerReporter(10, log)
     val result = c.javac.run(sources.toArray, args.toArray, incToolOptions, reporter, log)
     (result, reporter.problems)
   }
@@ -196,7 +196,7 @@ class JavaCompilerSpec extends UnitSpec {
           incToolOptions: IncToolOptions = IncToolOptionsUtil.defaultIncToolOptions())
     : (Boolean, Array[Problem]) = {
     val log = LogExchange.logger("JavaCompilerSpec")
-    val reporter = new LoggerReporter(10, log)
+    val reporter = new ManagedLoggerReporter(10, log)
     val result = c.javadoc.run(sources.toArray, args.toArray, incToolOptions, reporter, log)
     (result, reporter.problems)
   }

--- a/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/javac/JavaCompilerSpec.scala
+++ b/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/javac/JavaCompilerSpec.scala
@@ -185,7 +185,7 @@ class JavaCompilerSpec extends UnitSpec {
               incToolOptions: IncToolOptions = IncToolOptionsUtil.defaultIncToolOptions())
     : (Boolean, Array[Problem]) = {
     val log = LogExchange.logger("JavaCompilerSpec")
-    val reporter = new ManagedLoggerReporter(10, log)
+    val reporter = new ManagedLoggedReporter(10, log)
     val result = c.javac.run(sources.toArray, args.toArray, incToolOptions, reporter, log)
     (result, reporter.problems)
   }
@@ -196,7 +196,7 @@ class JavaCompilerSpec extends UnitSpec {
           incToolOptions: IncToolOptions = IncToolOptionsUtil.defaultIncToolOptions())
     : (Boolean, Array[Problem]) = {
     val log = LogExchange.logger("JavaCompilerSpec")
-    val reporter = new ManagedLoggerReporter(10, log)
+    val reporter = new ManagedLoggedReporter(10, log)
     val result = c.javadoc.run(sources.toArray, args.toArray, incToolOptions, reporter, log)
     (result, reporter.problems)
   }

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -347,7 +347,7 @@ case class ProjectStructure(
     // to specify it in the incremental option property file (this is the default for sbt)
     val incOptionsFile = baseDirectory / "incOptions.properties"
     val (incOptions, scalacOptions) = loadIncOptions(incOptionsFile)
-    val reporter = new ManagedLoggerReporter(maxErrors, scriptedLog)
+    val reporter = new ManagedLoggedReporter(maxErrors, scriptedLog)
     val extra = Array(t2(("key", "value")))
     val setup = compiler.setup(lookup,
                                skip = false,

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -347,7 +347,7 @@ case class ProjectStructure(
     // to specify it in the incremental option property file (this is the default for sbt)
     val incOptionsFile = baseDirectory / "incOptions.properties"
     val (incOptions, scalacOptions) = loadIncOptions(incOptionsFile)
-    val reporter = new LoggerReporter(maxErrors, scriptedLog, identity)
+    val reporter = new LoggerReporter(maxErrors, scriptedLog)
     val extra = Array(t2(("key", "value")))
     val setup = compiler.setup(lookup,
                                skip = false,

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -347,7 +347,7 @@ case class ProjectStructure(
     // to specify it in the incremental option property file (this is the default for sbt)
     val incOptionsFile = baseDirectory / "incOptions.properties"
     val (incOptions, scalacOptions) = loadIncOptions(incOptionsFile)
-    val reporter = new LoggerReporter(maxErrors, scriptedLog)
+    val reporter = new ManagedLoggerReporter(maxErrors, scriptedLog)
     val extra = Array(t2(("key", "value")))
     val setup = compiler.setup(lookup,
                                skip = false,

--- a/project/Scripted.scala
+++ b/project/Scripted.scala
@@ -14,6 +14,7 @@ object Scripted {
     "Execute scripted without publishing SBT first. Saves you some time when only your test has changed.")
   lazy val scriptedSource = SettingKey[File]("scripted-source")
   lazy val scriptedPrescripted = TaskKey[File => Unit]("scripted-prescripted")
+  lazy val scriptedBufferLog = SettingKey[Boolean]("scripted-buffer-log")
 
   import sbt.complete._
   import DefaultParsers._
@@ -71,6 +72,7 @@ object Scripted {
                  scriptedSbtInstance: ScalaInstance,
                  sourcePath: File,
                  args: Seq[String],
+                 bufferLog: Boolean,
                  prescripted: File => Unit): Unit = {
     System.err.println(s"About to run tests: ${args.mkString("\n * ", "\n * ", "\n")}")
     val noJLine = new classpath.FilteredLoader(scriptedSbtInstance.loader, "jline." :: Nil)
@@ -79,7 +81,7 @@ object Scripted {
     val bridge = bridgeClass.newInstance.asInstanceOf[IncScriptedRunner]
     // val launcherVmOptions = Array("-XX:MaxPermSize=256M") // increased after a failure in scripted source-dependencies/macro
     try {
-      bridge.run(sourcePath, true, args.toArray)
+      bridge.run(sourcePath, bufferLog, args.toArray)
     } catch { case ite: java.lang.reflect.InvocationTargetException => throw ite.getCause }
   }
 }

--- a/zinc-compile/src/test/scala/inc/DocSpec.scala
+++ b/zinc-compile/src/test/scala/inc/DocSpec.scala
@@ -6,7 +6,7 @@ import java.io.File
 import sbt.io.IO
 import sbt.internal.inc.javac.{ JavaCompiler, JavaTools, Javadoc }
 import sbt.internal.inc.javac.JavaCompilerSpec
-import sbt.internal.inc.{ LoggerReporter, UnitSpec }
+import sbt.internal.inc.{ ManagedLoggerReporter, UnitSpec }
 import xsbti.compile.IncToolOptionsUtil
 import sbt.util.CacheStoreFactory
 
@@ -48,7 +48,7 @@ class DocSpec extends UnitSpec {
       JavaCompiler.local.getOrElse(sys.error("This test cannot be run on a JRE, but only a JDK.")),
       Javadoc.local.getOrElse(Javadoc.fork())
     )
-  lazy val reporter = new LoggerReporter(10, log)
+  lazy val reporter = new ManagedLoggerReporter(10, log)
   def knownSampleGoodFile =
     new File(classOf[JavaCompilerSpec].getResource("good.java").toURI)
 }

--- a/zinc-compile/src/test/scala/inc/DocSpec.scala
+++ b/zinc-compile/src/test/scala/inc/DocSpec.scala
@@ -6,7 +6,7 @@ import java.io.File
 import sbt.io.IO
 import sbt.internal.inc.javac.{ JavaCompiler, JavaTools, Javadoc }
 import sbt.internal.inc.javac.JavaCompilerSpec
-import sbt.internal.inc.{ ManagedLoggerReporter, UnitSpec }
+import sbt.internal.inc.{ ManagedLoggedReporter, UnitSpec }
 import xsbti.compile.IncToolOptionsUtil
 import sbt.util.CacheStoreFactory
 
@@ -48,7 +48,7 @@ class DocSpec extends UnitSpec {
       JavaCompiler.local.getOrElse(sys.error("This test cannot be run on a JRE, but only a JDK.")),
       Javadoc.local.getOrElse(Javadoc.fork())
     )
-  lazy val reporter = new ManagedLoggerReporter(10, log)
+  lazy val reporter = new ManagedLoggedReporter(10, log)
   def knownSampleGoodFile =
     new File(classOf[JavaCompilerSpec].getResource("good.java").toURI)
 }

--- a/zinc/src/test/scala/sbt/inc/BaseCompilerSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/BaseCompilerSpec.scala
@@ -110,7 +110,7 @@ class BaseCompilerSpec extends BridgeProviderSpecification {
     val cs = compiler.compilers(si, ClasspathOptionsUtil.boot, None, sc)
 
     val lookup = MockedLookup(Function.const(Optional.empty[CompileAnalysis]))
-    val reporter = new LoggerReporter(maxErrors, log, identity)
+    val reporter = new LoggerReporter(maxErrors, log)
     val extra = Array(InterfaceUtil.t2(("key", "value")))
 
     var lastCompiledUnits: Set[String] = Set.empty

--- a/zinc/src/test/scala/sbt/inc/BaseCompilerSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/BaseCompilerSpec.scala
@@ -110,7 +110,7 @@ class BaseCompilerSpec extends BridgeProviderSpecification {
     val cs = compiler.compilers(si, ClasspathOptionsUtil.boot, None, sc)
 
     val lookup = MockedLookup(Function.const(Optional.empty[CompileAnalysis]))
-    val reporter = new LoggerReporter(maxErrors, log)
+    val reporter = new ManagedLoggerReporter(maxErrors, log)
     val extra = Array(InterfaceUtil.t2(("key", "value")))
 
     var lastCompiledUnits: Set[String] = Set.empty

--- a/zinc/src/test/scala/sbt/inc/BaseCompilerSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/BaseCompilerSpec.scala
@@ -110,7 +110,7 @@ class BaseCompilerSpec extends BridgeProviderSpecification {
     val cs = compiler.compilers(si, ClasspathOptionsUtil.boot, None, sc)
 
     val lookup = MockedLookup(Function.const(Optional.empty[CompileAnalysis]))
-    val reporter = new ManagedLoggerReporter(maxErrors, log)
+    val reporter = new ManagedLoggedReporter(maxErrors, log)
     val extra = Array(InterfaceUtil.t2(("key", "value")))
 
     var lastCompiledUnits: Set[String] = Set.empty

--- a/zinc/src/test/scala/sbt/inc/MultiProjectIncrementalSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/MultiProjectIncrementalSpec.scala
@@ -73,7 +73,7 @@ class MultiProjectIncrementalSpec extends BridgeProviderSpecification {
           def externalClassFileManager: Optional[ClassFileManager] = Optional.empty()
         })
 
-      val reporter = new LoggerReporter(maxErrors, log, identity)
+      val reporter = new LoggerReporter(maxErrors, log)
       val setup = compiler.setup(lookup,
                                  skip = false,
                                  cacheFile,

--- a/zinc/src/test/scala/sbt/inc/MultiProjectIncrementalSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/MultiProjectIncrementalSpec.scala
@@ -73,7 +73,7 @@ class MultiProjectIncrementalSpec extends BridgeProviderSpecification {
           def externalClassFileManager: Optional[ClassFileManager] = Optional.empty()
         })
 
-      val reporter = new LoggerReporter(maxErrors, log)
+      val reporter = new ManagedLoggerReporter(maxErrors, log)
       val setup = compiler.setup(lookup,
                                  skip = false,
                                  cacheFile,

--- a/zinc/src/test/scala/sbt/inc/MultiProjectIncrementalSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/MultiProjectIncrementalSpec.scala
@@ -73,7 +73,7 @@ class MultiProjectIncrementalSpec extends BridgeProviderSpecification {
           def externalClassFileManager: Optional[ClassFileManager] = Optional.empty()
         })
 
-      val reporter = new ManagedLoggerReporter(maxErrors, log)
+      val reporter = new ManagedLoggedReporter(maxErrors, log)
       val setup = compiler.setup(lookup,
                                  skip = false,
                                  cacheFile,


### PR DESCRIPTION
This is the follow-up work to https://github.com/sbt/zinc/pull/304 and all the
comments that @stuhood has provided. Thank you for that.

Every commit is rich in details in its message. If you have any doubt about a
change, I invite you to read it.

I'm attaching a screenshot showing all the commits passing in Scala Center's
CI. I had to remove the first of the commits, and therefore all those passing
commits are lost.