### PR TITLE
Remove unused imports + variables

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/Command.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/Command.scala
@@ -8,7 +8,6 @@
 package xsbt
 
 import scala.tools.nsc.{ CompilerCommand, Settings }
-import Compat._
 
 object Command {
 

--- a/internal/compiler-bridge/src/main/scala/xsbt/CompilerInterface.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CompilerInterface.scala
@@ -7,10 +7,9 @@
 
 package xsbt
 
-import xsbti.{ AnalysisCallback, Logger, Problem, Reporter, Severity }
+import xsbti.{ AnalysisCallback, Logger, Problem, Reporter }
 import xsbti.compile._
-import scala.tools.nsc.{ io, reporters, Phase, Global, Settings, SubComponent }
-import io.AbstractFile
+import scala.tools.nsc.Settings
 import scala.collection.mutable
 import Log.debug
 import java.io.File

--- a/internal/compiler-bridge/src/main/scala/xsbt/DelegatingReporter.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/DelegatingReporter.scala
@@ -78,7 +78,7 @@ private object DelegatingReporter {
       val pointer = offset - src.lineToOffset(src.offsetToLine(offset))
       val pointerSpace = lineContent.toList.take(pointer).map {
         case '\t' => '\t'
-        case x    => ' '
+        case _    => ' '
       }
       new PositionImpl(Option(sourcePath),
                        Option(sourceFile),

--- a/internal/compiler-bridge/src/main/scala/xsbt/ExtractAPI.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ExtractAPI.scala
@@ -10,7 +10,6 @@ package xsbt
 import java.io.File
 import java.util.{ Arrays, Comparator }
 import scala.tools.nsc.symtab.Flags
-import scala.collection.mutable.{ HashMap, HashSet, ListBuffer }
 import xsbti.api._
 
 import scala.tools.nsc.Global

--- a/internal/zinc-apiinfo/src/main/scala/xsbt/api/Discovery.scala
+++ b/internal/zinc-apiinfo/src/main/scala/xsbt/api/Discovery.scala
@@ -99,12 +99,12 @@ object Discovery {
   def named(t: Type, nme: String) = simpleName(t) == Some(nme)
 
   def simpleName(t: Type): Option[String] = t match {
-    case a: Annotated    => simpleName(a.baseType)
-    case sing: Singleton => None
+    case a: Annotated => simpleName(a.baseType)
+    case _: Singleton => None
     case p: Projection =>
       p.prefix match {
         case s: Singleton => pathName(s.path, p.id)
-        case e: EmptyType => Some(p.id)
+        case _: EmptyType => Some(p.id)
         case _            => None
       }
     case _ => None

--- a/internal/zinc-apiinfo/src/main/scala/xsbt/api/HashAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/xsbt/api/HashAPI.scala
@@ -198,8 +198,8 @@ final class HashAPI private (
   }
   def hashField(f: FieldLike): Unit = {
     f match {
-      case v: Var => extend(VarHash)
-      case v: Val => extend(ValHash)
+      case _: Var => extend(VarHash)
+      case _: Val => extend(ValHash)
     }
     hashType(f.tpe)
   }
@@ -211,13 +211,13 @@ final class HashAPI private (
   }
   def hashAccess(a: Access): Unit =
     a match {
-      case pub: Public     => extend(PublicHash)
+      case _: Public       => extend(PublicHash)
       case qual: Qualified => hashQualified(qual)
     }
   def hashQualified(qual: Qualified): Unit = {
     qual match {
-      case p: Protected => extend(ProtectedHash)
-      case p: Private   => extend(PrivateHash)
+      case _: Protected => extend(ProtectedHash)
+      case _: Private   => extend(PrivateHash)
     }
     hashQualifier(qual.qualifier)
   }

--- a/internal/zinc-apiinfo/src/main/scala/xsbt/api/ShowAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/xsbt/api/ShowAPI.scala
@@ -64,7 +64,7 @@ object ShowAPI {
     case st: Projection   => showType(st.prefix) + "#" + st.id
     case st: ParameterRef => "<" + st.id + ">"
     case st: Singleton    => showPath(st.path)
-    case st: EmptyType    => "<empty>"
+    case _: EmptyType     => "<empty>"
     case p: Parameterized =>
       showType(p.baseType) + p.typeArguments.map(showType).mkString("[", ", ", "]")
     case c: Constant  => showType(c.baseType) + "(" + c.value + ")"
@@ -149,7 +149,7 @@ object ShowAPI {
   }
 
   private def showAccess(a: Access) = a match {
-    case p: Public    => ""
+    case _: Public    => ""
     case p: Protected => "protected" + showQualifier(p.qualifier)
     case p: Private   => "private" + showQualifier(p.qualifier)
   }

--- a/internal/zinc-benchmarks/src/main/scala/xsbt/GlobalBenchmarkSetup.scala
+++ b/internal/zinc-benchmarks/src/main/scala/xsbt/GlobalBenchmarkSetup.scala
@@ -9,7 +9,7 @@ package xsbt
 
 import java.io.File
 
-import xsbt.BenchmarkProjects.{ Scalac, Shapeless }
+import xsbt.BenchmarkProjects.Scalac
 
 object GlobalBenchmarkSetup {
 

--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/ScalaInstance.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/ScalaInstance.scala
@@ -176,7 +176,7 @@ object ScalaInstance {
   /** Gets the version of Scala in the compiler.properties file from the loader.*/
   private def actualVersion(scalaLoader: ClassLoader)(label: String) = {
     try fastActualVersion(scalaLoader)
-    catch { case e: Exception => slowActualVersion(scalaLoader)(label) }
+    catch { case _: Exception => slowActualVersion(scalaLoader)(label) }
   }
 
   private def slowActualVersion(scalaLoader: ClassLoader)(label: String) = {

--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClasspathUtilities.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClasspathUtilities.scala
@@ -107,7 +107,7 @@ object ClasspathUtilities {
         (in.read() == 0x03) &&
         (in.read() == 0x04)
       }
-    } catch { case e: Exception => false }
+    } catch { case _: Exception => false }
 
   /** Returns all entries in 'classpath' that correspond to a compiler plugin.*/
   private[sbt] def compilerPlugins(classpath: Seq[File]): Iterable[File] = {
@@ -128,6 +128,6 @@ object ClasspathUtilities {
           new File(new URI(if (end == -1) path else path.substring(0, end))) :: Nil
         case _ => Nil
       }
-    } catch { case e: Exception => Nil }
+    } catch { case _: Exception => Nil }
   }
 }

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/DiagnosticsReporter.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/DiagnosticsReporter.scala
@@ -110,7 +110,7 @@ final class DiagnosticsReporter(reporter: Reporter) extends DiagnosticListener[J
           }
         } catch {
           // TODO - catch ReflectiveOperationException once sbt is migrated to JDK7
-          case ignored: Throwable => None
+          case _: Throwable => None
         }
 
       def getExpression: String =
@@ -137,7 +137,7 @@ final class DiagnosticsReporter(reporter: Reporter) extends DiagnosticListener[J
     private def fixSource[T <: JavaFileObject](source: T): Option[String] = {
       try Option(source).map(_.toUri.normalize).map(new File(_)).map(_.getAbsolutePath)
       catch {
-        case t: IllegalArgumentException =>
+        case _: IllegalArgumentException =>
           // Oracle JDK6 has a super dumb notion of what a URI is.  In fact, it's not even a legimitate URL, but a dump
           // of the filename in a "I hope this works to toString it" kind of way.  This appears to work in practice
           // but we may need to re-evaluate.

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavaErrorParser.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavaErrorParser.scala
@@ -112,7 +112,7 @@ class JavaErrorParser(relativeDir: File = new File(new File(".").getAbsolutePath
   private object ParsedInteger {
     def unapply(s: String): Option[Int] =
       try Some(Integer.parseInt(s))
-      catch { case e: NumberFormatException => None }
+      catch { case _: NumberFormatException => None }
   }
   // Parses a line number
   val line: Parser[Int] = allUntilChar(':') ^? {
@@ -221,10 +221,10 @@ class JavaErrorParser(relativeDir: File = new File(new File(".").getAbsolutePath
   final def parseProblems(in: String, logger: sbt.util.Logger): Seq[Problem] =
     parse(javacOutput, in) match {
       case Success(result, _) => result
-      case Failure(msg, n) =>
+      case Failure(_, n) =>
         logger.warn(s"Unexpected javac output at:${n.pos.longString}.")
         Seq.empty
-      case Error(msg, n) =>
+      case Error(_, n) =>
         logger.warn(s"Unexpected javac output at:${n.pos.longString}.")
         Seq.empty
     }

--- a/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/javac/javaErrorParserSpec.scala
+++ b/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/javac/javaErrorParserSpec.scala
@@ -37,7 +37,7 @@ class JavaErrorParserSpec extends UnitSpec {
   def parseWindowsFile() = {
     val parser = new JavaErrorParser()
     parser.parse(parser.fileAndLineNo, sampleWindowsMessage) match {
-      case parser.Success((file, line), rest) => file shouldBe (windowsFile)
+      case parser.Success((file, _), _) => file shouldBe (windowsFile)
       case parser.Error(msg, next) =>
         assert(false, s"Error to parse: $msg, ${next.pos.longString}")
       case parser.Failure(msg, next) =>

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/APIDiff.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/APIDiff.scala
@@ -10,8 +10,6 @@ package internal
 package inc
 
 import xsbt.api.DefaultShowAPI
-import java.lang.reflect.Method
-import java.util.{ List => JList }
 
 import xsbti.api.Companions
 
@@ -170,7 +168,6 @@ private[inc] class APIDiff {
         } else {
           val xlen = x.length
           val xmid = xlen / 2
-          val ylen = y.length
 
           val (x1, x2) = x.splitAt(xmid)
           val leftScore = nwScore(x1, y)

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Compile.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Compile.scala
@@ -12,16 +12,7 @@ package inc
 import sbt.internal.inc.Analysis.{ LocalProduct, NonLocalProduct }
 import xsbt.api.{ APIUtil, HashAPI, NameHashing }
 import xsbti.api._
-import xsbti.compile.{
-  ClassFileManager,
-  CompileAnalysis,
-  DependencyChanges,
-  IncOptions,
-  MultipleOutput,
-  Output,
-  OutputGroup,
-  SingleOutput
-}
+import xsbti.compile.{ ClassFileManager, CompileAnalysis, DependencyChanges, IncOptions, Output }
 import xsbti.{ Position, Problem, Severity, UseScope }
 import sbt.util.Logger
 import sbt.util.InterfaceUtil.jo2o

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
@@ -12,14 +12,7 @@ package inc
 import java.io.File
 
 import xsbti.api.AnalyzedClass
-import xsbti.compile.{
-  Changes,
-  ClassFileManager,
-  CompileAnalysis,
-  DependencyChanges,
-  IncOptions,
-  IncOptionsUtil
-}
+import xsbti.compile.{ Changes, ClassFileManager, CompileAnalysis, DependencyChanges, IncOptions }
 import xsbti.compile.analysis.{ ReadStamps, Stamp }
 
 import scala.annotation.tailrec
@@ -287,7 +280,7 @@ private[inc] abstract class IncrementalCommon(val log: sbt.util.Logger, options:
   /** Invalidate all classes that claim to produce the same class file as another class. */
   def invalidateDuplicates(merged: Relations): Set[String] =
     merged.srcProd.reverseMap.flatMap {
-      case (classFile, sources) =>
+      case (_, sources) =>
         if (sources.size > 1) sources.flatMap(merged.classNames) else Nil
     }.toSet
 
@@ -456,7 +449,7 @@ private[inc] abstract class IncrementalCommon(val log: sbt.util.Logger, options:
           if (lookup.changedClasspathHash.isEmpty)
             lookup.lookupAnalysis(binaryClassName) match {
               case None    => false
-              case Some(e) => inv(s"shadowing is detected for class $binaryClassName")
+              case Some(_) => inv(s"shadowing is detected for class $binaryClassName")
             } else
             lookup.lookupOnClasspath(binaryClassName) match {
               case None    => inv(s"could not find class $binaryClassName on the classpath.")

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Lookup.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Lookup.scala
@@ -8,7 +8,7 @@
 package sbt.internal.inc
 
 import java.io.File
-import java.{ lang, util }
+import java.util
 import java.util.Optional
 
 import xsbti.compile.{ Changes, CompileAnalysis, ExternalHooks, FileHash }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
@@ -138,7 +138,7 @@ object Stamp {
 object Stamper {
   private def tryStamp(g: => Stamp): Stamp = {
     try { g } // TODO: Double check correctness. Why should we not report an exception here?
-    catch { case i: IOException => EmptyStamp }
+    catch { case _: IOException => EmptyStamp }
   }
 
   val forHash = (toStamp: File) => tryStamp(Hash.ofFile(toStamp))

--- a/internal/zinc-ivy-integration/src/main/scala/sbt/internal/inc/ZincComponentCompiler.scala
+++ b/internal/zinc-ivy-integration/src/main/scala/sbt/internal/inc/ZincComponentCompiler.scala
@@ -14,7 +14,7 @@ import java.net.URLClassLoader
 import java.util.concurrent.Callable
 
 import sbt.internal.inc.classpath.ClasspathUtilities
-import sbt.io.{ Hash, IO }
+import sbt.io.IO
 import sbt.internal.librarymanagement._
 import sbt.internal.util.FullLogger
 import sbt.librarymanagement._
@@ -290,7 +290,6 @@ private object ZincLMHelper {
     val updateConfiguration = defaultUpdateConfiguration(retrieveDirectory, noSource)
     val dependencies = prettyPrintDependency(module)
     logger.info(s"Attempting to fetch $dependencies.")
-    val clockForCache = LogicalClock.unknown
     dependencyResolution.update(module, updateConfiguration, warningConf, logger) match {
       case Left(unresolvedWarning) =>
         logger.debug(s"Couldn't retrieve module(s) ${prettyPrintDependency(module)}.")

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/cached/CacheAwareStore.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/cached/CacheAwareStore.scala
@@ -10,7 +10,6 @@ package sbt.internal.inc.cached
 import java.io.File
 import java.util.Optional
 
-import sbt.internal.inc.ConcreteAnalysisContents
 import xsbti.compile.{ AnalysisContents, AnalysisStore }
 
 case class CacheAwareStore(localStore: AnalysisStore,

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/cached/ExportableCache.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/cached/ExportableCache.scala
@@ -53,7 +53,7 @@ class ExportableCache(val cacheLocation: Path, cleanOutputMode: CleanOutputMode 
     val oldStamps = analysis.stamps
 
     val updatedProducts = oldStamps.products.map {
-      case (file, stamp) if importedFiles.contains(file) =>
+      case (file, _) if importedFiles.contains(file) =>
         (file, Stamper.forLastModified(file))
       case other => other
     }

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/text/InputWrapperStream.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/text/InputWrapperStream.scala
@@ -11,6 +11,6 @@ import sbinary.Input
 
 final class InputWrapperStream(in: Input) extends java.io.InputStream {
   def toInt(b: Byte) = if (b < 0) b + 256 else b.toInt
-  def read() = try { toInt(in.readByte) } catch { case e: sbinary.EOF => -1 }
+  def read() = try { toInt(in.readByte) } catch { case _: sbinary.EOF => -1 }
   override def read(b: Array[Byte], off: Int, len: Int) = in.readTo(b, off, len)
 }

--- a/internal/zinc-persist/src/test/scala/sbt/inc/binary/BinaryMappersSpecification.scala
+++ b/internal/zinc-persist/src/test/scala/sbt/inc/binary/BinaryMappersSpecification.scala
@@ -3,12 +3,7 @@ package sbt.inc.binary
 import java.nio.file.Paths
 
 import org.scalacheck.{ Prop, Properties }
-import sbt.internal.inc.{
-  Analysis,
-  AnalysisGenerators,
-  ConcreteAnalysisContents,
-  FileAnalysisStore
-}
+import sbt.internal.inc.{ Analysis, AnalysisGenerators, FileAnalysisStore }
 import sbt.io.IO
 import xsbti.compile.AnalysisContents
 import xsbti.compile.analysis.ReadWriteMappers

--- a/internal/zinc-testing/src/main/scala/sbt/internal/inc/BaseIvySpecification.scala
+++ b/internal/zinc-testing/src/main/scala/sbt/internal/inc/BaseIvySpecification.scala
@@ -19,8 +19,6 @@ import sbt.librarymanagement._
 import sbt.librarymanagement.ivy._
 import Configurations._
 
-import sjsonnew.shaded.scalajson.ast.unsafe.JValue
-
 trait BaseIvySpecification extends UnitSpec {
   def currentBase: File = new File(".")
   def currentTarget: File = currentBase / "target" / "ivyhome"

--- a/zinc/src/test/scala/sbt/inc/MultiProjectIncrementalSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/MultiProjectIncrementalSpec.scala
@@ -56,15 +56,6 @@ class MultiProjectIncrementalSpec extends BridgeProviderSpecification {
         },
         Locate.definesClass
       )
-      val skipBinaryChangeDetection = false
-      val emptyLookup = new ExternalLookup {
-        override def changedSources(previous: CompileAnalysis): Option[Changes[File]] = None
-        override def changedBinaries(previous: CompileAnalysis): Option[Set[File]] =
-          if (skipBinaryChangeDetection) Some(Set.empty) else None
-        override def removedProducts(previous: CompileAnalysis): Option[Set[File]] = None
-        override def shouldDoIncrementalCompilation(changedClasses: Set[String],
-                                                    analysis: CompileAnalysis): Boolean = true
-      }
       val incOptions = IncOptions
         .of()
         .withApiDebug(true)


### PR DESCRIPTION
Partially addresses #349.
The remaining warnings are mostly due to unused method + parameter (I'm not sure whether it is okay to remove them).