### PR TITLE
Remove unused 'resident' option

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/CompilerInterface.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CompilerInterface.scala
@@ -19,9 +19,8 @@ final class CompilerInterface {
   def newCompiler(options: Array[String],
                   output: Output,
                   initialLog: Logger,
-                  initialDelegate: Reporter,
-                  resident: Boolean): CachedCompiler =
-    new CachedCompiler0(options, output, new WeakLog(initialLog, initialDelegate), resident)
+                  initialDelegate: Reporter): CachedCompiler =
+    new CachedCompiler0(options, output, new WeakLog(initialLog, initialDelegate))
 
   def run(sources: Array[File],
           changes: DependencyChanges,
@@ -54,10 +53,7 @@ private final class WeakLog(private[this] var log: Logger, private[this] var del
   }
 }
 
-private final class CachedCompiler0(args: Array[String],
-                                    output: Output,
-                                    initialLog: WeakLog,
-                                    resident: Boolean)
+private final class CachedCompiler0(args: Array[String], output: Output, initialLog: WeakLog)
     extends CachedCompiler
     with CachedCompilerCompat {
 

--- a/internal/compiler-bridge/src/test/scala/xsbt/ScalaCompilerForUnitTesting.scala
+++ b/internal/compiler-bridge/src/test/scala/xsbt/ScalaCompilerForUnitTesting.scala
@@ -189,7 +189,7 @@ class ScalaCompilerForUnitTesting {
       override def toString = s"SingleOutput($getOutputDirectory)"
     }
     val weakLog = new WeakLog(ConsoleLogger(), ConsoleReporter)
-    val cachedCompiler = new CachedCompiler0(args, output, weakLog, false)
+    val cachedCompiler = new CachedCompiler0(args, output, weakLog)
     val settings = cachedCompiler.settings
     settings.classpath.value = classpath
     settings.usejavacp.value = true

--- a/internal/compiler-interface/src/main/java/xsbti/compile/CachedCompilerProvider.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/CachedCompilerProvider.java
@@ -18,5 +18,5 @@ public interface CachedCompilerProvider {
 	ScalaInstance scalaInstance();
 
 	/** Return a new cached compiler from the usual compiler input. */
-	CachedCompiler newCachedCompiler(String[] arguments, Output output, Logger log, Reporter reporter, boolean resident);
+	CachedCompiler newCachedCompiler(String[] arguments, Output output, Logger log, Reporter reporter);
 }

--- a/internal/zinc-benchmarks/src/main/scala/xsbt/ZincBenchmark.scala
+++ b/internal/zinc-benchmarks/src/main/scala/xsbt/ZincBenchmark.scala
@@ -133,7 +133,7 @@ private[xsbt] object ZincBenchmark {
     val args = compilationInfo.scalacOptions
     val classpath = compilationInfo.classpath
     val weakLog = new WeakLog(ConsoleLogger(), ConsoleReporter)
-    val cachedCompiler = new CachedCompiler0(args, output, weakLog, false)
+    val cachedCompiler = new CachedCompiler0(args, output, weakLog)
     val settings = cachedCompiler.settings
     settings.classpath.value = classpath
     val delegatingReporter = DelegatingReporter(settings, ConsoleReporter)

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala
@@ -114,26 +114,22 @@ final class AnalyzingCompiler(
       arguments: Array[String],
       output: Output,
       log: xLogger,
-      reporter: Reporter,
-      resident: Boolean
+      reporter: Reporter
   ): CachedCompiler =
-    newCachedCompiler(arguments: Seq[String], output, log, reporter, resident)
+    newCachedCompiler(arguments: Seq[String], output, log, reporter)
 
   def newCachedCompiler(
       arguments: Seq[String],
       output: Output,
       log: xLogger,
-      reporter: Reporter,
-      resident: Boolean
+      reporter: Reporter
   ): CachedCompiler = {
-    val javaResident: java.lang.Boolean = resident
     val compiler = call("xsbt.CompilerInterface", "newCompiler", log)(
       classOf[Array[String]],
       classOf[Output],
       classOf[xLogger],
-      classOf[Reporter],
-      classOf[Boolean]
-    )(arguments.toArray[String], output, log, reporter, javaResident)
+      classOf[Reporter]
+    )(arguments.toArray[String], output, log, reporter)
     compiler.asInstanceOf[CachedCompiler]
   }
 

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerCache.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerCache.scala
@@ -45,7 +45,7 @@ final class CompilerCache(val maxInstances: Int) extends GlobalsCache {
       case null =>
         log.debug(f0(s"Compiler cache miss. $key "))
         val newCompiler: CachedCompiler =
-          c.newCachedCompiler(args, output, log, reporter, !forceNew)
+          c.newCachedCompiler(args, output, log, reporter)
         cache.put(key, newCompiler)
         newCompiler
       case cachedCompiler =>
@@ -75,5 +75,5 @@ final class FreshCompilerCache extends GlobalsCache {
       c: CachedCompilerProvider,
       log: xLogger,
       reporter: Reporter
-  ): CachedCompiler = c.newCachedCompiler(args, output, log, reporter, false)
+  ): CachedCompiler = c.newCachedCompiler(args, output, log, reporter)
 }


### PR DESCRIPTION
Remove unused 'resident' option, fixes #340 