### PR TITLE
Allow clients to override hashing classpath.

### DIFF
--- a/internal/compiler-interface/src/main/java/xsbti/compile/ExternalHooks.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/ExternalHooks.java
@@ -51,6 +51,8 @@ public interface ExternalHooks {
          * @return API changes
          */
         boolean shouldDoIncrementalCompilation(Set<String> changedClasses, CompileAnalysis previousAnalysis);
+
+        Optional<FileHash[]> hashClasspath(File[] classpath);
     }
 
     /**

--- a/internal/compiler-interface/src/main/mima-filters/1.0.0.backwards.excludes
+++ b/internal/compiler-interface/src/main/mima-filters/1.0.0.backwards.excludes
@@ -1,0 +1,1 @@
+ProblemFilters.exclude[ReversedMissingMethodProblem]("xsbti.compile.ExternalHooks#Lookup.hashClasspath")

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Lookup.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Lookup.scala
@@ -90,3 +90,12 @@ trait ExternalLookup extends ExternalHooks.Lookup {
     shouldDoIncrementalCompilation(changedClasses.iterator().asScala.toSet, previousAnalysis)
   }
 }
+
+trait NoopExternalLookup extends ExternalLookup {
+  override def changedSources(previous: CompileAnalysis): Option[Changes[File]] = None
+  override def changedBinaries(previous: CompileAnalysis): Option[Set[File]] = None
+  override def removedProducts(previous: CompileAnalysis): Option[Set[File]] = None
+  override def shouldDoIncrementalCompilation(changedClasses: Set[String],
+                                              analysis: CompileAnalysis): Boolean = true
+  override def hashClasspath(classpath: Array[File]): Optional[Array[FileHash]] = Optional.empty()
+}

--- a/zinc/src/main/scala/sbt/internal/inc/LookupImpl.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/LookupImpl.scala
@@ -8,6 +8,7 @@
 package sbt.internal.inc
 
 import java.io.File
+import java.util.Optional
 
 import xsbti.compile.{ Changes, CompileAnalysis, FileHash, MiniSetup }
 
@@ -39,11 +40,8 @@ class LookupImpl(compileConfiguration: CompileConfiguration, previousSetup: Opti
 
   private val entry = MixedAnalyzingCompiler.classPathLookup(compileConfiguration)
 
-  override def lookupAnalysis(binaryClassName: String): Option[CompileAnalysis] = {
-    analyses.collectFirst {
-      case a if a.relations.productClassName._2s.contains(binaryClassName) => a
-    }
-  }
+  override def lookupAnalysis(binaryClassName: String): Option[CompileAnalysis] =
+    analyses.find(_.relations.productClassName._2s.contains(binaryClassName))
 
   override def lookupOnClasspath(binaryClassName: String): Option[File] =
     entry(binaryClassName)
@@ -64,4 +62,7 @@ class LookupImpl(compileConfiguration: CompileConfiguration, previousSetup: Opti
   override def shouldDoIncrementalCompilation(changedClasses: Set[String],
                                               analysis: CompileAnalysis): Boolean =
     externalLookup.forall(_.shouldDoIncrementalCompilation(changedClasses, analysis))
+
+  override def hashClasspath(classpath: Array[File]): Optional[Array[FileHash]] =
+    externalLookup.map(_.hashClasspath(classpath)).getOrElse(Optional.empty())
 }

--- a/zinc/src/test/scala/sbt/inc/ClasspathHashingHookSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/ClasspathHashingHookSpec.scala
@@ -1,0 +1,35 @@
+package sbt.inc
+
+import java.io.File
+import java.util.Optional
+
+import sbt.internal.inc.NoopExternalLookup
+import sbt.io.IO
+import xsbti.compile.DefaultExternalHooks
+import xsbti.compile.FileHash
+import xsbti.compile.IncOptions
+
+class ClasspathHashingHookSpec extends BaseCompilerSpec {
+  it should "allow client to override classpath hashing" in {
+    IO.withTemporaryDirectory { tempDir =>
+      val setup = ProjectSetup.simple(tempDir.toPath, SourceFiles.Foo :: Nil)
+
+      def hashFile(f: File): FileHash =
+        FileHash.of(f, f.hashCode() * 37 + 41) // Some deterministic random changes
+
+      val lookup = new NoopExternalLookup {
+        override def hashClasspath(classpath: Array[File]): Optional[Array[FileHash]] =
+          Optional.of(classpath.map(hashFile))
+
+      }
+      val hooks = new DefaultExternalHooks(Optional.of(lookup), Optional.empty())
+      val compiler =
+        setup.createCompiler().copy(incOptions = IncOptions.of().withExternalHooks(hooks))
+      val result = compiler.doCompile()
+
+      result.setup().options().classpathHash().foreach { original =>
+        original shouldEqual hashFile(original.file())
+      }
+    }
+  }
+}

--- a/zinc/src/test/scala/sbt/inc/MultiProjectIncrementalSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/MultiProjectIncrementalSpec.scala
@@ -56,15 +56,6 @@ class MultiProjectIncrementalSpec extends BridgeProviderSpecification {
         },
         Locate.definesClass
       )
-      val skipBinaryChangeDetection = false
-      val emptyLookup = new ExternalLookup {
-        override def changedSources(previous: CompileAnalysis): Option[Changes[File]] = None
-        override def changedBinaries(previous: CompileAnalysis): Option[Set[File]] =
-          if (skipBinaryChangeDetection) Some(Set.empty) else None
-        override def removedProducts(previous: CompileAnalysis): Option[Set[File]] = None
-        override def shouldDoIncrementalCompilation(changedClasses: Set[String],
-                                                    analysis: CompileAnalysis): Boolean = true
-      }
       val incOptions = IncOptions
         .of()
         .withApiDebug(true)


### PR DESCRIPTION
This is useful in big builds with 100+ projects with 100+ jars on classpath (mostly the same).

Fixes #400