### PR TITLE
Address #349: Remove unused imports 

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/DelegatingReporter.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/DelegatingReporter.scala
@@ -11,7 +11,6 @@ import java.io.File
 import java.util.Optional
 
 import scala.reflect.internal.util.{ FakePos, NoPosition, Position }
-import Compat._
 
 private object DelegatingReporter {
   def apply(settings: scala.tools.nsc.Settings, delegate: xsbti.Reporter): DelegatingReporter =

--- a/internal/compiler-bridge/src/main/scala/xsbt/DelegatingReporter.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/DelegatingReporter.scala
@@ -11,6 +11,8 @@ import java.io.File
 import java.util.Optional
 
 import scala.reflect.internal.util.{ FakePos, NoPosition, Position }
+// Left for compatibility
+import Compat._
 
 private object DelegatingReporter {
   def apply(settings: scala.tools.nsc.Settings, delegate: xsbti.Reporter): DelegatingReporter =

--- a/internal/compiler-bridge/src/main/scala/xsbt/ExtractUsedNames.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ExtractUsedNames.scala
@@ -12,6 +12,8 @@ import java.util.{ HashSet => JavaSet }
 import java.util.EnumSet
 
 import xsbti.UseScope
+// Left for compatibility
+import Compat._
 
 /**
  * Extracts simple names used in given compilation unit.

--- a/internal/compiler-bridge/src/main/scala/xsbt/ExtractUsedNames.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ExtractUsedNames.scala
@@ -13,8 +13,6 @@ import java.util.EnumSet
 
 import xsbti.UseScope
 
-import Compat._
-
 /**
  * Extracts simple names used in given compilation unit.
  *

--- a/internal/compiler-interface/src/main/java/xsbti/compile/DefaultExternalHooks.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/DefaultExternalHooks.java
@@ -7,9 +7,7 @@
 
 package xsbti.compile;
 
-import java.io.File;
 import java.util.Optional;
-import java.util.Set;
 
 public class DefaultExternalHooks implements ExternalHooks {
     private Optional<ExternalHooks.Lookup> lookup = Optional.empty();

--- a/internal/compiler-interface/src/main/java/xsbti/compile/analysis/ReadSourceInfos.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/analysis/ReadSourceInfos.java
@@ -8,7 +8,6 @@
 package xsbti.compile.analysis;
 
 import java.io.File;
-import java.util.Iterator;
 import java.util.Map;
 
 /**

--- a/internal/zinc-core/src/main/java/xsbti/compile/IncOptionsUtil.java
+++ b/internal/zinc-core/src/main/java/xsbti/compile/IncOptionsUtil.java
@@ -10,7 +10,6 @@ package xsbti.compile;
 import xsbti.Logger;
 
 import java.io.File;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -11,7 +11,6 @@ package inc
 
 import java.io.File
 import java.lang.ref.{ Reference, SoftReference }
-import java.nio.file.Files
 import java.util.Optional
 
 import inc.javac.AnalyzingJavaCompiler


### PR DESCRIPTION
This PR partially addresses https://github.com/sbt/zinc/issues/349

The below 3 warnings are left intentionally for compatibility.

```
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-benchmarks/src/main/scala/xsbt/ZincBenchmark.scala:352:24: Unused import
[warn]   import ZincBenchmark.TryEnrich
[warn]                        ^
```

```
[warn] /home/exoego/IdeaProjects/zinc/internal/compiler-bridge/src/main/scala/xsbt/ExtractUsedNames.scala:16:15: Unused import
[warn] import Compat._
[warn]                        ^
```

```
[warn] /home/exoego/IdeaProjects/zinc/internal/compiler-bridge/src/main/scala/xsbt/DelegatingReporter.scala:15:15: Unused import
[warn] import Compat._
[warn]               ^
```
