### PR TITLE
Address #349: Prefix the classes imported from xsbti with X to prevent name conflict

### DIFF
--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavaCompiler.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavaCompiler.scala
@@ -16,9 +16,9 @@ import java.io.File
 import xsbti.compile.{
   ClasspathOptions,
   ClasspathOptionsUtil,
-  JavaCompiler,
-  JavaTools,
-  Javadoc,
+  JavaCompiler => XJavacompiler,
+  JavaTools => XJavaTools,
+  Javadoc => XJavadoc,
   MultipleOutput,
   Output,
   ScalaInstance,
@@ -29,8 +29,8 @@ import xsbti.compile.{
 object JavaTools {
 
   /** Create a new aggregate tool from existing tools. */
-  def apply(c: JavaCompiler, docgen: Javadoc): JavaTools = {
-    new JavaTools {
+  def apply(c: XJavacompiler, docgen: XJavadoc): XJavaTools = {
+    new XJavaTools {
       override val javac = c
       override val javadoc = docgen
     }
@@ -51,7 +51,7 @@ object JavaTools {
       instance: ScalaInstance,
       options: ClasspathOptions,
       javaHome: Option[File]
-  ): JavaTools = {
+  ): XJavaTools = {
     val (javaCompiler, javaDoc) = javaHome match {
       case Some(_) =>
         (JavaCompiler.fork(javaHome), Javadoc.fork(javaHome))
@@ -68,7 +68,7 @@ object JavaTools {
 object JavaCompiler {
 
   /** Returns a local compiler, if the current runtime supports it. */
-  def local: Option[JavaCompiler] = {
+  def local: Option[XJavacompiler] = {
     Option(javax.tools.ToolProvider.getSystemJavaCompiler).map {
       (compiler: javax.tools.JavaCompiler) =>
         new LocalJavaCompiler(compiler)
@@ -76,7 +76,7 @@ object JavaCompiler {
   }
 
   /** Returns a local compiler that will fork javac when needed. */
-  def fork(javaHome: Option[File] = None): JavaCompiler =
+  def fork(javaHome: Option[File] = None): XJavacompiler =
     new ForkedJavaCompiler(javaHome)
 
   /**
@@ -113,7 +113,7 @@ object JavaCompiler {
 object Javadoc {
 
   /** Returns a local compiler, if the current runtime supports it. */
-  def local: Option[Javadoc] = {
+  def local: Option[XJavadoc] = {
     // TODO - javax doc tool not supported in JDK6
     //Option(javax.tools.ToolProvider.getSystemDocumentationTool)
     if (LocalJava.hasLocalJavadoc) Some(new LocalJavadoc)
@@ -121,6 +121,6 @@ object Javadoc {
   }
 
   /** Returns a local compiler that will fork javac when needed. */
-  def fork(javaHome: Option[File] = None): Javadoc =
+  def fork(javaHome: Option[File] = None): XJavadoc =
     new ForkedJavadoc(javaHome)
 }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Analysis.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Analysis.scala
@@ -14,7 +14,13 @@ import java.io.File
 
 import xsbti.api.{ AnalyzedClass, ExternalDependency, InternalDependency }
 import xsbti.compile.CompileAnalysis
-import xsbti.compile.analysis.{ ReadCompilations, ReadSourceInfos, ReadStamps, SourceInfo, Stamp }
+import xsbti.compile.analysis.{
+  ReadCompilations,
+  ReadSourceInfos,
+  ReadStamps,
+  SourceInfo,
+  Stamp => XStamp
+}
 
 trait Analysis extends CompileAnalysis {
   val stamps: Stamps
@@ -56,13 +62,13 @@ trait Analysis extends CompileAnalysis {
 
   def addSource(src: File,
                 apis: Iterable[AnalyzedClass],
-                stamp: Stamp,
+                stamp: XStamp,
                 info: SourceInfo,
                 nonLocalProducts: Iterable[NonLocalProduct],
                 localProducts: Iterable[LocalProduct],
                 internalDeps: Iterable[InternalDependency],
                 externalDeps: Iterable[ExternalDependency],
-                binaryDeps: Iterable[(File, String, Stamp)]): Analysis
+                binaryDeps: Iterable[(File, String, XStamp)]): Analysis
 
   override lazy val toString = Analysis.summary(this)
 }
@@ -71,8 +77,8 @@ object Analysis {
   case class NonLocalProduct(className: String,
                              binaryClassName: String,
                              classFile: File,
-                             classFileStamp: Stamp)
-  case class LocalProduct(classFile: File, classFileStamp: Stamp)
+                             classFileStamp: XStamp)
+  case class LocalProduct(classFile: File, classFileStamp: XStamp)
   lazy val Empty: Analysis =
     new MAnalysis(Stamps.empty, APIs.empty, Relations.empty, SourceInfos.empty, Compilations.empty)
   def empty: Analysis =
@@ -141,13 +147,13 @@ private class MAnalysis(val stamps: Stamps,
 
   def addSource(src: File,
                 apis: Iterable[AnalyzedClass],
-                stamp: Stamp,
+                stamp: XStamp,
                 info: SourceInfo,
                 nonLocalProducts: Iterable[NonLocalProduct],
                 localProducts: Iterable[LocalProduct],
                 internalDeps: Iterable[InternalDependency],
                 externalDeps: Iterable[ExternalDependency],
-                binaryDeps: Iterable[(File, String, Stamp)]): Analysis = {
+                binaryDeps: Iterable[(File, String, XStamp)]): Analysis = {
 
     val newStamps = {
       val nonLocalProductStamps =

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/AnalysisStore.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/AnalysisStore.scala
@@ -11,11 +11,11 @@ package inc
 
 import java.util.Optional
 
-import xsbti.compile.{ AnalysisContents, AnalysisStore }
+import xsbti.compile.{ AnalysisContents, AnalysisStore => XAnalysisStore }
 
 object AnalysisStore {
-  def cached(backing: AnalysisStore): AnalysisStore = new CachedAnalysisStore(backing)
-  private final class CachedAnalysisStore(backing: AnalysisStore) extends AnalysisStore {
+  def cached(backing: XAnalysisStore): XAnalysisStore = new CachedAnalysisStore(backing)
+  private final class CachedAnalysisStore(backing: XAnalysisStore) extends XAnalysisStore {
     private var lastStore: Optional[AnalysisContents] = Optional.empty()
     override def get(): Optional[AnalysisContents] = {
       if (!lastStore.isPresent())
@@ -29,8 +29,8 @@ object AnalysisStore {
     }
   }
 
-  def sync(backing: AnalysisStore): AnalysisStore = new SyncedAnalysisStore(backing)
-  private final class SyncedAnalysisStore(backing: AnalysisStore) extends AnalysisStore {
+  def sync(backing: XAnalysisStore): XAnalysisStore = new SyncedAnalysisStore(backing)
+  private final class SyncedAnalysisStore(backing: XAnalysisStore) extends XAnalysisStore {
     override def get(): Optional[AnalysisContents] = synchronized {
       backing.get()
     }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Changes.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Changes.scala
@@ -14,7 +14,7 @@ import java.io.File
 import xsbti.UseScope
 import xsbti.api.NameHash
 import xsbti.compile.Changes
-import xsbti.compile.analysis.Stamp
+import xsbti.compile.analysis.{ Stamp => XStamp }
 
 final case class InitialChanges(
     internalSrc: Changes[File],
@@ -107,5 +107,5 @@ abstract class UnderlyingChanges[A] extends Changes[A] {
 
 sealed abstract class Change(val file: File)
 final class Removed(f: File) extends Change(f)
-final class Added(f: File, newStamp: Stamp) extends Change(f)
-final class Modified(f: File, oldStamp: Stamp, newStamp: Stamp) extends Change(f)
+final class Added(f: File, newStamp: XStamp) extends Change(f)
+final class Modified(f: File, oldStamp: XStamp, newStamp: XStamp) extends Change(f)

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/ClassFileManager.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/ClassFileManager.scala
@@ -15,7 +15,7 @@ import java.util.Optional
 
 import collection.mutable
 import xsbti.compile.{
-  ClassFileManager,
+  ClassFileManager => XClassFileManager,
   ClassFileManagerType,
   DeleteImmediatelyManagerType,
   IncOptions,
@@ -24,7 +24,7 @@ import xsbti.compile.{
 
 object ClassFileManager {
   def getDefaultClassFileManager(
-      classFileManagerType: Optional[ClassFileManagerType]): ClassFileManager = {
+      classFileManagerType: Optional[ClassFileManagerType]): XClassFileManager = {
     if (classFileManagerType.isPresent) {
       classFileManagerType.get match {
         case _: DeleteImmediatelyManagerType => new DeleteClassFileManager
@@ -34,7 +34,7 @@ object ClassFileManager {
     } else new DeleteClassFileManager
   }
 
-  def getClassFileManager(options: IncOptions): ClassFileManager = {
+  def getClassFileManager(options: IncOptions): XClassFileManager = {
     import sbt.internal.inc.JavaInterfaceUtil.{ EnrichOptional, EnrichOption }
     val internal = getDefaultClassFileManager(options.classfileManagerType)
     val external = Option(options.externalHooks())
@@ -42,7 +42,7 @@ object ClassFileManager {
     xsbti.compile.WrappedClassFileManager.of(internal, external.toOptional)
   }
 
-  private final class DeleteClassFileManager extends ClassFileManager {
+  private final class DeleteClassFileManager extends XClassFileManager {
     override def delete(classes: Array[File]): Unit =
       IO.deleteFilesEmptyDirs(classes)
     override def generated(classes: Array[File]): Unit = ()
@@ -54,7 +54,7 @@ object ClassFileManager {
    * class files when they are requested. This is the default implementation of the class
    * file manager by the Scala incremental compiler if no class file manager is specified.
    */
-  def deleteImmediately: ClassFileManager = new DeleteClassFileManager
+  def deleteImmediately: XClassFileManager = new DeleteClassFileManager
 
   /**
    * Constructs a transactional [[ClassFileManager]] implementation that restores class
@@ -63,11 +63,11 @@ object ClassFileManager {
    *
    * This is the default class file manager used by sbt, and makes sense in a lot of scenarios.
    */
-  def transactional(tempDir0: File, logger: sbt.util.Logger): ClassFileManager =
+  def transactional(tempDir0: File, logger: sbt.util.Logger): XClassFileManager =
     new TransactionalClassFileManager(tempDir0, logger)
 
   private final class TransactionalClassFileManager(tempDir0: File, logger: sbt.util.Logger)
-      extends ClassFileManager {
+      extends XClassFileManager {
     val tempDir = tempDir0.getCanonicalFile
     IO.delete(tempDir)
     IO.createDirectory(tempDir)

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Compile.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Compile.scala
@@ -12,7 +12,13 @@ package inc
 import sbt.internal.inc.Analysis.{ LocalProduct, NonLocalProduct }
 import xsbt.api.{ APIUtil, HashAPI, NameHashing }
 import xsbti.api._
-import xsbti.compile.{ ClassFileManager, CompileAnalysis, DependencyChanges, IncOptions, Output }
+import xsbti.compile.{
+  ClassFileManager => XClassFileManager,
+  CompileAnalysis,
+  DependencyChanges,
+  IncOptions,
+  Output
+}
 import xsbti.{ Position, Problem, Severity, UseScope }
 import sbt.util.Logger
 import sbt.util.InterfaceUtil.jo2o
@@ -45,7 +51,7 @@ object IncrementalCompile {
   def apply(
       sources: Set[File],
       lookup: Lookup,
-      compile: (Set[File], DependencyChanges, xsbti.AnalysisCallback, ClassFileManager) => Unit,
+      compile: (Set[File], DependencyChanges, xsbti.AnalysisCallback, XClassFileManager) => Unit,
       previous0: CompileAnalysis,
       output: Output,
       log: Logger,

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/FileValueCache.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/FileValueCache.scala
@@ -12,15 +12,15 @@ package inc
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 
-import xsbti.compile.analysis.Stamp
+import xsbti.compile.analysis.{ Stamp => XStamp }
 
 sealed trait FileValueCache[T] {
   def clear(): Unit
   def get: File => T
 }
 
-private[this] final class FileValueCache0[T](getStamp: File => Stamp, make: File => T)(
-    implicit equiv: Equiv[Stamp])
+private[this] final class FileValueCache0[T](getStamp: File => XStamp, make: File => T)(
+    implicit equiv: Equiv[XStamp])
     extends FileValueCache[T] {
   private[this] val backing = new ConcurrentHashMap[File, FileCache]
 
@@ -32,7 +32,7 @@ private[this] final class FileValueCache0[T](getStamp: File => Stamp, make: File
   }
 
   private[this] final class FileCache(file: File) {
-    private[this] var stampedValue: Option[(Stamp, T)] = None
+    private[this] var stampedValue: Option[(XStamp, T)] = None
     def get(): T = synchronized {
       val latest = getStamp(file)
       stampedValue match {
@@ -41,7 +41,7 @@ private[this] final class FileValueCache0[T](getStamp: File => Stamp, make: File
       }
     }
 
-    private[this] def update(stamp: Stamp): T = {
+    private[this] def update(stamp: XStamp): T = {
       val value = make(file)
       stampedValue = Some((stamp, value))
       value
@@ -50,6 +50,6 @@ private[this] final class FileValueCache0[T](getStamp: File => Stamp, make: File
 }
 object FileValueCache {
   def apply[T](f: File => T): FileValueCache[T] = make(Stamper.forLastModified)(f)
-  def make[T](stamp: File => Stamp)(f: File => T): FileValueCache[T] =
+  def make[T](stamp: File => XStamp)(f: File => T): FileValueCache[T] =
     new FileValueCache0[T](stamp, f)
 }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
@@ -12,8 +12,14 @@ package inc
 import java.io.File
 
 import xsbti.api.AnalyzedClass
-import xsbti.compile.{ Changes, ClassFileManager, CompileAnalysis, DependencyChanges, IncOptions }
-import xsbti.compile.analysis.{ ReadStamps, Stamp }
+import xsbti.compile.{
+  Changes,
+  ClassFileManager => XClassFileManager,
+  CompileAnalysis,
+  DependencyChanges,
+  IncOptions
+}
+import xsbti.compile.analysis.{ ReadStamps, Stamp => XStamp }
 
 import scala.annotation.tailrec
 
@@ -36,7 +42,7 @@ private[inc] abstract class IncrementalCommon(val log: sbt.util.Logger, options:
                            lookup: ExternalLookup,
                            previous: Analysis,
                            doCompile: (Set[File], DependencyChanges) => Analysis,
-                           classfileManager: ClassFileManager,
+                           classfileManager: XClassFileManager,
                            cycleNum: Int): Analysis =
     if (invalidatedRaw.isEmpty && modifiedSrcs.isEmpty)
       previous
@@ -101,7 +107,7 @@ private[inc] abstract class IncrementalCommon(val log: sbt.util.Logger, options:
                                      binaryChanges: DependencyChanges,
                                      previous: Analysis,
                                      doCompile: (Set[File], DependencyChanges) => Analysis,
-                                     classfileManager: ClassFileManager): (Analysis, Set[File]) = {
+                                     classfileManager: XClassFileManager): (Analysis, Set[File]) = {
     val invalidatedSources = classes.flatMap(previous.relations.definesClass) ++ modifiedSrcs
     val invalidatedSourcesForCompilation = expand(invalidatedSources, allSources)
     val pruned = Incremental.prune(invalidatedSourcesForCompilation, previous, classfileManager)
@@ -207,7 +213,7 @@ private[inc] abstract class IncrementalCommon(val log: sbt.util.Logger, options:
   def changedInitial(sources: Set[File],
                      previousAnalysis0: CompileAnalysis,
                      current: ReadStamps,
-                     lookup: Lookup)(implicit equivS: Equiv[Stamp]): InitialChanges = {
+                     lookup: Lookup)(implicit equivS: Equiv[XStamp]): InitialChanges = {
     val previousAnalysis = previousAnalysis0 match { case a: Analysis => a }
     val previous = previousAnalysis.stamps
     val previousRelations = previousAnalysis.relations
@@ -421,7 +427,7 @@ private[inc] abstract class IncrementalCommon(val log: sbt.util.Logger, options:
       lookup: Lookup,
       previous: Stamps,
       current: ReadStamps,
-      previousRelations: Relations)(implicit equivS: Equiv[Stamp]): File => Boolean =
+      previousRelations: Relations)(implicit equivS: Equiv[XStamp]): File => Boolean =
     dependsOn => {
       def inv(reason: String): Boolean = {
         log.debug("Invalidating " + dependsOn + ": " + reason)

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Relations.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Relations.scala
@@ -15,7 +15,7 @@ import sbt.internal.util.Relation
 import xsbti.api.{ DependencyContext, ExternalDependency, InternalDependency }
 import xsbti.api.DependencyContext._
 import Relations.ClassDependencies
-import xsbti.compile.analysis.Stamp
+import xsbti.compile.analysis.{ Stamp => XStamp }
 
 /**
  * Provides mappings between source files, generated classes (products), and binaries.
@@ -89,7 +89,7 @@ trait Relations {
       classes: Iterable[(String, String)],
       internalDeps: Iterable[InternalDependency],
       externalDeps: Iterable[ExternalDependency],
-      libraryDeps: Iterable[(File, String, Stamp)]
+      libraryDeps: Iterable[(File, String, XStamp)]
   ): Relations = {
     addProducts(src, products)
       .addClasses(src, classes)
@@ -123,7 +123,7 @@ trait Relations {
   /**
    * Records all the library dependencies `deps` of `src`
    */
-  private[inc] def addLibraryDeps(src: File, deps: Iterable[(File, String, Stamp)]): Relations
+  private[inc] def addLibraryDeps(src: File, deps: Iterable[(File, String, XStamp)]): Relations
 
   private[inc] def addUsedName(className: String, name: UsedName): Relations
 
@@ -584,7 +584,7 @@ private class MRelationsNameHashing(
       productClassName = productClassName
     )
 
-  def addLibraryDeps(src: File, deps: Iterable[(File, String, Stamp)]) =
+  def addLibraryDeps(src: File, deps: Iterable[(File, String, XStamp)]) =
     new MRelationsNameHashing(
       srcProd,
       libraryDep + (src, deps.map(_._1)),

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
@@ -14,7 +14,7 @@ import java.util
 import java.util.Optional
 
 import sbt.io.{ Hash => IOHash, IO }
-import xsbti.compile.analysis.{ ReadStamps, Stamp }
+import xsbti.compile.analysis.{ ReadStamps, Stamp => XStamp }
 
 import scala.collection.immutable.TreeMap
 import scala.util.matching.Regex
@@ -30,12 +30,12 @@ trait Stamps extends ReadStamps {
   def allBinaries: collection.Set[File]
   def allProducts: collection.Set[File]
 
-  def sources: Map[File, Stamp]
-  def binaries: Map[File, Stamp]
-  def products: Map[File, Stamp]
-  def markSource(src: File, s: Stamp): Stamps
-  def markBinary(bin: File, className: String, s: Stamp): Stamps
-  def markProduct(prod: File, s: Stamp): Stamps
+  def sources: Map[File, XStamp]
+  def binaries: Map[File, XStamp]
+  def products: Map[File, XStamp]
+  def markSource(src: File, s: XStamp): Stamps
+  def markBinary(bin: File, className: String, s: XStamp): Stamps
+  def markProduct(prod: File, s: XStamp): Stamps
 
   def filter(prod: File => Boolean, removeSources: Iterable[File], bin: File => Boolean): Stamps
 
@@ -45,12 +45,12 @@ trait Stamps extends ReadStamps {
                  bin: Map[K, File => Boolean]): Map[K, Stamps]
 }
 
-private[sbt] sealed abstract class StampBase extends Stamp {
+private[sbt] sealed abstract class StampBase extends XStamp {
   override def toString: String = this.writeStamp()
   override def hashCode(): Int = this.getValueId()
   override def equals(other: Any): Boolean = other match {
-    case o: Stamp => Stamp.equivStamp.equiv(this, o)
-    case _        => false
+    case o: XStamp => Stamp.equivStamp.equiv(this, o)
+    case _         => false
   }
 }
 
@@ -110,8 +110,8 @@ private[inc] object LastModified extends WithPattern {
 
 object Stamp {
   private final val maxModificationDifferenceInMillis = 100L
-  implicit val equivStamp: Equiv[Stamp] = new Equiv[Stamp] {
-    def equiv(a: Stamp, b: Stamp) = (a, b) match {
+  implicit val equivStamp: Equiv[XStamp] = new Equiv[XStamp] {
+    def equiv(a: XStamp, b: XStamp) = (a, b) match {
       case (h1: Hash, h2: Hash) => h1.hexHash == h2.hexHash
       // Windows is handling this differently sometimes...
       case (lm1: LastModified, lm2: LastModified) =>
@@ -124,7 +124,7 @@ object Stamp {
     }
   }
 
-  def fromString(s: String): Stamp = s match {
+  def fromString(s: String): XStamp = s match {
     case EmptyStamp.Value            => EmptyStamp
     case Hash.FromString(hash)       => hash
     case LastModified.Pattern(value) => new LastModified(java.lang.Long.parseLong(value))
@@ -132,11 +132,11 @@ object Stamp {
       throw new IllegalArgumentException("Unrecognized Stamp string representation: " + s)
   }
 
-  def getStamp(map: Map[File, Stamp], src: File): Stamp = map.getOrElse(src, EmptyStamp)
+  def getStamp(map: Map[File, XStamp], src: File): XStamp = map.getOrElse(src, EmptyStamp)
 }
 
 object Stamper {
-  private def tryStamp(g: => Stamp): Stamp = {
+  private def tryStamp(g: => XStamp): XStamp = {
     try { g } // TODO: Double check correctness. Why should we not report an exception here?
     catch { case _: IOException => EmptyStamp }
   }
@@ -154,35 +154,35 @@ object Stamps {
    * stamp is calculated separately on demand.
    * The stamp for a product is always recalculated.
    */
-  def initial(prodStamp: File => Stamp,
-              srcStamp: File => Stamp,
-              binStamp: File => Stamp): ReadStamps =
+  def initial(prodStamp: File => XStamp,
+              srcStamp: File => XStamp,
+              binStamp: File => XStamp): ReadStamps =
     new InitialStamps(prodStamp, srcStamp, binStamp)
 
   def empty: Stamps = {
     // Use a TreeMap to avoid sorting when serializing
-    val eSt = TreeMap.empty[File, Stamp]
+    val eSt = TreeMap.empty[File, XStamp]
     apply(eSt, eSt, eSt)
   }
-  def apply(products: Map[File, Stamp],
-            sources: Map[File, Stamp],
-            binaries: Map[File, Stamp]): Stamps =
+  def apply(products: Map[File, XStamp],
+            sources: Map[File, XStamp],
+            binaries: Map[File, XStamp]): Stamps =
     new MStamps(products, sources, binaries)
 
   def merge(stamps: Traversable[Stamps]): Stamps = (Stamps.empty /: stamps)(_ ++ _)
 }
 
-private class MStamps(val products: Map[File, Stamp],
-                      val sources: Map[File, Stamp],
-                      val binaries: Map[File, Stamp])
+private class MStamps(val products: Map[File, XStamp],
+                      val sources: Map[File, XStamp],
+                      val binaries: Map[File, XStamp])
     extends Stamps {
 
   import scala.collection.JavaConverters.mapAsJavaMapConverter
-  override def getAllBinaryStamps: util.Map[File, Stamp] =
+  override def getAllBinaryStamps: util.Map[File, XStamp] =
     mapAsJavaMapConverter(binaries).asJava
-  override def getAllProductStamps: util.Map[File, Stamp] =
+  override def getAllProductStamps: util.Map[File, XStamp] =
     mapAsJavaMapConverter(products).asJava
-  override def getAllSourceStamps: util.Map[File, Stamp] =
+  override def getAllSourceStamps: util.Map[File, XStamp] =
     mapAsJavaMapConverter(sources).asJava
 
   def allSources: collection.Set[File] = sources.keySet
@@ -192,13 +192,13 @@ private class MStamps(val products: Map[File, Stamp],
   def ++(o: Stamps): Stamps =
     new MStamps(products ++ o.products, sources ++ o.sources, binaries ++ o.binaries)
 
-  def markSource(src: File, s: Stamp): Stamps =
+  def markSource(src: File, s: XStamp): Stamps =
     new MStamps(products, sources.updated(src, s), binaries)
 
-  def markBinary(bin: File, className: String, s: Stamp): Stamps =
+  def markBinary(bin: File, className: String, s: XStamp): Stamps =
     new MStamps(products, sources, binaries.updated(bin, s))
 
-  def markProduct(prod: File, s: Stamp): Stamps =
+  def markProduct(prod: File, s: XStamp): Stamps =
     new MStamps(products.updated(prod, s), sources, binaries)
 
   def filter(prod: File => Boolean, removeSources: Iterable[File], bin: File => Boolean): Stamps =
@@ -207,12 +207,12 @@ private class MStamps(val products: Map[File, Stamp],
   def groupBy[K](prod: Map[K, File => Boolean],
                  f: File => K,
                  bin: Map[K, File => Boolean]): Map[K, Stamps] = {
-    val sourcesMap: Map[K, Map[File, Stamp]] = sources.groupBy(x => f(x._1))
+    val sourcesMap: Map[K, Map[File, XStamp]] = sources.groupBy(x => f(x._1))
 
     val constFalse = (f: File) => false
     def kStamps(k: K): Stamps = new MStamps(
       products.filterKeys(prod.getOrElse(k, constFalse)),
-      sourcesMap.getOrElse(k, Map.empty[File, Stamp]),
+      sourcesMap.getOrElse(k, Map.empty[File, XStamp]),
       binaries.filterKeys(bin.getOrElse(k, constFalse))
     )
 
@@ -236,25 +236,25 @@ private class MStamps(val products: Map[File, Stamp],
                                                               binaries.size)
 }
 
-private class InitialStamps(prodStamp: File => Stamp,
-                            srcStamp: File => Stamp,
-                            binStamp: File => Stamp)
+private class InitialStamps(prodStamp: File => XStamp,
+                            srcStamp: File => XStamp,
+                            binStamp: File => XStamp)
     extends ReadStamps {
   import collection.mutable.{ HashMap, Map }
   // cached stamps for files that do not change during compilation
-  private val sources: Map[File, Stamp] = new HashMap
-  private val binaries: Map[File, Stamp] = new HashMap
+  private val sources: Map[File, XStamp] = new HashMap
+  private val binaries: Map[File, XStamp] = new HashMap
 
   import scala.collection.JavaConverters.mapAsJavaMapConverter
-  override def getAllBinaryStamps: util.Map[File, Stamp] =
+  override def getAllBinaryStamps: util.Map[File, XStamp] =
     mapAsJavaMapConverter(binaries).asJava
-  override def getAllSourceStamps: util.Map[File, Stamp] =
+  override def getAllSourceStamps: util.Map[File, XStamp] =
     mapAsJavaMapConverter(sources).asJava
-  override def getAllProductStamps: util.Map[File, Stamp] = new util.HashMap()
+  override def getAllProductStamps: util.Map[File, XStamp] = new util.HashMap()
 
-  override def product(prod: File): Stamp = prodStamp(prod)
-  override def source(src: File): Stamp =
+  override def product(prod: File): XStamp = prodStamp(prod)
+  override def source(src: File): XStamp =
     synchronized { sources.getOrElseUpdate(src, srcStamp(src)) }
-  override def binary(bin: File): Stamp =
+  override def binary(bin: File): XStamp =
     synchronized { binaries.getOrElseUpdate(bin, binStamp(bin)) }
 }

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/FileAnalysisStore.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/FileAnalysisStore.scala
@@ -19,7 +19,7 @@ import sbt.internal.inc.text.TextAnalysisFormat
 import sbt.io.{ IO, Using }
 import xsbti.api.Companions
 import xsbti.compile.analysis.ReadWriteMappers
-import xsbti.compile.{ AnalysisContents, AnalysisStore }
+import xsbti.compile.{ AnalysisContents, AnalysisStore => XAnalysisStore }
 
 import scala.util.control.Exception.allCatch
 
@@ -28,20 +28,20 @@ object FileAnalysisStore {
   private final val analysisFileName = s"inc_compile.$BinExtension"
   private final val companionsFileName = s"api_companions.$BinExtension"
 
-  def binary(analysisFile: File): AnalysisStore =
+  def binary(analysisFile: File): XAnalysisStore =
     new BinaryFileStore(analysisFile, ReadWriteMappers.getEmptyMappers())
-  def binary(analysisFile: File, mappers: ReadWriteMappers): AnalysisStore =
+  def binary(analysisFile: File, mappers: ReadWriteMappers): XAnalysisStore =
     new BinaryFileStore(analysisFile, mappers)
 
-  def text(file: File): AnalysisStore =
+  def text(file: File): XAnalysisStore =
     new FileBasedStoreImpl(file, TextAnalysisFormat)
-  def text(file: File, mappers: ReadWriteMappers): AnalysisStore =
+  def text(file: File, mappers: ReadWriteMappers): XAnalysisStore =
     new FileBasedStoreImpl(file, new TextAnalysisFormat(mappers))
-  def text(file: File, format: TextAnalysisFormat): AnalysisStore =
+  def text(file: File, format: TextAnalysisFormat): XAnalysisStore =
     new FileBasedStoreImpl(file, format)
 
   private final class BinaryFileStore(file: File, readWriteMappers: ReadWriteMappers)
-      extends AnalysisStore {
+      extends XAnalysisStore {
 
     private final val format = new BinaryAnalysisFormat(readWriteMappers)
     private final val TmpEnding = ".tmp"
@@ -97,7 +97,7 @@ object FileAnalysisStore {
   }
 
   private final class FileBasedStoreImpl(file: File, format: TextAnalysisFormat)
-      extends AnalysisStore {
+      extends XAnalysisStore {
     val companionsStore = new FileBasedCompanionsMapStore(file, format)
 
     def set(analysisContents: AnalysisContents): Unit = {

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -22,7 +22,7 @@ import sbt.io.IO
 import sbt.util.{ InterfaceUtil, Logger }
 import sbt.internal.inc.JavaInterfaceUtil.EnrichOption
 import sbt.internal.inc.caching.ClasspathCache
-import xsbti.compile.ClassFileManager
+import xsbti.compile.{ ClassFileManager => XClassFileManager }
 
 /** An instance of an analyzing compiler that can run both javac + scalac. */
 final class MixedAnalyzingCompiler(
@@ -53,7 +53,7 @@ final class MixedAnalyzingCompiler(
       include: Set[File],
       changes: DependencyChanges,
       callback: XAnalysisCallback,
-      classfileManager: ClassFileManager
+      classfileManager: XClassFileManager
   ): Unit = {
     val outputDirs = outputDirectories(output)
     outputDirs.foreach { d =>


### PR DESCRIPTION
This PR partially addresses https://github.com/sbt/zinc/issues/349 by resolving ```imported `Foo` is is permanently hidden by definition of object Foo in package bar``` warnings such as

> [warn] /home/exoego/IdeaProjects/zinc/internal/zinc-core/src/main/scala/sbt/internal/inc/AnalysisStore.scala:14:42: imported `AnalysisStore' is permanently hidden by definition of object AnalysisStore in package inc
> [warn] import xsbti.compile.{ AnalysisContents, AnalysisStore }