### PR TITLE
Timestamp hashes

### DIFF
--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -182,7 +182,9 @@ object MixedAnalyzingCompiler {
       extra: List[(String, String)]
   ): CompileConfiguration = {
     val classpathHash = classpath map { x =>
-      FileHash.of(x, Stamper.forHash(x).hashCode)
+      val mod = x.lastModified
+      val length = x.length // TODO reverse
+      FileHash.of(x, (mod ^ length).##)
     }
     val compileSetup = MiniSetup.of(
       output,


### PR DESCRIPTION
Because of  https://github.com/sbt/sbt/issues/363 I am unable to say anything about the perf characteristics of this PR.

I guess it is addressing the same problem that https://github.com/sbt/zinc/pull/371 is addressing and a hacky alternative to #433 (which is probably the correct solution).

What I thought was an I/O bottleneck in https://github.com/sbt/io/pull/79 turned out to be a CPU hashcode bottleneck when hashing *classpath files*, not source files. YourKit doesn't pick up the hash/crypto work, showing it as InputFilterStream. Given the many many bugs in the entire scala tooling chain when it comes to `.jar` files mutating on disk, see https://gitlab.com/fommil/class-monkey/blob/master/README.md, I really don't think SHA-1 is needed here. Timestamps (and file size) should be more than enough.

Also, this hashing could be done *in parallel*. Even if it's as simple as using the terrible `.par`.