### PR TITLE
Convert lastModified() calls to the more precise getModifiedTime()

### DIFF
--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaderCache.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaderCache.scala
@@ -14,6 +14,7 @@ import java.lang.ref.{ Reference, SoftReference }
 import java.io.File
 import java.net.URLClassLoader
 import java.util.HashMap
+import sbt.io.Milli.getModifiedTime
 
 // Hack for testing only
 final class ClassLoaderCache(val commonParent: ClassLoader) {
@@ -43,7 +44,7 @@ final class ClassLoaderCache(val commonParent: ClassLoader) {
       mkLoader: () => ClassLoader
   ): ClassLoader =
     synchronized {
-      val tstamps = files.map(_.lastModified)
+      val tstamps = files.map(getModifiedTime)
       getFromReference(files, tstamps, delegate.get(files), mkLoader)
     }
 

--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaderCache.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaderCache.scala
@@ -14,7 +14,7 @@ import java.lang.ref.{ Reference, SoftReference }
 import java.io.File
 import java.net.URLClassLoader
 import java.util.HashMap
-import sbt.io.IO.getModifiedTime
+import sbt.io.IO
 
 // Hack for testing only
 final class ClassLoaderCache(val commonParent: ClassLoader) {
@@ -44,7 +44,7 @@ final class ClassLoaderCache(val commonParent: ClassLoader) {
       mkLoader: () => ClassLoader
   ): ClassLoader =
     synchronized {
-      val tstamps = files.map(getModifiedTime)
+      val tstamps = files.map(IO.getModifiedTime)
       getFromReference(files, tstamps, delegate.get(files), mkLoader)
     }
 

--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaderCache.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaderCache.scala
@@ -14,7 +14,7 @@ import java.lang.ref.{ Reference, SoftReference }
 import java.io.File
 import java.net.URLClassLoader
 import java.util.HashMap
-import sbt.io.Milli.getModifiedTime
+import sbt.io.IO.getModifiedTime
 
 // Hack for testing only
 final class ClassLoaderCache(val commonParent: ClassLoader) {

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
@@ -13,9 +13,8 @@ import java.io.{ File, IOException }
 import java.util
 import java.util.Optional
 
-import sbt.io.{ Hash => IOHash }
+import sbt.io.{ Hash => IOHash, IO }
 import xsbti.compile.analysis.{ ReadStamps, Stamp }
-import sbt.io.IO.getModifiedTime
 
 import scala.collection.immutable.TreeMap
 import scala.util.matching.Regex
@@ -143,7 +142,7 @@ object Stamper {
   }
 
   val forHash = (toStamp: File) => tryStamp(Hash.ofFile(toStamp))
-  val forLastModified = (toStamp: File) => tryStamp(new LastModified(getModifiedTime(toStamp)))
+  val forLastModified = (toStamp: File) => tryStamp(new LastModified(IO.getModifiedTime(toStamp)))
 }
 
 object Stamps {

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
@@ -15,7 +15,7 @@ import java.util.Optional
 
 import sbt.io.{ Hash => IOHash }
 import xsbti.compile.analysis.{ ReadStamps, Stamp }
-import sbt.io.Milli.getModifiedTime
+import sbt.io.IO.getModifiedTime
 
 import scala.collection.immutable.TreeMap
 import scala.util.matching.Regex

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
@@ -15,6 +15,7 @@ import java.util.Optional
 
 import sbt.io.{ Hash => IOHash }
 import xsbti.compile.analysis.{ ReadStamps, Stamp }
+import sbt.io.Milli.getModifiedTime
 
 import scala.collection.immutable.TreeMap
 import scala.util.matching.Regex
@@ -142,7 +143,7 @@ object Stamper {
   }
 
   val forHash = (toStamp: File) => tryStamp(Hash.ofFile(toStamp))
-  val forLastModified = (toStamp: File) => tryStamp(new LastModified(toStamp.lastModified()))
+  val forLastModified = (toStamp: File) => tryStamp(new LastModified(getModifiedTime(toStamp)))
 }
 
 object Stamps {

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -21,6 +21,8 @@ object Util {
     val timestamp = formatter.format(new Date)
     val content = versionLine(version) + "\ntimestamp=" + timestamp
     val f = dir / "incrementalcompiler.version.properties"
+    // TODO: replace lastModified() with sbt.io.Milli.getModifiedTime(), once the build
+    // has been upgraded to a version of sbt that includes sbt.io.Milli.
     if (!f.exists || f.lastModified < lastCompilationTime(analysis) || !containsVersion(f, version)) {
       s.log.info("Writing version information to " + f + " :\n" + content)
       IO.write(f, content)

--- a/zinc/src/main/scala/sbt/internal/inc/caching/ClasspathCache.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/caching/ClasspathCache.scala
@@ -7,7 +7,7 @@ import java.nio.file.attribute.{ BasicFileAttributes, FileTime }
 
 import xsbti.compile.FileHash
 import sbt.internal.inc.{ EmptyStamp, Stamper }
-import sbt.io.IO.getModifiedTime
+import sbt.io.IO
 
 object ClasspathCache {
   // For more safety, store both the time and size
@@ -30,7 +30,7 @@ object ClasspathCache {
         val attrs = Files.readAttributes(file.toPath, classOf[BasicFileAttributes])
         if (attrs.isDirectory) emptyFileHash(file)
         else {
-          val currentMetadata = (FileTime.fromMillis(getModifiedTime(file)), attrs.size())
+          val currentMetadata = (FileTime.fromMillis(IO.getModifiedTime(file)), attrs.size())
           Option(cacheMetadataJar.get(file)) match {
             case Some((metadata, hashHit)) if metadata == currentMetadata => hashHit
             case _                                                        => genFileHash(file, currentMetadata)

--- a/zinc/src/main/scala/sbt/internal/inc/caching/ClasspathCache.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/caching/ClasspathCache.scala
@@ -7,6 +7,7 @@ import java.nio.file.attribute.{ BasicFileAttributes, FileTime }
 
 import xsbti.compile.FileHash
 import sbt.internal.inc.{ EmptyStamp, Stamper }
+import sbt.io.Milli.getModifiedTime
 
 object ClasspathCache {
   // For more safety, store both the time and size
@@ -29,7 +30,7 @@ object ClasspathCache {
         val attrs = Files.readAttributes(file.toPath, classOf[BasicFileAttributes])
         if (attrs.isDirectory) emptyFileHash(file)
         else {
-          val currentMetadata = (attrs.lastModifiedTime(), attrs.size())
+          val currentMetadata = (FileTime.fromMillis(getModifiedTime(file)), attrs.size())
           Option(cacheMetadataJar.get(file)) match {
             case Some((metadata, hashHit)) if metadata == currentMetadata => hashHit
             case _                                                        => genFileHash(file, currentMetadata)

--- a/zinc/src/main/scala/sbt/internal/inc/caching/ClasspathCache.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/caching/ClasspathCache.scala
@@ -7,7 +7,7 @@ import java.nio.file.attribute.{ BasicFileAttributes, FileTime }
 
 import xsbti.compile.FileHash
 import sbt.internal.inc.{ EmptyStamp, Stamper }
-import sbt.io.Milli.getModifiedTime
+import sbt.io.IO.getModifiedTime
 
 object ClasspathCache {
   // For more safety, store both the time and size


### PR DESCRIPTION
Use the new native file modification timestamps, which return times with full millisecond precisions whenever possible.
Depends on https://github.com/sbt/librarymanagement/pull/189
See: https://github.com/sbt/io/pull/92