### PR TITLE
Upgrade to sbt 1 & add, configure & enable MiMa

### DIFF
--- a/bin/run-ci.sh
+++ b/bin/run-ci.sh
@@ -3,12 +3,15 @@ set -eu
 set -o nounset
 SCALA_VERSION="$1"
 
+# drop scalafmt on the 1.0.0 branch to dogfood 1.0.0-RC2 before there is a sbt 1.0 of new-sbt-scalafnt
+#  see https://github.com/lucidsoftware/neo-sbt-scalafmt/pull/34
+# scalafmt::test \
+# test:scalafmt::test \
+
 sbt -Dfile.encoding=UTF-8 \
   -J-XX:ReservedCodeCacheSize=256M \
   -J-Xmx3046M -J-Xms3046M -J-server \
   zincRoot/test:compile \
-  scalafmt::test \
-  test:scalafmt::test \
   crossTestBridges \
   "publishBridgesAndSet $SCALA_VERSION" \
   zincRoot/test \

--- a/bin/run-ci.sh
+++ b/bin/run-ci.sh
@@ -11,6 +11,7 @@ SCALA_VERSION="$1"
 sbt -Dfile.encoding=UTF-8 \
   -J-XX:ReservedCodeCacheSize=256M \
   -J-Xmx3046M -J-Xms3046M -J-server \
+  +mimaReportBinaryIssues \
   zincRoot/test:compile \
   crossTestBridges \
   "publishBridgesAndSet $SCALA_VERSION" \

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,18 @@
 import Util._
 import Dependencies._
 import Scripted._
-// import com.typesafe.tools.mima.core._, ProblemFilters._
+import com.typesafe.tools.mima.core._, ProblemFilters._
 
 def baseVersion = "1.0.0-X21-SNAPSHOT"
 def internalPath = file("internal")
 
 lazy val compilerBridgeScalaVersions = List(scala212, scala211, scala210)
+
+def mimaSettings: Seq[Setting[_]] = Seq(
+  mimaPreviousArtifacts := Set(organization.value % moduleName.value % "1.0.0-X20"
+    cross (if (crossPaths.value) CrossVersion.binary else CrossVersion.disabled)
+  )
+)
 
 def commonSettings: Seq[Setting[_]] = Seq(
   scalaVersion := scala212,
@@ -21,7 +27,6 @@ def commonSettings: Seq[Setting[_]] = Seq(
   testOptions += Tests.Argument(TestFrameworks.ScalaCheck, "-w", "1"),
   javacOptions in compile ++= Seq("-Xlint", "-Xlint:-serial"),
   crossScalaVersions := Seq(scala211, scala212),
-  // mimaPreviousArtifacts := Set(), // Some(organization.value %% moduleName.value % "1.0.0"),
   publishArtifact in Test := false,
   commands ++= Seq(publishBridgesAndTest, publishBridgesAndSet, crossTestBridges),
   scalacOptions += "-YdisableFlatCpCaching"
@@ -174,7 +179,8 @@ lazy val zinc = (project in file("zinc"))
   )
   .configure(addBaseSettingsAndTestDeps)
   .settings(
-    name := "zinc"
+    name := "zinc",
+    mimaSettings,
   )
 
 lazy val zincTesting = (project in internalPath / "zinc-testing")
@@ -190,7 +196,8 @@ lazy val zincCompile = (project in file("zinc-compile"))
   .dependsOn(zincCompileCore, zincCompileCore % "test->test")
   .configure(addBaseSettingsAndTestDeps)
   .settings(
-    name := "zinc Compile"
+    name := "zinc Compile",
+    mimaSettings,
   )
   .configure(addSbtUtilTracking)
 
@@ -202,7 +209,8 @@ lazy val zincPersist = (project in internalPath / "zinc-persist")
     name := "zinc Persist",
     libraryDependencies += sbinary,
     compileOrder := sbt.CompileOrder.Mixed,
-    PB.targets in Compile := List(scalapb.gen() -> (sourceManaged in Compile).value)
+    PB.targets in Compile := List(scalapb.gen() -> (sourceManaged in Compile).value),
+    mimaSettings,
   )
 
 // Implements the core functionality of detecting and propagating changes incrementally.
