### PR TITLE
Allow benchmark to disable zinc's APIExtract and Dependency phases

### DIFF
--- a/internal/zinc-benchmarks/src/main/scala/xsbt/BenchmarkBase.scala
+++ b/internal/zinc-benchmarks/src/main/scala/xsbt/BenchmarkBase.scala
@@ -19,6 +19,8 @@ class BenchmarkBase {
   @Param(Array("")) var _tempDir: String = _
   var _project: BenchmarkProject = _
   var _subprojectToRun: String = _
+  @Param(Array("true"))
+  var zincEnabled: Boolean = _
 
   /* Data filled in by the benchmark setup. */
   var _dir: File = _
@@ -39,7 +41,7 @@ class BenchmarkBase {
     _dir = new File(_tempDir)
     assert(_dir.exists(), s"Unexpected inexistent directory ${_tempDir}")
 
-    val compiler = new ZincBenchmark(_project)
+    val compiler = new ZincBenchmark(_project, zincEnabled = this.zincEnabled)
     _subprojectsSetup = compiler.readSetup(_dir).getOrCrash
     assert(_subprojectsSetup.nonEmpty)
 

--- a/internal/zinc-benchmarks/src/main/scala/xsbt/ZincBenchmark.scala
+++ b/internal/zinc-benchmarks/src/main/scala/xsbt/ZincBenchmark.scala
@@ -14,7 +14,7 @@ import sbt.internal.util.ConsoleLogger
 import sbt.io.{ IO, RichFile }
 import xsbt.ZincBenchmark.CompilationInfo
 import xsbti._
-import xsbti.compile.SingleOutput
+import xsbti.compile.{ IncOptions, SingleOutput }
 
 import scala.util.Try
 
@@ -49,7 +49,7 @@ case class ZincSetup(result: ZincBenchmark.Result[List[ProjectSetup]]) {
 /* Classes are defined `private[xsbt]` to avoid scoping issues w/ `CachedCompiler0`. */
 
 /** Instantiate a `ZincBenchmark` from a given project. */
-private[xsbt] class ZincBenchmark(toCompile: BenchmarkProject) {
+private[xsbt] class ZincBenchmark(toCompile: BenchmarkProject, zincEnabled: Boolean = true) {
   import ZincBenchmark.WriteBuildInfo
 
   def writeSetup(globalDir: File): WriteBuildInfo = {
@@ -74,7 +74,7 @@ private[xsbt] class ZincBenchmark(toCompile: BenchmarkProject) {
 
       // Set up the compiler and store the current setup
       val javaFile = new RichFile(compilationDir) / "benchmark-target"
-      val runGen = ZincBenchmark.setUpCompiler(buildInfo, javaFile)
+      val runGen = ZincBenchmark.setUpCompiler(buildInfo, javaFile, zincEnabled)
       ProjectSetup(subproject, javaFile, buildInfo, runGen)
     }
 
@@ -108,11 +108,14 @@ private[xsbt] object ZincBenchmark {
   /** Set up the compiler to compile `sources` with -cp `classpath` at `targetDir`. */
   def setUpCompiler(
       compilationInfo: CompilationInfo,
-      targetDir: File
+      targetDir: File,
+      zincEnabled: Boolean
   ): Generator = () => {
     IO.delete(targetDir)
     IO.createDirectory(targetDir)
-    val callback = new xsbti.TestCallback
+    val callback: xsbti.TestCallback = new xsbti.TestCallback {
+      override def enabled: Boolean = zincEnabled
+    }
     val compiler = prepareCompiler(targetDir, callback, compilationInfo)
     new compiler.Run
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("org.scala-sbt" % "sbt-houserules" % "0.3.5")
 addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.3.2")
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.27")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.3")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "3.0.2")
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.12-rc5")
 libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin" % "0.6.0"


### PR DESCRIPTION
The scala-library corpus is known to be a tough one for Zinc, perhaps due to the inheritance
heirarchy of the collections. These results confirm that enabling zinc increases compilation
time by 1.4x for the full clean build.

```
sbt:zinc Root> zincBenchmarks/jmh:run -p _tempDir=/tmp/zinc-bench-baseline HotScalacBenchmark  -penableZinc=false,true -wi 10 -i 6 -f1

[info] Benchmark                                                 (_tempDir)  (zincEnabled)    Mode  Cnt      Score      Error  Units
[info] HotScalacBenchmark.compile                  /tmp/zinc-bench-baseline          false  sample    6  10463.390 ±  128.555  ms/op
[info] HotScalacBenchmark.compile:compile·p0.00    /tmp/zinc-bench-baseline          false  sample       10401.874             ms/op
[info] HotScalacBenchmark.compile:compile·p0.50    /tmp/zinc-bench-baseline          false  sample       10468.983             ms/op
[info] HotScalacBenchmark.compile:compile·p0.90    /tmp/zinc-bench-baseline          false  sample       10519.314             ms/op
[info] HotScalacBenchmark.compile:compile·p0.95    /tmp/zinc-bench-baseline          false  sample       10519.314             ms/op
[info] HotScalacBenchmark.compile:compile·p0.99    /tmp/zinc-bench-baseline          false  sample       10519.314             ms/op
[info] HotScalacBenchmark.compile:compile·p0.999   /tmp/zinc-bench-baseline          false  sample       10519.314             ms/op
[info] HotScalacBenchmark.compile:compile·p0.9999  /tmp/zinc-bench-baseline          false  sample       10519.314             ms/op
[info] HotScalacBenchmark.compile:compile·p1.00    /tmp/zinc-bench-baseline          false  sample       10519.314             ms/op
[info] HotScalacBenchmark.compile                  /tmp/zinc-bench-baseline           true  sample    6  14610.159 ± 1392.898  ms/op
[info] HotScalacBenchmark.compile:compile·p0.00    /tmp/zinc-bench-baseline           true  sample       14042.530             ms/op
[info] HotScalacBenchmark.compile:compile·p0.50    /tmp/zinc-bench-baseline           true  sample       14554.235             ms/op
[info] HotScalacBenchmark.compile:compile·p0.90    /tmp/zinc-bench-baseline           true  sample       15435.039             ms/op
[info] HotScalacBenchmark.compile:compile·p0.95    /tmp/zinc-bench-baseline           true  sample       15435.039             ms/op
[info] HotScalacBenchmark.compile:compile·p0.99    /tmp/zinc-bench-baseline           true  sample       15435.039             ms/op
[info] HotScalacBenchmark.compile:compile·p0.999   /tmp/zinc-bench-baseline           true  sample       15435.039             ms/op
[info] HotScalacBenchmark.compile:compile·p0.9999  /tmp/zinc-bench-baseline           true  sample       15435.039             ms/op
[info] HotScalacBenchmark.compile:compile·p1.00    /tmp/zinc-bench-baseline           true  sample       15435.039             ms/op
```