### PR TITLE
neo-sbt-scalafmt and making LoggedReporter extensible

### DIFF
--- a/bin/run-ci.sh
+++ b/bin/run-ci.sh
@@ -8,7 +8,8 @@ sbt -Dfile.encoding=UTF-8 \
   -J-XX:ReservedCodeCacheSize=256M \
   -J-Xmx3046M -J-Xms3046M -J-server \
   +mimaReportBinaryIssues \
-  scalafmtTest \
+  scalafmt::test \
+  test:scalafmt::test \
   zincRoot/test:compile \
   crossTestBridges \
   "publishBridgesAndSet $SCALA_VERSION" \

--- a/build.sbt
+++ b/build.sbt
@@ -157,6 +157,9 @@ lazy val zincRoot: Project = (project in file("."))
         homepage := Some(url("https://github.com/sbt/zinc")),
         developers +=
           Developer("jvican", "Jorge Vicente Cantero", "@jvican", url("https://github.com/jvican")),
+        scalafmtOnCompile := true,
+        scalafmtVersion := "1.2.0",
+        scalafmtOnCompile in Sbt := false,
       )),
     minimalSettings,
     otherRootSettings,

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/LoggedReporter.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/LoggedReporter.scala
@@ -101,9 +101,9 @@ class LoggedReporter(
     sourcePositionMapper: Position => Position = identity[Position]
 ) extends Reporter {
   import sbt.util.InterfaceUtil.{ toSupplier => f0 }
-  val positions = new mutable.HashMap[PositionKey, Severity]
-  val count = new EnumMap[Severity, Int](classOf[Severity])
-  protected val allProblems = new mutable.ListBuffer[Problem]
+  lazy val positions = new mutable.HashMap[PositionKey, Severity]
+  lazy val count = new EnumMap[Severity, Int](classOf[Severity])
+  protected lazy val allProblems = new mutable.ListBuffer[Problem]
   reset()
 
   def reset(): Unit = {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.0
+sbt.version=1.0.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.27")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0-M1")
-addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.2.0")
+addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.10")
 // addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.7.0")
 addSbtPlugin("org.scala-sbt" % "sbt-houserules" % "0.3.3")
 addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.3.0")


### PR DESCRIPTION
I have two relatively minor changes here.

First is the adoption of neo-sbt-scalafmt. Without it I can't use emulated monorepo because all other modules are using neo-sbt-scalafmt.

Second, I am turning all the fields in `LoggedReporter` lazy. Without the change I get NPE when extending ManagedLoggedReporter for LSP. I think this is because ctor calls `reset` at line 107, and I am overriding it in the subclass, so it could get called before all fields are initialized. (Initialization still confuses me.) No other observable changes are expected.
