### PR TITLE
Set Scala's compiler interface version to 2.12

### DIFF
--- a/bin/run-ci.sh
+++ b/bin/run-ci.sh
@@ -3,7 +3,6 @@ set -eu
 set -o nounset
 SCALA_VERSION="$1"
 
-
 sbt -Dfile.encoding=UTF-8 \
   -J-XX:ReservedCodeCacheSize=256M \
   -J-Xmx3046M -J-Xms3046M -J-server \
@@ -11,6 +10,7 @@ sbt -Dfile.encoding=UTF-8 \
   scalafmt::test \
   test:scalafmt::test \
   whitesourceCheckPolicies \
+  compilerBridgeJava6Compat/compile \
   zincRoot/test:compile \
   crossTestBridges \
   "publishBridgesAndSet $SCALA_VERSION" \

--- a/build.sbt
+++ b/build.sbt
@@ -307,11 +307,8 @@ lazy val compilerInterface = (project in internalPath / "compiler-interface")
     minimalSettings,
     // javaOnlySettings,
     name := "Compiler Interface",
-    // Use the smallest Scala version in the compilerBridgeScalaVersions
-    // Technically the scalaVersion shouldn't have any effect since scala library is not included,
-    // but given that Scala 2.10 compiler cannot parse Java 8 source, it's probably good to keep this.
-    crossScalaVersions := Seq(scala210),
-    scalaVersion := scala210,
+    scalaVersion := scala212,
+    crossScalaVersions := Seq(scala212),
     relaxNon212,
     libraryDependencies ++= Seq(scalaLibrary.value % Test),
     exportJars := true,
@@ -341,6 +338,17 @@ lazy val compilerInterface = (project in internalPath / "compiler-interface")
     },
   )
   .configure(addSbtUtilInterface)
+
+/* Create a duplicated compiler-interface project that uses Scala 2.10 to parse Java files.
+ * Scala 2.10's parser uses Java 6 semantics, so this way we ensure that the interface can
+ * be compiled with Java 6 too. `compiler-interface` checks compilation for Java 8. */
+val compilerInterfaceJava6Compat = compilerInterface
+  .withId("compilerInterfaceJava6Compat")
+  .settings(
+    scalaVersion := scala210,
+    crossScalaVersions := Seq(scala210),
+    target := (target in compilerInterface).value / "java6-parser-compat"
+  )
 
 val cleanSbtBridge = taskKey[Unit]("Cleans the sbt bridge.")
 

--- a/build.sbt
+++ b/build.sbt
@@ -347,7 +347,8 @@ val compilerInterfaceJava6Compat = compilerInterface
   .settings(
     scalaVersion := scala210,
     crossScalaVersions := Seq(scala210),
-    target := (target in compilerInterface).value / "java6-parser-compat"
+    target := (target in compilerInterface).value / "java6-parser-compat",
+    skip in publish := true
   )
 
 val cleanSbtBridge = taskKey[Unit]("Cleans the sbt bridge.")


### PR DESCRIPTION
Fixes https://github.com/sbt/zinc/issues/495.

Trivial fix was:

```
diff --git a/build.sbt b/build.sbt
index bb93aab99..56e518d5f 100644
--- a/build.sbt
+++ b/build.sbt
@@ -310,8 +310,8 @@ lazy val compilerInterface = (project in internalPath / "compiler-interface")
    // Use the smallest Scala version in the compilerBridgeScalaVersions
    // Technically the scalaVersion shouldn't have any effect since scala library is not included,
    // but given that Scala 2.10 compiler cannot parse Java 8 source, it's probably good to keep this.
-    crossScalaVersions := Seq(scala210),
-    scalaVersion := scala210,
+    crossScalaVersions := Seq(scala212),
+    scalaVersion := scala212,
    relaxNon212,
    libraryDependencies ++= Seq(scalaLibrary.value % Test),
    exportJars := true,
```

but that would publish the bridge three times when releasing and cause
an error.