### PR TITLE
Fix pattern matching in classpath hash caching

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,10 @@ def commonSettings: Seq[Setting[_]] = Seq(
   crossScalaVersions := Seq(scala211, scala212),
   publishArtifact in Test := false,
   commands ++= Seq(publishBridgesAndTest, publishBridgesAndSet, crossTestBridges),
-  scalacOptions += "-YdisableFlatCpCaching"
+  scalacOptions ++= Seq(
+    "-YdisableFlatCpCaching",
+    "-target:jvm-1.8",
+  )
 )
 
 def relaxNon212: Seq[Setting[_]] = Seq(
@@ -44,7 +47,7 @@ def relaxNon212: Seq[Setting[_]] = Seq(
           "-deprecation",
           "-Ywarn-unused",
           "-Ywarn-unused-import",
-          "-YdisableFlatCpCaching"
+          "-YdisableFlatCpCaching",
         )
     }
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,14 +2,14 @@ import sbt._, Keys._
 import sbt.contraband.ContrabandPlugin.autoImport._
 
 object Dependencies {
-  val scala210 = "2.10.6"
-  val scala211 = "2.11.11"
-  val scala212 = "2.12.3"
+  val scala210 = "2.10.7"
+  val scala211 = "2.11.12"
+  val scala212 = "2.12.4"
   val scala213 = "2.13.0-M2"
 
-  private val ioVersion = "1.0.0"
-  private val utilVersion = "1.0.0"
-  private val lmVersion = "1.0.0"
+  private val ioVersion = "1.0.2"
+  private val utilVersion = "1.0.3"
+  private val lmVersion = "1.0.4"
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion
 

--- a/zinc/src/main/scala/sbt/internal/inc/caching/ClasspathCache.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/caching/ClasspathCache.scala
@@ -32,7 +32,7 @@ object ClasspathCache {
           val currentMetadata = (attrs.lastModifiedTime(), attrs.size())
           Option(cacheMetadataJar.get(file)) match {
             case Some((metadata, hashHit)) if metadata == currentMetadata => hashHit
-            case None                                                     => genFileHash(file, currentMetadata)
+            case _                                                        => genFileHash(file, currentMetadata)
           }
         }
       }


### PR DESCRIPTION
Fixes #457

I'm seeing the following during the scripted test dependency-management / snapshot-resolution on sbt.

```
[info] [error] ## Exception when compiling 1 sources to /tmp/sbt_8c2c1ba5/dependent/target/scala-2.11/classes
[info] [error] Some(((2017-11-25T06:55:41Z,1066),FileHash(file: /tmp/sbt_8c2c1ba5/ivy-cache/cache/com.badexample/badexample/jars/badexample-1.0-SNAPSHOT.jar, hash: -1108521295))) (of class scala.Some)
[info] [error] sbt.internal.inc.caching.ClasspathCache$.fromCacheOrHash$1(ClasspathCache.scala:35)
```

See also the added unit test:

```diff
+      IO.copyFile(fromResource(Paths.get("jar1.jar")), fakeLibraryJar)
+      genConfig
+
+      // This mimics changing dependency like -SNAPSHOT
+      IO.copyFile(fromResource(Paths.get("classesDep1.zip")), fakeLibraryJar)
+      genConfig
```

This fixes the issue by making sure the case falls back to `genFileHash`.