@@ -219,7 +227,8 @@ lazy val zincCore = (project in internalPath / "zinc-core")
     // compiler instances that are memory hungry
     javaOptions in Test += "-Xmx1G",
     name := "zinc Core",
-    compileOrder := sbt.CompileOrder.Mixed
+    compileOrder := sbt.CompileOrder.Mixed,
+    mimaSettings,
   )
   .configure(addSbtIO, addSbtUtilLogging, addSbtUtilRelation)
 
@@ -244,7 +253,8 @@ lazy val zincIvyIntegration = (project in internalPath / "zinc-ivy-integration")
   .settings(
     baseSettings,
     name := "zinc Ivy Integration",
-    compileOrder := sbt.CompileOrder.ScalaThenJava
+    compileOrder := sbt.CompileOrder.ScalaThenJava,
+    mimaSettings,
   )
   .configure(addSbtLmCore, addSbtLmIvyTest)
 
@@ -265,7 +275,8 @@ lazy val zincCompileCore = (project in internalPath / "zinc-compile-core")
     unmanagedJars in Test := Seq(packageSrc in compilerBridge in Compile value).classpath,
     managedSourceDirectories in Compile +=
       baseDirectory.value / "src" / "main" / "contraband-java",
-    sourceManaged in (Compile, generateContrabands) := baseDirectory.value / "src" / "main" / "contraband-java"
+    sourceManaged in (Compile, generateContrabands) := baseDirectory.value / "src" / "main" / "contraband-java",
+    mimaSettings,
   )
   .configure(addSbtUtilLogging, addSbtIO, addSbtUtilControl)
 
@@ -301,7 +312,8 @@ lazy val compilerInterface = (project in internalPath / "compiler-interface")
     sourceManaged in (Compile, generateContrabands) := baseDirectory.value / "src" / "main" / "contraband-java",
     crossPaths := false,
     autoScalaLibrary := false,
-    altPublishSettings
+    altPublishSettings,
+    mimaSettings,
   )
   .configure(addSbtUtilInterface)
 
@@ -368,7 +380,8 @@ lazy val compilerBridge: Project = (project in internalPath / "compiler-bridge")
       }
     },
     publishLocal := publishLocal.dependsOn(cleanSbtBridge).value,
-    altPublishSettings
+    altPublishSettings,
+    mimaSettings,
   )
 
 val scalaPartialVersion = Def setting (CrossVersion partialVersion scalaVersion.value)
@@ -383,7 +396,8 @@ lazy val zincApiInfo = (project in internalPath / "zinc-apiinfo")
   .settings(
     name := "zinc ApiInfo",
     crossScalaVersions := compilerBridgeScalaVersions,
-    relaxNon212
+    relaxNon212,
+    mimaSettings,
   )
 
 // Utilities related to reflection, managing Scala versions, and custom class loaders
@@ -394,7 +408,8 @@ lazy val zincClasspath = (project in internalPath / "zinc-classpath")
     name := "zinc Classpath",
     crossScalaVersions := compilerBridgeScalaVersions,
     relaxNon212,
-    libraryDependencies ++= Seq(scalaCompiler.value, launcherInterface)
+    libraryDependencies ++= Seq(scalaCompiler.value, launcherInterface),
+    mimaSettings,
   )
   .configure(addSbtIO)
 
@@ -405,7 +420,8 @@ lazy val zincClassfile = (project in internalPath / "zinc-classfile")
   .settings(
     name := "zinc Classfile",
     crossScalaVersions := compilerBridgeScalaVersions,
-    relaxNon212
+    relaxNon212,
+    mimaSettings,
   )
   .configure(addSbtIO, addSbtUtilLogging)
 

--- a/build.sbt
+++ b/build.sbt
@@ -74,17 +74,9 @@ def altPublishSettings: Seq[Setting[_]] =
       val moduleSettings = (Keys.moduleSettings).value
       val ivy = new IvySbt((ivyConfiguration.value))
 
