### PR TITLE
Address #349: Partially resolve deprecated warnings

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
@@ -163,7 +163,7 @@ sealed class ZincCompiler(settings: Settings, dreporter: DelegatingReporter, out
   }
 }
 
-import scala.tools.nsc.interactive.RangePositions
+import scala.reflect.internal.Positions
 final class ZincCompilerRangePos(settings: Settings, dreporter: DelegatingReporter, output: Output)
     extends ZincCompiler(settings, dreporter, output)
-    with RangePositions
+    with Positions

--- a/internal/compiler-bridge/src/main/scala_2.11-12/xsbt/ConsoleInterface.scala
+++ b/internal/compiler-bridge/src/main/scala_2.11-12/xsbt/ConsoleInterface.scala
@@ -49,7 +49,6 @@ class ConsoleInterface {
             override protected def newCompiler(settings: Settings, reporter: Reporter) =
               super.newCompiler(compilerSettings, reporter)
           }
-          intp.setContextClassLoader()
         } else
           super.createInterpreter()
 

--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaders.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaders.scala
@@ -92,10 +92,9 @@ final class ClasspathFilter(parent: ClassLoader, root: ClassLoader, classpath: S
   }
 
   override def getResources(name: String): java.util.Enumeration[URL] = {
-    import collection.convert.WrapAsScala.{ enumerationAsScalaIterator => asIt }
-    import collection.convert.WrapAsJava.{ asJavaEnumeration => asEn }
+    import scala.collection.JavaConverters._
     val us = super.getResources(name)
-    if (us ne null) asEn(asIt(us).filter(onClasspath)) else null
+    if (us ne null) us.asScala.filter(onClasspath).asJavaEnumeration else null
   }
 
   @tailrec private[this] def includeLoader(c: ClassLoader, base: ClassLoader): Boolean =

