### PR TITLE
Fix copy/pasto in definition of IncOptions

### DIFF
--- a/internal/compiler-interface/src/main/contraband/incremental.json
+++ b/internal/compiler-interface/src/main/contraband/incremental.json
@@ -110,7 +110,7 @@
         {
           "name": "useCustomizedFileManager",
           "type": "boolean",
-          "default": "xsbti.compile.IncOptions.defaultUseOptimizedSealed()",
+          "default": "xsbti.compile.IncOptions.defaultUseCustomizedFileManager()",
           "doc": [
             "Option to turn on customized file manager that tracks generated class files for transactional rollbacks.",
             "Using customized file manager may conflict with some libraries, this option allows user to decide",


### PR DESCRIPTION
The wrong default value was being used, but the bug was benign because
that was also just `false`
