### PR TITLE
Adds external hook to filter scala compiler options for product invalidation

### DIFF
--- a/internal/compiler-interface/src/main/java/xsbti/compile/DefaultExternalHooks.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/DefaultExternalHooks.java
@@ -45,4 +45,9 @@ public class DefaultExternalHooks implements ExternalHooks {
     public ExternalHooks withExternalLookup(ExternalHooks.Lookup externalLookup) {
         return new DefaultExternalHooks(Optional.of(externalLookup), this.getExternalClassFileManager());
     }
+
+    @Override
+    public String[] filterScalaCompilerOptions(String[] options) {
+        return options;
+    }
 }

--- a/internal/compiler-interface/src/main/java/xsbti/compile/ExternalHooks.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/ExternalHooks.java
@@ -86,4 +86,14 @@ public interface ExternalHooks {
      * @return An instance of {@link ExternalHooks} with the specified lookup.
      */
     ExternalHooks withExternalLookup(Lookup externalLookup);
+
+    /**
+     * Alter which scala compiler options are considered for invalidation of compiled products.
+     *
+     * Expected to be used by filtering out options which do not affect the products,
+     * e.g. debug/logging flags, flags which change the number of cores used, et al.
+     *
+     * @return A String array used to calculate changes in scala options for invalidation.
+     */
+    String[] filterScalaCompilerOptions(String[] options);
 }

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -184,11 +184,15 @@ object MixedAnalyzingCompiler {
     val classpathHash = classpath map { x =>
       FileHash.of(x, Stamper.forHash(x).hashCode)
     }
+
+    val filteredOptions =
+      incrementalCompilerOptions.externalHooks().filterScalaCompilerOptions(options.toArray)
+
     val compileSetup = MiniSetup.of(
       output,
       MiniOptions.of(
         classpathHash.toArray,
-        options.toArray,
+        filteredOptions,
         javacOptions.toArray
       ),
       scalac.scalaInstance.actualVersion,


### PR DESCRIPTION
This adds `filterScalaCompilerOptions` to `ExternalHooks`, which can be overridden to remove scala compiler options which do not affect the resulting products.

Fixes #406