-      val module =
-        new ivy.Module(moduleSettings)
-      val newConfig =
-        new PublishConfiguration(
-          config.ivyFile,
-          altLocalRepoName,
-          config.artifacts,
-          config.checksums,
-          config.logging
-        )
-      streams.value.log.info("Publishing " + module + " to local repo: " + altLocalRepoName)
+      val module = new ivy.Module(moduleSettings)
+      val newConfig = config.withResolverName(altLocalRepoName).withOverwrite(false)
+      streams.value.log.info(s"Publishing $module to local repo: $altLocalRepoName")
       IvyActions.publish(module, newConfig, streams.value.log)
     }
   )
@@ -158,9 +150,11 @@ lazy val zincRoot: Project = (project in file("."))
           ScmInfo(url("https://github.com/sbt/zinc"), "git@github.com:sbt/zinc.git")),
         description := "Incremental compiler of Scala",
         homepage := Some(url("https://github.com/sbt/zinc")),
-        scalafmtOnCompile := true,
+        // drop scalafmt on the 1.0.0 branch to dogfood 1.0.0-RC2 before there is a sbt 1.0 of new-sbt-scalafnt
+        //  see https://github.com/lucidsoftware/neo-sbt-scalafmt/pull/34
+        // scalafmtOnCompile := true,
         // scalafmtVersion 1.0.0-RC3 has regression
-        scalafmtVersion := "0.6.8"
+        // scalafmtVersion := "0.6.8"
       )),
     minimalSettings,
     otherRootSettings,
@@ -292,7 +286,6 @@ lazy val compilerInterface = (project in internalPath / "compiler-interface")
     relaxNon212,
     libraryDependencies ++= Seq(scalaLibrary.value % Test),
     exportJars := true,
-    watchSources ++= apiDefinitions.value,
     resourceGenerators in Compile += Def
       .task(
         generateVersionFile(
@@ -303,11 +296,6 @@ lazy val compilerInterface = (project in internalPath / "compiler-interface")
         )
       )
       .taskValue,
-    apiDefinitions := List(
-      (baseDirectory.value / "definition"),
-      (baseDirectory.value / "other"),
-      (baseDirectory.value / "type")
-    ),
     managedSourceDirectories in Compile +=
       baseDirectory.value / "src" / "main" / "contraband-java",
     sourceManaged in (Compile, generateContrabands) := baseDirectory.value / "src" / "main" / "contraband-java",
@@ -321,7 +309,7 @@ val cleanSbtBridge = taskKey[Unit]("Cleans the sbt bridge.")
 
 def wrapIn(color: String, content: String): String = {
   import sbt.internal.util.ConsoleAppender
-  if (!ConsoleAppender.formatEnabled) content
+  if (!ConsoleAppender.formatEnabledInEnv) content
   else color + content + scala.Console.RESET
 }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.0-M6
+sbt.version=1.0.0-RC2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,14 +1,11 @@
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.26")
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.4.0")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.27")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0-M1")
-addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.3")
+// drop scalafmt on the 1.0.0 branch to dogfood 1.0.0-RC2 before there is a sbt 1.0 of new-sbt-scalafnt
+//  see https://github.com/lucidsoftware/neo-sbt-scalafmt/pull/34
+// addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.3")
 // addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.7.0")
 addSbtPlugin("org.scala-sbt" % "sbt-houserules" % "0.3.3")
 addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.3.0-M9")
-
-resolvers += Resolver.bintrayIvyRepo("scalacenter", "sbt-releases")
-addSbtPlugin(
-  ("com.thesamet" % "sbt-protoc" % "0.99.12")
-    .exclude("com.trueaccord.scalapb", "protoc-bridge_2.12"))
-
-libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin-shaded" % "0.6.0"
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.12-rc4")
+libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin" % "0.6.0"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,4 @@ addSbtPlugin("org.scala-sbt" % "sbt-houserules" % "0.3.3")
 addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.3.0-M9")
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.12-rc4")
 libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin" % "0.6.0"
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.15")


### PR DESCRIPTION
Re-take on #378, which looks to be running into an issue with also trying to upgrade to Scala 2.12.3.

I **really** want to have MiMa up and running on the 1.0.0 branch to check and enforce our binary API, so I de-scoped the Scala upgrade for right now. I also cleaned up the commits - thank you Jorge for helping figure out WTH was going on with sbt-protoc/scalapb/protobuf.