### PR TITLE
Ignore null in generic lambdas parameters

### DIFF
--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
@@ -244,11 +244,13 @@ object ClassToAPI {
     accumulate(t).filterNot(_ == null).distinct
   }
 
-  @deprecated("No longer used", "0.13.0")
-  def parents(c: Class[_]): Seq[api.Type] = types(allSuperTypes(c))
-  def types(ts: Seq[Type]): Array[api.Type] = (ts filter (_ ne null) map reference).toArray
+  def types(ts: Seq[Type]): Array[api.Type] =
+    ts.filter(_ ne null).map(reference).toArray
   def upperBounds(ts: Array[Type]): api.Type =
     api.Structure.of(lzy(types(ts)), lzyEmptyDefArray, lzyEmptyDefArray)
+
+  @deprecated("No longer used", "0.13.0")
+  def parents(c: Class[_]): Seq[api.Type] = types(allSuperTypes(c))
 
   @deprecated("Use fieldToDef[4] instead", "0.13.9")
   def fieldToDef(enclPkg: Option[String])(f: Field): api.FieldLike = {
@@ -496,12 +498,18 @@ object ClassToAPI {
         api.Projection.of(api.Singleton.of(pathFromString(p)), cls)
     }
   }
+
+  // sbt/zinc#389: Ignore nulls coming from generic parameter types of lambdas
+  private[this] def ignoreNulls[T](genericTypes: Array[T]): Array[T] =
+    genericTypes.filter(_ != null)
+
   def referenceP(t: ParameterizedType): api.Parameterized = {
-    val targs = t.getActualTypeArguments
+    val targs = ignoreNulls(t.getActualTypeArguments)
     val args = if (targs.isEmpty) emptyTypeArray else arrayMap(targs)(t => reference(t): api.Type)
     val base = reference(t.getRawType)
     api.Parameterized.of(base, args)
   }
+
   def reference(t: Type): api.Type =
     t match {
       case _: WildcardType       => reference("_")
@@ -553,8 +561,10 @@ object ClassToAPI {
   private[this] def exceptionTypes(c: Constructor[_]): Array[Type] = c.getGenericExceptionTypes
 
   private[this] def exceptionTypes(m: Method): Array[Type] = m.getGenericExceptionTypes
-  private[this] def parameterTypes(m: Method): Array[Type] = m.getGenericParameterTypes
-  private[this] def parameterTypes(c: Constructor[_]): Array[Type] = c.getGenericParameterTypes
+  private[this] def parameterTypes(m: Method): Array[Type] =
+    ignoreNulls(m.getGenericParameterTypes)
+  private[this] def parameterTypes(c: Constructor[_]): Array[Type] =
+    ignoreNulls(c.getGenericParameterTypes)
 
   private[this] def typeParameterTypes[T](m: Constructor[T]): Array[TypeVariable[Constructor[T]]] =
     m.getTypeParameters

--- a/zinc/src/sbt-test/source-dependencies/java-lambda-typeparams/Example.java
+++ b/zinc/src/sbt-test/source-dependencies/java-lambda-typeparams/Example.java
@@ -1,0 +1,26 @@
+package typeparameters;
+
+import java.util.function.Supplier;
+
+public class Example {
+
+  static <I, O> void call() {
+    Supplier<BaseBlah<I, O>> blah = () ->
+      new BaseBlah<I, O>() {
+        @Override
+        protected O getResponseInternal(I i) {
+          return null;
+        }
+      };
+  }
+
+  public static void main(String[] args) {
+    Example.<String, String>call();
+  }
+}
+
+abstract class BaseBlah<I, O> {
+  protected O getResponseInternal(I i) {
+    return null;
+  }
+}

--- a/zinc/src/sbt-test/source-dependencies/java-lambda-typeparams/test
+++ b/zinc/src/sbt-test/source-dependencies/java-lambda-typeparams/test
@@ -1,0 +1,1 @@
+> compile


### PR DESCRIPTION
This is a WIP and needs to be double-checked before merge.

Related but not exact reasons why this happens can be found in JDK's
issue tracker: https://bugs.openjdk.java.net/browse/JDK-8178523?jql=text%20%7E%20%22lambda%20generic%20type%22

We ignore nulls that are returned by `getActualTypeArguments`.

It would be good to file a ticket in JIRA before merge.

Fixes #389.