### PR TITLE
Reproduce #417

### DIFF
--- a/zinc/src/sbt-test/source-dependencies/trait-trait-211/build.json
+++ b/zinc/src/sbt-test/source-dependencies/trait-trait-211/build.json
@@ -1,0 +1,13 @@
+{
+  "projects": [
+    {
+      "name": "mirtest",
+      "scalaVersion": "2.11.8",
+      "dependsOn": ["gg"]
+    },
+    {
+      "name": "gg",
+      "scalaVersion": "2.11.8"
+    }
+  ]
+}

--- a/zinc/src/sbt-test/source-dependencies/trait-trait-211/changes/SliceTransforms1.scala
+++ b/zinc/src/sbt-test/source-dependencies/trait-trait-211/changes/SliceTransforms1.scala
@@ -1,0 +1,11 @@
+package gg
+package table
+
+trait SliceTransforms[F[+ _]] extends TableModule[F]
+  with ObjectConcatHelpers {
+  buildNonemptyObjects(0, 1)
+}
+
+trait ObjectConcatHelpers {
+  def buildNonemptyObjects(a: Int, b: Int): Unit = ()
+}

--- a/zinc/src/sbt-test/source-dependencies/trait-trait-211/gg/ColumnarTableModule.scala
+++ b/zinc/src/sbt-test/source-dependencies/trait-trait-211/gg/ColumnarTableModule.scala
@@ -1,0 +1,5 @@
+package gg
+package table
+
+trait ColumnarTableModule[F[+ _]] extends TableModule[F]
+  with SliceTransforms[F]

--- a/zinc/src/sbt-test/source-dependencies/trait-trait-211/gg/SliceTransforms.scala
+++ b/zinc/src/sbt-test/source-dependencies/trait-trait-211/gg/SliceTransforms.scala
@@ -1,0 +1,11 @@
+package gg
+package table
+
+trait SliceTransforms[F[+ _]] extends TableModule[F]
+  with ObjectConcatHelpers {
+  buildNonemptyObjects(0)
+}
+
+trait ObjectConcatHelpers {
+  def buildNonemptyObjects(a: Int): Unit = ()
+}

--- a/zinc/src/sbt-test/source-dependencies/trait-trait-211/gg/TableModule.scala
+++ b/zinc/src/sbt-test/source-dependencies/trait-trait-211/gg/TableModule.scala
@@ -1,0 +1,3 @@
+package gg
+
+trait TableModule[F[+ _]]

--- a/zinc/src/sbt-test/source-dependencies/trait-trait-211/mirtest/EvaluatorModule.scala
+++ b/zinc/src/sbt-test/source-dependencies/trait-trait-211/mirtest/EvaluatorModule.scala
@@ -1,0 +1,8 @@
+package xx
+
+import gg._
+
+// note changing the parent from TableModule to ColumnarTableModule here changes the result.
+trait EvaluatorModule[F[+ _]] extends TableModule[F] {
+  def eval: String = "x"
+}

--- a/zinc/src/sbt-test/source-dependencies/trait-trait-211/mirtest/EvaluatorSpecs.scala
+++ b/zinc/src/sbt-test/source-dependencies/trait-trait-211/mirtest/EvaluatorSpecs.scala
@@ -1,0 +1,12 @@
+package xx
+
+import gg.table._
+
+trait EvaluatorSpecification[F[+_]] extends EvaluatorTestSupport[F] { self =>
+}
+
+trait EvaluatorTestSupport[F[+_]] extends EvaluatorModule[F]
+    with ColumnarTableModule[F] { outer =>
+
+  def consumeEval: String = eval
+}

--- a/zinc/src/sbt-test/source-dependencies/trait-trait-211/mirtest/Hello.scala
+++ b/zinc/src/sbt-test/source-dependencies/trait-trait-211/mirtest/Hello.scala
@@ -1,0 +1,14 @@
+package xx
+
+import gg.table._
+
+object Hello extends App {
+  def testEval: Unit = {
+    val consumer = new StringLibSpecs[Option] {}
+    consumer.consumeEval
+  }
+  testEval
+}
+
+trait StringLibSpecs[F[+_]] extends EvaluatorSpecification[F] { self =>
+}

--- a/zinc/src/sbt-test/source-dependencies/trait-trait-211/test
+++ b/zinc/src/sbt-test/source-dependencies/trait-trait-211/test
@@ -1,0 +1,4 @@
+> mirtest/run
+
+$ copy-file changes/SliceTransforms1.scala gg/SliceTransforms.scala
+> mirtest/run


### PR DESCRIPTION
```
Caused by: java.lang.AbstractMethodError: xx.Hello$$anon$1.buildNonemptyObjects(II)V
	at gg.table.SliceTransforms$class.$init$(SliceTransforms.scala:6)
	at xx.Hello$$anon$1.<init>(Hello.scala:7)
	at xx.Hello$.testEval(Hello.scala:7)
	at xx.Hello$.delayedEndpoint$xx$Hello$1(Hello.scala:10)
	at xx.Hello$delayedInit$body.apply(Hello.scala:5)
	at scala.Function0$class.apply$mcV$sp(Function0.scala:34)
	at scala.runtime.AbstractFunction0.apply$mcV$sp(AbstractFunction0.scala:12)
	at scala.App$$anonfun$main$1.apply(App.scala:76)
	at scala.App$$anonfun$main$1.apply(App.scala:76)
	at scala.collection.immutable.List.foreach(List.scala:381)
	at scala.collection.generic.TraversableForwarder$class.foreach(TraversableForwarder.scala:35)
	at scala.App$class.main(App.scala:76)
	at xx.Hello$.main(Hello.scala:5)
	at xx.Hello.main(Hello.scala)
```

```
[debug] Invalidating (transitively) by inheritance from xx.EvaluatorTestSupport...
[debug] Initial set of included nodes: Set(xx.EvaluatorTestSupport)
[debug] Invalidated by transitive inheritance dependency: Set(xx.EvaluatorTestSupport)
[debug] None of the modified names appears in source file of xx.Hello. This dependency is not being considered for invalidation.
[debug] Change NamesChange(xx.EvaluatorTestSupport,ModifiedNames(changes = UsedName(buildNonemptyObjects,[Default]))) invalidates 1 classes due to The xx.EvaluatorTestSupport has the following regular definitions changed:
[debug] 	UsedName(buildNonemptyObjects,[Default]).
[debug] 	> by transitive inheritance: Set(xx.EvaluatorTestSupport)
[debug] 	>
[debug] 	>
[debug]
[debug] New invalidations:
[debug] 	Set()
[debug] Initial set of included nodes: Set()
[debug] Previously invalidated, but (transitively) depend on new invalidations:
[debug] 	Set()
[debug] All newly invalidated classes after taking into account (previously) recompiled classes:Set()
[info] Compilation done: /var/folders/hg/2602nfrs2958vnshglyl3srw0000gn/T/sbt_b8528900/trait-trait-211/mirtest/EvaluatorModule.scala, /var/folders/hg/2602nfrs2958vnshglyl3srw0000gn/T/sbt_b8528900/trait-trait-211/mirtest/EvaluatorSpecs.scala, /var/folders/hg/2602nfrs2958vnshglyl3srw0000gn/T/sbt_b8528900/trait-trait-211/mirtest/Hello.scala
```

