### PR TITLE
Use IO.getModifiedTimeOrZero(file) calls

### DIFF
--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaderCache.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaderCache.scala
@@ -44,7 +44,7 @@ final class ClassLoaderCache(val commonParent: ClassLoader) {
       mkLoader: () => ClassLoader
   ): ClassLoader =
     synchronized {
-      val tstamps = files.map(IO.lastModified)
+      val tstamps = files.map(IO.getModifiedTimeOrZero)
       getFromReference(files, tstamps, delegate.get(files), mkLoader)
     }
 

--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaderCache.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaderCache.scala
@@ -44,7 +44,7 @@ final class ClassLoaderCache(val commonParent: ClassLoader) {
       mkLoader: () => ClassLoader
   ): ClassLoader =
     synchronized {
-      val tstamps = files.map(IO.getModifiedTime)
+      val tstamps = files.map(IO.lastModified)
       getFromReference(files, tstamps, delegate.get(files), mkLoader)
     }
 

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
@@ -142,7 +142,7 @@ object Stamper {
   }
 
   val forHash = (toStamp: File) => tryStamp(Hash.ofFile(toStamp))
-  val forLastModified = (toStamp: File) => tryStamp(new LastModified(IO.lastModified(toStamp)))
+  val forLastModified = (toStamp: File) => tryStamp(new LastModified(IO.getModifiedTimeOrZero(toStamp)))
 }
 
 object Stamps {

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
@@ -142,7 +142,7 @@ object Stamper {
   }
 
   val forHash = (toStamp: File) => tryStamp(Hash.ofFile(toStamp))
-  val forLastModified = (toStamp: File) => tryStamp(new LastModified(IO.getModifiedTime(toStamp)))
+  val forLastModified = (toStamp: File) => tryStamp(new LastModified(IO.lastModified(toStamp)))
 }
 
 object Stamps {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,9 +7,9 @@ object Dependencies {
   val scala212 = "2.12.4"
   val scala213 = "2.13.0-M2"
 
-  private val ioVersion = "1.1.2"
-  private val utilVersion = "1.1.1"
-  private val lmVersion = "1.1.1"
+  private val ioVersion = "1.1.3"
+  private val utilVersion = "1.1.2"
+  private val lmVersion = "1.1.2"
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion
 

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -21,7 +21,7 @@ object Util {
     val timestamp = formatter.format(new Date)
     val content = versionLine(version) + "\ntimestamp=" + timestamp
     val f = dir / "incrementalcompiler.version.properties"
-    // TODO: replace lastModified() with sbt.io.IO.lastModified(), once the build
+    // TODO: replace lastModified() with sbt.io.IO.getModifiedTimeOrZero(), once the build
     // has been upgraded to a version of sbt that includes that call.
     if (!f.exists || f.lastModified < lastCompilationTime(analysis) || !containsVersion(f, version)) {
       s.log.info("Writing version information to " + f + " :\n" + content)

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -21,8 +21,8 @@ object Util {
     val timestamp = formatter.format(new Date)
     val content = versionLine(version) + "\ntimestamp=" + timestamp
     val f = dir / "incrementalcompiler.version.properties"
-    // TODO: replace lastModified() with sbt.io.Milli.getModifiedTime(), once the build
-    // has been upgraded to a version of sbt that includes sbt.io.Milli.
+    // TODO: replace lastModified() with sbt.io.IO.lastModified(), once the build
+    // has been upgraded to a version of sbt that includes that call.
     if (!f.exists || f.lastModified < lastCompilationTime(analysis) || !containsVersion(f, version)) {
       s.log.info("Writing version information to " + f + " :\n" + content)
       IO.write(f, content)

--- a/zinc/src/main/scala/sbt/internal/inc/caching/ClasspathCache.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/caching/ClasspathCache.scala
@@ -30,7 +30,7 @@ object ClasspathCache {
         val attrs = Files.readAttributes(file.toPath, classOf[BasicFileAttributes])
         if (attrs.isDirectory) emptyFileHash(file)
         else {
-          val currentMetadata = (FileTime.fromMillis(IO.getModifiedTime(file)), attrs.size())
+          val currentMetadata = (FileTime.fromMillis(IO.lastModified(file)), attrs.size())
           Option(cacheMetadataJar.get(file)) match {
             case Some((metadata, hashHit)) if metadata == currentMetadata => hashHit
             case _                                                        => genFileHash(file, currentMetadata)

--- a/zinc/src/main/scala/sbt/internal/inc/caching/ClasspathCache.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/caching/ClasspathCache.scala
@@ -30,7 +30,7 @@ object ClasspathCache {
         val attrs = Files.readAttributes(file.toPath, classOf[BasicFileAttributes])
         if (attrs.isDirectory) emptyFileHash(file)
         else {
-          val currentMetadata = (FileTime.fromMillis(IO.lastModified(file)), attrs.size())
+          val currentMetadata = (FileTime.fromMillis(IO.getModifiedTimeOrZero(file)), attrs.size())
           Option(cacheMetadataJar.get(file)) match {
             case Some((metadata, hashHit)) if metadata == currentMetadata => hashHit
             case _                                                        => genFileHash(file, currentMetadata)


### PR DESCRIPTION
There are just too many instances in which sbt's code relies on
the `lastModified`/`setLastModified` semantics, so instead of moving
to `get`/`setModifiedTime`, we use new IO calls that offer the new
timestamp precision, but retain the old semantics.