### PR TITLE
Remove workarounds for sbt/sbt#1035

### DIFF
--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
@@ -548,56 +548,18 @@ object ClassToAPI {
   }.toMap
   def primitive(name: String): api.Type = PrimitiveRefs(name)
 
-  // Workarounds for https://github.com/sbt/sbt/issues/1035
-  //   these catch the GenericSignatureFormatError and return the erased type
+  private[this] def returnType(f: Field): Type = f.getGenericType
+  private[this] def returnType(m: Method): Type = m.getGenericReturnType
+  private[this] def exceptionTypes(c: Constructor[_]): Array[Type] = c.getGenericExceptionTypes
 
-  private[this] def returnType(f: Field): Type =
-    try f.getGenericType
-    catch {
-      case _: GenericSignatureFormatError => f.getType
-    }
-  private[this] def parameterTypes(c: Constructor[_]): Array[Type] =
-    try c.getGenericParameterTypes
-    catch {
-      case _: GenericSignatureFormatError => convert(c.getParameterTypes)
-    }
-  private[this] def exceptionTypes(c: Constructor[_]): Array[Type] =
-    try c.getGenericExceptionTypes
-    catch {
-      case _: GenericSignatureFormatError => convert(c.getExceptionTypes)
-    }
-  private[this] def parameterTypes(m: Method): Array[Type] =
-    try m.getGenericParameterTypes
-    catch {
-      case _: GenericSignatureFormatError => convert(m.getParameterTypes)
-    }
-  private[this] def returnType(m: Method): Type =
-    try m.getGenericReturnType
-    catch {
-      case _: GenericSignatureFormatError => m.getReturnType
-    }
-  private[this] def exceptionTypes(m: Method): Array[Type] =
-    try m.getGenericExceptionTypes
-    catch {
-      case _: GenericSignatureFormatError => convert(m.getExceptionTypes)
-    }
+  private[this] def exceptionTypes(m: Method): Array[Type] = m.getGenericExceptionTypes
+  private[this] def parameterTypes(m: Method): Array[Type] = m.getGenericParameterTypes
+  private[this] def parameterTypes(c: Constructor[_]): Array[Type] = c.getGenericParameterTypes
 
   private[this] def typeParameterTypes[T](m: Constructor[T]): Array[TypeVariable[Constructor[T]]] =
-    try m.getTypeParameters
-    catch {
-      case _: GenericSignatureFormatError => new Array(0)
-    }
+    m.getTypeParameters
   private[this] def typeParameterTypes[T](m: Class[T]): Array[TypeVariable[Class[T]]] =
-    try m.getTypeParameters
-    catch {
-      case _: GenericSignatureFormatError => new Array(0)
-    }
+    m.getTypeParameters
   private[this] def typeParameterTypes(m: Method): Array[TypeVariable[Method]] =
-    try m.getTypeParameters
-    catch {
-      case _: GenericSignatureFormatError => new Array(0)
-    }
-
-  private[this] def convert(classes: Array[Class[_]]): Array[Type] =
-    classes.asInstanceOf[Array[Type]] // ok: treat Arrays as read-only
+    m.getTypeParameters
 }


### PR DESCRIPTION
The workarounds are not necessary anymore,
http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6476261 has been
fixed in JDK8, which is the JDK version that Zinc demands.

We can change the target branch after this is LGTM'ed and the forward port
for 1.0.x is finished.