### PR TITLE
Remove JDK-version dependent code out of the compiler bridge

### DIFF
--- a/internal/compiler-interface/src/main/java/xsbti/compile/CompilerBridgeProvider.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/CompilerBridgeProvider.java
@@ -7,9 +7,7 @@
 
 package xsbti.compile;
 
-import xsbti.F0;
 import xsbti.Logger;
-
 import java.io.File;
 
 /**
@@ -20,44 +18,6 @@ import java.io.File;
  * compile them and then define the sbt component, which is reused across different sbt projects.
  */
 public interface CompilerBridgeProvider {
-
-    /**
-     * Defines a constant {@link CompilerBridgeProvider} that returns an already compiled bridge.
-     * <p>
-     * This method is useful for external build tools that want full control over the retrieval
-     * and compilation of the compiler bridge, as well as the Scala instance to be used.
-     *
-     * @param file The jar or directory of the compiled Scala bridge.
-     * @return A provider that always returns the same compiled bridge.
-     */
-    static CompilerBridgeProvider constant(File file, ScalaInstance scalaInstance) {
-        return new CompilerBridgeProvider() {
-            @Override
-            public File fetchCompiledBridge(ScalaInstance scalaInstance, Logger logger) {
-                logger.debug(new F0<String>() {
-                    @Override
-                    public String apply() {
-                        String bridgeName = file.getAbsolutePath();
-                        return "Returning already retrieved and compiled bridge: " + bridgeName + ".";
-                    }
-                });
-                return file;
-            }
-
-            @Override
-            public ScalaInstance fetchScalaInstance(String scalaVersion, Logger logger) {
-                logger.debug(new F0<String>() {
-                    @Override
-                    public String apply() {
-                        String instance = scalaInstance.toString();
-                        return "Returning default scala instance:\n\t" + instance;
-                    }
-                });
-                return scalaInstance;
-            }
-        };
-    }
-
     /**
      * Get the location of the compiled Scala compiler bridge for a concrete Scala version.
      *

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -113,7 +113,7 @@ final class IncHandler(directory: File, cacheDir: File, scriptedLog: ManagedLogg
 
   private final val unit = (_: Seq[String]) => ()
   def scalaCompiler(instance: xsbti.compile.ScalaInstance, bridgeJar: File): AnalyzingCompiler = {
-    val bridgeProvider = CompilerBridgeProvider.constant(bridgeJar, instance)
+    val bridgeProvider = ZincUtil.constantBridgeProvider(instance, bridgeJar)
     val classpath = ClasspathOptionsUtil.boot
     new AnalyzingCompiler(instance, bridgeProvider, classpath, unit, IncHandler.classLoaderCache)
   }

--- a/zinc/src/main/java/xsbti/compile/ZincCompilerUtil.java
+++ b/zinc/src/main/java/xsbti/compile/ZincCompilerUtil.java
@@ -8,6 +8,8 @@
 package xsbti.compile;
 
 import java.io.File;
+import xsbti.F0;
+import xsbti.Logger;
 
 /**
  * Defines a util interface to get Scala compilers and the default implementation
@@ -50,5 +52,43 @@ public interface ZincCompilerUtil {
     public static ScalaCompiler scalaCompiler(ScalaInstance scalaInstance,
                                               File compilerBridgeJar) {
         return sbt.internal.inc.ZincUtil.scalaCompiler(scalaInstance, compilerBridgeJar);
+    }
+
+    /**
+     * Defines a constant {@link CompilerBridgeProvider} that returns an already compiled bridge.
+     * <p>
+     * This method is useful for external build tools that want full control over the retrieval
+     * and compilation of the compiler bridge, as well as the Scala instance to be used.
+     *
+     * @param file The jar or directory of the compiled Scala bridge.
+     * @return A provider that always returns the same compiled bridge.
+     */
+    public static CompilerBridgeProvider constantBridgeProvider(ScalaInstance scalaInstance,
+                                                         File compilerBridgeJar) {
+        return new CompilerBridgeProvider() {
+            @Override
+            public File fetchCompiledBridge(ScalaInstance scalaInstance, Logger logger) {
+                logger.debug(new F0<String>() {
+                    @Override
+                    public String apply() {
+                        String bridgeName = compilerBridgeJar.getAbsolutePath();
+                        return "Returning already retrieved and compiled bridge: " + bridgeName + ".";
+                    }
+                });
+                return compilerBridgeJar;
+            }
+
+            @Override
+            public ScalaInstance fetchScalaInstance(String scalaVersion, Logger logger) {
+                logger.debug(new F0<String>() {
+                    @Override
+                    public String apply() {
+                        String instance = scalaInstance.toString();
+                        return "Returning default scala instance:\n\t" + instance;
+                    }
+                });
+                return scalaInstance;
+            }
+        };
     }
 }

