### PR TITLE
Fix ConsoleInterface binding things properly^2

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/ConsoleInterface.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ConsoleInterface.scala
@@ -8,7 +8,7 @@
 package xsbt
 
 import xsbti.Logger
-import scala.tools.nsc.interpreter.{ ILoop, IMain, InteractiveReader }
+import scala.tools.nsc.interpreter.{ ILoop, IMain, InteractiveReader, NamedParam }
 import scala.tools.nsc.reporters.Reporter
 import scala.tools.nsc.{ GenericRunnerCommand, Settings }
 
@@ -54,7 +54,7 @@ class ConsoleInterface {
           super.createInterpreter()
 
         for ((id, value) <- bindNames zip bindValues)
-          intp.beQuietDuring(intp.bind(id, value.asInstanceOf[AnyRef].getClass.getName, value))
+          intp.quietBind(NamedParam.clazz(id, value))
 
         if (!initialCommands.isEmpty)
           intp.interpret(initialCommands)


### PR DESCRIPTION
Follow-up on #314 - I _still_ misinterpreted..

Turns out the ".asInstanceOf[AnyRef].getClass.getName" implementation
was the _original_ implementation. Then Mark switched to using bindValue
in sbt/sbt@4b8f0f3f941d5b3970fa24dfd9a34508d6974345.

Since Scala 2.11.0 (scala/scala#1648 in particular) bindValue was
removed. So we'll use NamedParam and quietBind, both which exist since
Scala 2.9.0.

Fixes sbt/sbt#2884, tested with local releases.