### PR TITLE
Convert lastModified() calls to the more precise getModifiedTime()

### DIFF
--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaderCache.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaderCache.scala
@@ -14,6 +14,7 @@ import java.lang.ref.{ Reference, SoftReference }
 import java.io.File
 import java.net.URLClassLoader
 import java.util.HashMap
+import sbt.io.Milli.getModifiedTime
 
 // Hack for testing only
 final class ClassLoaderCache(val commonParent: ClassLoader) {
@@ -43,7 +44,7 @@ final class ClassLoaderCache(val commonParent: ClassLoader) {
       mkLoader: () => ClassLoader
   ): ClassLoader =
     synchronized {
-      val tstamps = files.map(_.lastModified)
+      val tstamps = files.map(getModifiedTime)
       getFromReference(files, tstamps, delegate.get(files), mkLoader)
     }
 

--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaderCache.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaderCache.scala
@@ -14,7 +14,7 @@ import java.lang.ref.{ Reference, SoftReference }
 import java.io.File
 import java.net.URLClassLoader
 import java.util.HashMap
-import sbt.io.IO.getModifiedTime
+import sbt.io.IO
 
 // Hack for testing only
 final class ClassLoaderCache(val commonParent: ClassLoader) {
@@ -44,7 +44,7 @@ final class ClassLoaderCache(val commonParent: ClassLoader) {
       mkLoader: () => ClassLoader
   ): ClassLoader =
     synchronized {
-      val tstamps = files.map(getModifiedTime)
+      val tstamps = files.map(IO.getModifiedTime)
       getFromReference(files, tstamps, delegate.get(files), mkLoader)
     }
 

--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaderCache.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaderCache.scala
@@ -14,7 +14,7 @@ import java.lang.ref.{ Reference, SoftReference }
 import java.io.File
 import java.net.URLClassLoader
 import java.util.HashMap
-import sbt.io.Milli.getModifiedTime
+import sbt.io.IO.getModifiedTime
 
 // Hack for testing only
 final class ClassLoaderCache(val commonParent: ClassLoader) {

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
@@ -13,9 +13,8 @@ import java.io.{ File, IOException }
 import java.util
 import java.util.Optional
 
-import sbt.io.{ Hash => IOHash }
+import sbt.io.{ Hash => IOHash, IO }
 import xsbti.compile.analysis.{ ReadStamps, Stamp }
-import sbt.io.IO.getModifiedTime
 
 import scala.collection.immutable.TreeMap
 import scala.util.matching.Regex
@@ -143,7 +142,7 @@ object Stamper {
   }
 
   val forHash = (toStamp: File) => tryStamp(Hash.ofFile(toStamp))
-  val forLastModified = (toStamp: File) => tryStamp(new LastModified(getModifiedTime(toStamp)))
+  val forLastModified = (toStamp: File) => tryStamp(new LastModified(IO.getModifiedTime(toStamp)))
 }
 
 object Stamps {

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
@@ -15,7 +15,7 @@ import java.util.Optional
 
 import sbt.io.{ Hash => IOHash }
 import xsbti.compile.analysis.{ ReadStamps, Stamp }
-import sbt.io.Milli.getModifiedTime
+import sbt.io.IO.getModifiedTime
 
 import scala.collection.immutable.TreeMap
 import scala.util.matching.Regex

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
@@ -15,6 +15,7 @@ import java.util.Optional
 
 import sbt.io.{ Hash => IOHash }
 import xsbti.compile.analysis.{ ReadStamps, Stamp }
+import sbt.io.Milli.getModifiedTime
 
 import scala.collection.immutable.TreeMap
 import scala.util.matching.Regex
@@ -142,7 +143,7 @@ object Stamper {
   }
 
   val forHash = (toStamp: File) => tryStamp(Hash.ofFile(toStamp))
-  val forLastModified = (toStamp: File) => tryStamp(new LastModified(toStamp.lastModified()))
+  val forLastModified = (toStamp: File) => tryStamp(new LastModified(getModifiedTime(toStamp)))
 }
 
 object Stamps {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,9 +7,9 @@ object Dependencies {
   val scala212 = "2.12.4"
   val scala213 = "2.13.0-M2"
 
-  private val ioVersion = "1.1.1"
-  private val utilVersion = "1.1.0"
-  private val lmVersion = "1.0.4"
+  private val ioVersion = "1.1.2"
+  private val utilVersion = "1.1.1"
+  private val lmVersion = "1.1.1"
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion
 

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -21,6 +21,8 @@ object Util {
     val timestamp = formatter.format(new Date)
     val content = versionLine(version) + "\ntimestamp=" + timestamp
     val f = dir / "incrementalcompiler.version.properties"
+    // TODO: replace lastModified() with sbt.io.Milli.getModifiedTime(), once the build
+    // has been upgraded to a version of sbt that includes sbt.io.Milli.
     if (!f.exists || f.lastModified < lastCompilationTime(analysis) || !containsVersion(f, version)) {
       s.log.info("Writing version information to " + f + " :\n" + content)
       IO.write(f, content)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,7 @@
+addSbtPlugin("org.scala-sbt" % "sbt-houserules" % "0.3.4")
+addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.3.2")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.27")
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0-M1")
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.12")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "3.0.2")
-addSbtPlugin("org.scala-sbt" % "sbt-houserules" % "0.3.3")
-addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.3.0")
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.12-rc5")
 libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin" % "0.6.0"
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.17")

--- a/zinc/src/main/scala/sbt/internal/inc/caching/ClasspathCache.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/caching/ClasspathCache.scala
@@ -7,7 +7,7 @@ import java.nio.file.attribute.{ BasicFileAttributes, FileTime }
 
 import xsbti.compile.FileHash
 import sbt.internal.inc.{ EmptyStamp, Stamper }
-import sbt.io.IO.getModifiedTime
+import sbt.io.IO
 
 object ClasspathCache {
   // For more safety, store both the time and size
@@ -30,7 +30,7 @@ object ClasspathCache {
         val attrs = Files.readAttributes(file.toPath, classOf[BasicFileAttributes])
         if (attrs.isDirectory) emptyFileHash(file)
         else {
-          val currentMetadata = (FileTime.fromMillis(getModifiedTime(file)), attrs.size())
+          val currentMetadata = (FileTime.fromMillis(IO.getModifiedTime(file)), attrs.size())
           Option(cacheMetadataJar.get(file)) match {
             case Some((metadata, hashHit)) if metadata == currentMetadata => hashHit
             case _                                                        => genFileHash(file, currentMetadata)

--- a/zinc/src/main/scala/sbt/internal/inc/caching/ClasspathCache.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/caching/ClasspathCache.scala
@@ -7,6 +7,7 @@ import java.nio.file.attribute.{ BasicFileAttributes, FileTime }
 
 import xsbti.compile.FileHash
 import sbt.internal.inc.{ EmptyStamp, Stamper }
+import sbt.io.Milli.getModifiedTime
 
 object ClasspathCache {
   // For more safety, store both the time and size
@@ -29,7 +30,7 @@ object ClasspathCache {
         val attrs = Files.readAttributes(file.toPath, classOf[BasicFileAttributes])
         if (attrs.isDirectory) emptyFileHash(file)
         else {
-          val currentMetadata = (attrs.lastModifiedTime(), attrs.size())
+          val currentMetadata = (FileTime.fromMillis(getModifiedTime(file)), attrs.size())
           Option(cacheMetadataJar.get(file)) match {
             case Some((metadata, hashHit)) if metadata == currentMetadata => hashHit
             case _                                                        => genFileHash(file, currentMetadata)

--- a/zinc/src/main/scala/sbt/internal/inc/caching/ClasspathCache.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/caching/ClasspathCache.scala
@@ -7,7 +7,7 @@ import java.nio.file.attribute.{ BasicFileAttributes, FileTime }
 
 import xsbti.compile.FileHash
 import sbt.internal.inc.{ EmptyStamp, Stamper }
-import sbt.io.Milli.getModifiedTime
+import sbt.io.IO.getModifiedTime
 
 object ClasspathCache {
   // For more safety, store both the time and size


### PR DESCRIPTION
This is a continuation of https://github.com/sbt/zinc/pull/463, which is a ripple PR from https://github.com/sbt/io/pull/92 / https://github.com/sbt/librarymanagement/pull/191.

This uses the new native file modification timestamps that returns times with full millisecond precisions whenever possible to work around [[JDK-8177809] File.lastModified() is losing milliseconds (always ends in 000)](https://bugs.openjdk.java.net/browse/JDK-8177809).