--- a/zinc/src/main/scala/sbt/internal/inc/ZincUtil.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/ZincUtil.scala
@@ -46,7 +46,7 @@ object ZincUtil {
       compilerBridgeJar: File,
       classpathOptions: ClasspathOptions
   ): AnalyzingCompiler = {
-    val bridgeProvider = CompilerBridgeProvider.constant(compilerBridgeJar, scalaInstance)
+    val bridgeProvider = constantBridgeProvider(scalaInstance, compilerBridgeJar)
     val emptyHandler = (_: Seq[String]) => ()
     val loader = Some(new ClassLoaderCache(new URLClassLoader(Array())))
     new AnalyzingCompiler(
@@ -126,4 +126,8 @@ object ZincUtil {
   def compilers(javaTools: XJavaTools, scalac: ScalaCompiler): Compilers = {
     new Compilers(scalac, javaTools)
   }
+
+  def constantBridgeProvider(scalaInstance: xsbti.compile.ScalaInstance,
+                             compilerBridgeJar: File): xsbti.compile.CompilerBridgeProvider =
+    ZincCompilerUtil.constantBridgeProvider(scalaInstance, compilerBridgeJar)
 }

--- a/zinc/src/test/scala/sbt/inc/BaseCompilerSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/BaseCompilerSpec.scala
@@ -88,7 +88,7 @@ class BaseCompilerSpec extends BridgeProviderSpecification {
   }
 
   def scalaCompiler(instance: xsbti.compile.ScalaInstance, bridgeJar: File): AnalyzingCompiler = {
-    val bridgeProvider = CompilerBridgeProvider.constant(bridgeJar, instance)
+    val bridgeProvider = ZincUtil.constantBridgeProvider(instance, bridgeJar)
     val classpath = ClasspathOptionsUtil.boot
     val cache = Some(new ClassLoaderCache(new URLClassLoader(Array())))
     new AnalyzingCompiler(instance, bridgeProvider, classpath, _ => (), cache)

--- a/zinc/src/test/scala/sbt/inc/MultiProjectIncrementalSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/MultiProjectIncrementalSpec.scala
@@ -207,7 +207,7 @@ class MultiProjectIncrementalSpec extends BridgeProviderSpecification {
   }
 
   def scalaCompiler(instance: ScalaInstance, bridgeJar: File): AnalyzingCompiler = {
-    val bridgeProvider = CompilerBridgeProvider.constant(bridgeJar, instance)
+    val bridgeProvider = ZincUtil.constantBridgeProvider(instance, bridgeJar)
     val classpath = ClasspathOptionsUtil.boot
     val cache = Some(new ClassLoaderCache(new URLClassLoader(Array())))
     new AnalyzingCompiler(instance, bridgeProvider, classpath, _ => (), cache)


### PR DESCRIPTION
On both my local machine and on Drone box, `ZincComponentCompilerSpec` fails to compile 2.10 compiler bridge with the following error:

```
/T/sbt_1234/xsbti/compile/CompilerBridgeProvider.java:33: error: `;' expected but `{' found.
    static CompilerBridgeProvider constant(File file, ScalaInstance scalaInstance) {
                                                                                   ^
```

I suspected that this is due to Java `interface` defining a static method, a change introduced in only in Java 8.
After making this change, the spec passed the test.

## notes
- http://scala-lang.org/news/2.10.4

> Can target JDK 1.5, 1.6 and 1.7

- http://scala-lang.org/news/2.11.0

> The Scala 2.11.x series targets Java 6, with (evolving) experimental support for Java 8. In 2.11.0, Java 8 support is mostly limited to reading Java 8 bytecode and parsing Java 8 source.

Would it be reasonable to think that Scala 2.10 _cannot_ parse Java 8 source?

