### PR TITLE
Add 1.0.5 to mimaPreviousArtifacts, & backfill

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,9 +10,11 @@ lazy val compilerBridgeTestScalaVersions = List(scala212, scala211, scala210)
 
 def mimaSettings: Seq[Setting[_]] = Seq(
   mimaPreviousArtifacts := Set(
-    organization.value % moduleName.value % "1.0.0"
+    "1.0.0", "1.0.1", "1.0.2", "1.0.3", "1.0.4", "1.0.5",
+  ) map (version =>
+    organization.value %% moduleName.value % version
       cross (if (crossPaths.value) CrossVersion.binary else CrossVersion.disabled)
-  )
+  ),
 )
 
 def commonSettings: Seq[Setting[_]] = Seq(
@@ -284,6 +286,15 @@ lazy val zincCompileCore = (project in internalPath / "zinc-compile-core")
       baseDirectory.value / "src" / "main" / "contraband-java",
     sourceManaged in (Compile, generateContrabands) := baseDirectory.value / "src" / "main" / "contraband-java",
     mimaSettings,
+    mimaBinaryIssueFilters ++= {
+      import com.typesafe.tools.mima.core._
+      import com.typesafe.tools.mima.core.ProblemFilters._
+      Seq(
+        // PositionImpl is a private class only invoked in the same source.
+        exclude[FinalClassProblem]("sbt.internal.inc.javac.DiagnosticsReporter$PositionImpl"),
+        exclude[DirectMissingMethodProblem]("sbt.internal.inc.javac.DiagnosticsReporter#PositionImpl.this"),
+      )
+    },
   )
   .configure(addSbtUtilLogging, addSbtIO, addSbtUtilControl)
 
@@ -321,6 +332,13 @@ lazy val compilerInterface = (project in internalPath / "compiler-interface")
     autoScalaLibrary := false,
     altPublishSettings,
     mimaSettings,
+    mimaBinaryIssueFilters ++= {
+      import com.typesafe.tools.mima.core._
+      import com.typesafe.tools.mima.core.ProblemFilters._
+      Seq(
+        exclude[ReversedMissingMethodProblem]("xsbti.compile.ExternalHooks#Lookup.hashClasspath"),
+      )
+    },
   )
   .configure(addSbtUtilInterface)
 

--- a/internal/compiler-bridge/src/main/mima-filters/1.0.0.backwards.excludes
+++ b/internal/compiler-bridge/src/main/mima-filters/1.0.0.backwards.excludes
@@ -1,6 +1,0 @@
-# xsbti Java interfaces must be defined in the compiler interface, not the bridge.
-# Bridge implementations are compiled per Zinc, so these are safe to change.
-ProblemFilters.exclude[MissingClassProblem]("xsbti.InteractiveConsoleFactory")
-ProblemFilters.exclude[MissingClassProblem]("xsbti.InteractiveConsoleResult")
-ProblemFilters.exclude[MissingClassProblem]("xsbti.InteractiveConsoleInterface")
-ProblemFilters.exclude[MissingClassProblem]("xsbti.InteractiveConsoleResponse")

--- a/internal/compiler-interface/src/main/mima-filters/1.0.0.backwards.excludes
+++ b/internal/compiler-interface/src/main/mima-filters/1.0.0.backwards.excludes
@@ -1,1 +1,0 @@
-ProblemFilters.exclude[ReversedMissingMethodProblem]("xsbti.compile.ExternalHooks#Lookup.hashClasspath")

--- a/internal/zinc-compile-core/src/main/mima-filters/1.0.0.backwards.excludes
+++ b/internal/zinc-compile-core/src/main/mima-filters/1.0.0.backwards.excludes
@@ -1,3 +1,0 @@
-# PositionImpl is a private class only invoked in the same source.
-ProblemFilters.exclude[FinalClassProblem]("sbt.internal.inc.javac.DiagnosticsReporter$PositionImpl")
-ProblemFilters.exclude[DirectMissingMethodProblem]("sbt.internal.inc.javac.DiagnosticsReporter#PositionImpl.this")


### PR DESCRIPTION
Remove the file exclude files before (a) compiler-bridge's exclude
file is redundant since we no longer mima-check it, and (b) it interacts
badly with multiple versions.