### PR TITLE
Fix javaOptions in benchmark project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -254,7 +254,7 @@ lazy val zincBenchmarks = (project in internalPath / "zinc-benchmarks")
     ),
     scalaVersion := scala212,
     crossScalaVersions := Seq(scala211, scala212),
-    javaOptions in Test += "-Xmx600M -Xms600M",
+    javaOptions in Test += List("-Xmx600M", "-Xms600M"),
   )
 
 lazy val zincIvyIntegration = (project in internalPath / "zinc-ivy-integration")

--- a/build.sbt
+++ b/build.sbt
@@ -254,7 +254,7 @@ lazy val zincBenchmarks = (project in internalPath / "zinc-benchmarks")
     ),
     scalaVersion := scala212,
     crossScalaVersions := Seq(scala211, scala212),
-    javaOptions in Test += List("-Xmx600M", "-Xms600M"),
+    javaOptions in Test ++= List("-Xmx600M", "-Xms600M"),
   )
 
 lazy val zincIvyIntegration = (project in internalPath / "zinc-ivy-integration")


### PR DESCRIPTION
To prevent:

```
sbt:zinc Root> zincBenchmarks/jmh:run -vEXTRA
Waiting for lock on /Users/jz/.ivy2/.sbt.ivy.lock to be available...
[info] Packaging /Users/jz/code/sbt-all/zinc/internal/zinc-testing/target/scala-2.12/zinc-testing_2.12-1.1.1.jar ...
[info] Done packaging.
[info] Packaging /Users/jz/code/sbt-all/zinc/internal/zinc-benchmarks/target/scala-2.12/benchmarks-of-zinc-and-the-compiler-bridge_2.12-1.1.1-tests.jar ...
[info] Done packaging.
Processing 41 classes from /Users/jz/code/sbt-all/zinc/internal/zinc-benchmarks/target/scala-2.12/classes with "reflection" generator
Writing out Java source to /Users/jz/code/sbt-all/zinc/internal/zinc-benchmarks/target/scala-2.12/src_managed/jmh and resources to /Users/jz/code/sbt-all/zinc/internal/zinc-benchmarks/target/scala-2.12/resource_managed/jmh
[info] Packaging /Users/jz/code/sbt-all/zinc/internal/zinc-benchmarks/target/scala-2.12/benchmarks-of-zinc-and-the-compiler-bridge_2.12-1.1.1-jmh.jar ...
[info] Done packaging.
[info] Running (fork) org.openjdk.jmh.Main -vEXTRA
[error] Invalid maximum heap size: -Xmx600M -Xms600M
```