--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClasspathUtilities.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClasspathUtilities.scala
@@ -111,9 +111,9 @@ object ClasspathUtilities {
 
   /** Returns all entries in 'classpath' that correspond to a compiler plugin.*/
   private[sbt] def compilerPlugins(classpath: Seq[File]): Iterable[File] = {
-    import collection.JavaConversions._
+    import scala.collection.JavaConverters._
     val loader = new URLClassLoader(Path.toURLs(classpath))
-    loader.getResources("scalac-plugin.xml").toList.flatMap(asFile(true))
+    loader.getResources("scalac-plugin.xml").asScala.flatMap(asFile(true)).toIterable
   }
 
   /** Converts the given URL to a File.  If the URL is for an entry in a jar, the File for the jar is returned. */

--- a/zinc-compile/src/main/scala/sbt/inc/Doc.scala
+++ b/zinc-compile/src/main/scala/sbt/inc/Doc.scala
@@ -27,7 +27,6 @@ import sbt.util.CacheImplicits._
 import sbt.util.FileInfo.{ exists, hash, lastModified }
 import exists._
 import sjsonnew._
-import LList.:*:
 import xsbti.Reporter
 
 object Doc {


### PR DESCRIPTION
This PR address https://github.com/sbt/zinc/issues/349 by partially resolving `deprecated` warnings.

The deprecated codes are simply removed or rewriten, in accordance with the instruction in deprecation warning.



# Before (3c12aba4193b28fd16767c28a1cf8a1c3bbf91b8)

## Total

```sh
$ sbt -warn ";clean;compile" | grep "deprecated" | wc -l
15
```

```sh
$ sbt -warn ";clean;compile" | grep "deprecated"        
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaders.scala:98:21: object WrapAsJava in package convert is deprecated (since 2.12.0): use JavaConverters or consider ImplicitConversionsToJava
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaders.scala:98:26: object WrapAsScala in package convert is deprecated (since 2.12.0): use JavaConverters or consider ImplicitConversionsToScala
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClasspathUtilities.scala:116:24: object JavaConversions in package collection is deprecated (since 2.12.0): use JavaConverters
[warn] /home/exoego/IdeaProjects/zinc/internal/compiler-bridge/src/main/scala/xsbt/API.scala:82:12: method isImplClass in class Symbol is deprecated (since 2.12.0): trait implementation classes have been removed in Scala 2.12
[warn] /home/exoego/IdeaProjects/zinc/internal/compiler-bridge/src/main/scala/xsbt/Analyzer.scala:51:41: method isImplClass in class Symbol is deprecated (since 2.12.0): trait implementation classes have been removed in Scala 2.12
[warn] /home/exoego/IdeaProjects/zinc/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala:169:10: trait RangePositions in package interactive is deprecated (since 2.11.0): Use scala.reflect.internal.Positions
[warn] /home/exoego/IdeaProjects/zinc/internal/compiler-bridge/src/main/scala/xsbt/ClassName.scala:94:33: method isImplClass in class Symbol is deprecated (since 2.12.0): trait implementation classes have been removed in Scala 2.12
[warn] /home/exoego/IdeaProjects/zinc/internal/compiler-bridge/src/main/scala_2.11-12/xsbt/ConsoleInterface.scala:52:16: method setContextClassLoader in class IMain is deprecated (since 2.12.0): The thread context classloader is now set and restored around execution of REPL line, this method is now a no-op.
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala:347:56: method libraryJar in trait ScalaInstance is deprecated: see corresponding Javadoc for more information.
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala:72:67: method compilerJar in trait ScalaInstance is deprecated: see corresponding Javadoc for more information.
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala:73:65: method otherJars in trait ScalaInstance is deprecated: see corresponding Javadoc for more information.
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala:98:37: method libraryJar in trait ScalaInstance is deprecated: see corresponding Javadoc for more information.
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala:141:27: method libraryJar in trait ScalaInstance is deprecated: see corresponding Javadoc for more information.
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavaCompiler.scala:105:43: method libraryJar in trait ScalaInstance is deprecated: see corresponding Javadoc for more information.
[warn] /home/exoego/IdeaProjects/zinc/zinc-compile/src/main/scala/sbt/inc/Doc.scala:37:19: type :*: in object LList is deprecated (since 0.8.0): Switch to the type alias in the sjsonnew root package
```

# This PR
```bash
$ sbt -warn ";clean;compile" | grep "deprecated" | wc -l
9
```

```bash
$ sbt -warn ";clean;compile" | grep "deprecated"
[warn] /home/exoego/IdeaProjects/zinc/internal/compiler-bridge/src/main/scala/xsbt/API.scala:82:12: method isImplClass in class Symbol is deprecated (since 2.12.0): trait implementation classes have been removed in Scala 2.12
[warn] /home/exoego/IdeaProjects/zinc/internal/compiler-bridge/src/main/scala/xsbt/Analyzer.scala:51:41: method isImplClass in class Symbol is deprecated (since 2.12.0): trait implementation classes have been removed in Scala 2.12
[warn] /home/exoego/IdeaProjects/zinc/internal/compiler-bridge/src/main/scala/xsbt/ClassName.scala:94:33: method isImplClass in class Symbol is deprecated (since 2.12.0): trait implementation classes have been removed in Scala 2.12
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala:347:56: method libraryJar in trait ScalaInstance is deprecated: see corresponding Javadoc for more information.
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala:72:67: method compilerJar in trait ScalaInstance is deprecated: see corresponding Javadoc for more information.
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala:73:65: method otherJars in trait ScalaInstance is deprecated: see corresponding Javadoc for more information.
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala:98:37: method libraryJar in trait ScalaInstance is deprecated: see corresponding Javadoc for more information.
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala:141:27: method libraryJar in trait ScalaInstance is deprecated: see corresponding Javadoc for more information.
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavaCompiler.scala:105:43: method libraryJar in trait ScalaInstance is deprecated: see corresponding Javadoc for more information.
```

The above 9 `deprecated` warnings are kept.

* `Symbol.isImplClass` is needed for Scala 2.11.
* How to migrate some members of `ScalaInstance` is not clear for me.

Maybe those should be addressed as a legit issue?