### PR TITLE
Tweak ClassToAPI.classCanonicalName

### DIFF
--- a/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/ClassCanonicalNameSpec.scala
+++ b/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/ClassCanonicalNameSpec.scala
@@ -80,12 +80,12 @@ class ClassCanonicalNameSpec extends FlatSpec with Matchers {
   object CO extends Expected("x.y$")
   object CC extends Expected("x.y")
 
-  object OOO extends Expected("x.y$$z$", nativeClassNameIsMalformed = true)
-  object OOC extends Expected("x.y$$z", nativeClassNameIsMalformed = true)
+  object OOO extends Expected("x$y$z$", nativeClassNameIsMalformed = true)
+  object OOC extends Expected("x$y$z", nativeClassNameIsMalformed = true)
   object OCO extends Expected("x.y.z$")
   object OCC extends Expected("x.y.z")
-  object COO extends Expected("x.y$$z$", nativeClassNameIsMalformed = true)
-  object COC extends Expected("x.y$$z", nativeClassNameIsMalformed = true)
+  object COO extends Expected("x$y$z$", nativeClassNameIsMalformed = true)
+  object COC extends Expected("x$y$z", nativeClassNameIsMalformed = true)
   object CCO extends Expected("x.y.z$")
   object CCC extends Expected("x.y.z")
 


### PR DESCRIPTION
Builds on the spec defined in #380, proposing a change in behaviour.