### PR TITLE
ScalaInstance refactoring

### DIFF
--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/ScalaInstance.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/ScalaInstance.scala
@@ -142,40 +142,11 @@ object ScalaInstance {
   }
 
   def apply(version: String, scalaHome: File, launcher: xsbti.Launcher): ScalaInstance = {
+    val all = allJars(scalaHome)
+    val loader = scalaLoader(launcher)(all.toList)
     val library = libraryJar(scalaHome)
     val compiler = compilerJar(scalaHome)
-    val jars = allJars(scalaHome)
-    apply(version, library, compiler, jars: _*)(scalaLoader(launcher))
-  }
-
-  /* *******************************************************************
-       The following apply methods are deprecated but used internally.
-     ******************************************************************* */
-
-  private def apply(
-      version: String,
-      libraryJar: File,
-      compilerJar: File,
-      extraJars: File*
-  )(classLoader: List[File] => ClassLoader): ScalaInstance =
-    apply(version, None, libraryJar, compilerJar, extraJars: _*)(classLoader)
-
-  private def apply(
-      version: String,
-      explicitActual: Option[String],
-      libraryJar: File,
-      compilerJar: File,
-      extraJars: File*
-  )(classLoader: List[File] => ClassLoader): ScalaInstance = {
-    val loader = classLoader(libraryJar :: compilerJar :: extraJars.toList)
-    new ScalaInstance(
-      version,
-      loader,
-      libraryJar,
-      compilerJar,
-      extraJars.toArray,
-      explicitActual
-    )
+    new ScalaInstance(version, loader, library, compiler, all.toArray, None)
   }
 
   /** Return all the required Scala jars from a path `scalaHome`. */


### PR DESCRIPTION
This is a refactoring change that removes two private `apply` methods. No observable changes are expected.

1. It's only used by one `apply`, so they don't provide much values.
2. One of the parameter is named incorrectly as "extraJars" when it in fact expects "allJars."

Ref sbt/zinc#5, sbt/zinc#411, sbt/sbt#3561