### PR TITLE
Address #349: Resolve misc warnings

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/JavaUtils.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/JavaUtils.scala
@@ -11,7 +11,7 @@ private[xsbt] object JavaUtils {
   implicit class JavaForEach[T](val iterable: java.lang.Iterable[T]) extends AnyVal {
 
     @inline
-    def foreach(op: T => Unit): Unit = {
+    def foreach[U](op: T => U): Unit = {
       val iterator = iterable.iterator()
       while (iterator.hasNext) op(iterator.next())
     }
@@ -20,7 +20,7 @@ private[xsbt] object JavaUtils {
   implicit class JavaMapForEach[K, V](val map: java.util.Map[K, V]) extends AnyVal {
 
     @inline
-    def foreach(op: (K, V) => Unit): Unit = {
+    def foreach[U](op: (K, V) => U): Unit = {
       val iterator = map.keySet().iterator()
       while (iterator.hasNext) {
         val key = iterator.next()

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavacProcessLogger.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavacProcessLogger.scala
@@ -31,10 +31,16 @@ final class JavacLogger(log: sbt.util.Logger, reporter: Reporter, cwd: File) ext
   private var err: ListBuffer[String] = new ListBuffer()
 
   def out(s: => String): Unit =
-    synchronized { out += s }
+    synchronized {
+      out += s
+      ()
+    }
 
   def err(s: => String): Unit =
-    synchronized { err += s }
+    synchronized {
+      err += s
+      ()
+    }
 
   def buffer[T](f: => T): T = f
 

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/APIDiff.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/APIDiff.scala
@@ -76,15 +76,19 @@ private[inc] class APIDiff {
       if (str == "") {
         acc.reverse
       } else {
-        val head = str.charAt(0)
+        val head = str.charAt(0).toInt
         val (token, rest) = if (Character.isAlphabetic(head) || Character.isDigit(head)) {
-          str.span(c => Character.isAlphabetic(c) || Character.isDigit(c))
+          str.span { c =>
+            val i = c.toInt
+            Character.isAlphabetic(i) || Character.isDigit(i)
+          }
         } else if (Character.isMirrored(head) || Character.isWhitespace(head)) {
           str.splitAt(1)
         } else {
           str.span { c =>
-            !Character.isAlphabetic(c) && !Character.isDigit(c) &&
-            !Character.isMirrored(c) && !Character.isWhitespace(c)
+            val i = c.toInt
+            !Character.isAlphabetic(i) && !Character.isDigit(i) &&
+            !Character.isMirrored(i) && !Character.isWhitespace(i)
           }
         }
         splitTokens(rest, token :: acc)

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/APIDiff.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/APIDiff.scala
@@ -156,10 +156,10 @@ private[inc] class APIDiff {
     }
 
     private sealed trait Patch
-    private final case class Unmodified(str: String) extends Patch
-    private final case class Modified(original: String, str: String) extends Patch
-    private final case class Deleted(str: String) extends Patch
-    private final case class Inserted(str: String) extends Patch
+    private case class Unmodified(str: String) extends Patch
+    private case class Modified(original: String, str: String) extends Patch
+    private case class Deleted(str: String) extends Patch
+    private case class Inserted(str: String) extends Patch
 
     private def hirschberg(a: Array[String], b: Array[String]): Array[Patch] = {
       def build(x: Array[String], y: Array[String], builder: mutable.ArrayBuilder[Patch]): Unit = {

--- a/internal/zinc-ivy-integration/src/main/scala/sbt/internal/inc/ZincComponentCompiler.scala
+++ b/internal/zinc-ivy-integration/src/main/scala/sbt/internal/inc/ZincComponentCompiler.scala
@@ -91,7 +91,7 @@ private[sbt] object ZincComponentCompiler {
       compiledBridge(bridgeSources, scalaInstance, logger)
     }
 
-    private final case class ScalaArtifacts(compiler: File, library: File, others: Vector[File])
+    private case class ScalaArtifacts(compiler: File, library: File, others: Vector[File])
 
     private def getScalaArtifacts(scalaVersion: String, logger: xsbti.Logger): ScalaArtifacts = {
       def isPrefixedWith(artifact: File, prefix: String) = artifact.getName.startsWith(prefix)


### PR DESCRIPTION
The following 3 types of warning are resolved, to address #349.

* discarded non-Unit value
    * `A => U` instead of `A => Unit` as same as in [IterableLike#foreach](https://github.com/scala/scala/blob/07d61ecf134dbba143531f5a1bd3c1289c437296/src/library/scala/collection/IterableLike.scala#L70)
    * Explicitly add `()` to synchronized block 
* implicit numeric widening
    * `.toInt` is used explicitly.
* The outer reference in this type test cannot be checked at run time.
    * `final` modifier are removed for private case class. https://issues.scala-lang.org/browse/SI-4440

# Before this PR (https://github.com/sbt/zinc/commit/ad46221ca148629df111dbc1561ac348d2b15c9c)

The below commands shows the warnings except `never used`.   I will address `never used` warnings in another PR.


```bash
$ sbt -warn ";clean;compile" | grep -E "\[.*warn.*/zinc" | grep -E -v "is never used" --count
24
```

```bash
$ sbt -warn ";clean;compile" | grep -E "\[.*warn.*/zinc" | grep -E -v "is never used"
[warn] /home/exoego/IdeaProjects/zinc/internal/compiler-bridge/src/main/scala/xsbt/DelegatingReporter.scala:15:15: Unused import
[warn] /home/exoego/IdeaProjects/zinc/internal/compiler-bridge/src/main/scala/xsbt/ExtractUsedNames.scala:75:75: discarded non-Unit value
[warn] /home/exoego/IdeaProjects/zinc/internal/compiler-bridge/src/main/scala/xsbt/ExtractUsedNames.scala:78:23: discarded non-Unit value
[warn] /home/exoego/IdeaProjects/zinc/internal/compiler-bridge/src/main/scala/xsbt/ExtractUsedNames.scala:16:15: Unused import
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-core/src/main/scala/sbt/internal/inc/APIDiff.scala:80:56: implicit numeric widening
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-core/src/main/scala/sbt/internal/inc/APIDiff.scala:81:48: implicit numeric widening
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-core/src/main/scala/sbt/internal/inc/APIDiff.scala:86:37: implicit numeric widening
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavacProcessLogger.scala:34:18: discarded non-Unit value
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavacProcessLogger.scala:37:18: discarded non-Unit value
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala:347:56: method libraryJar in trait ScalaInstance is deprecated: see corresponding Javadoc for more information.
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala:72:67: method compilerJar in trait ScalaInstance is deprecated: see corresponding Javadoc for more information.
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala:73:65: method otherJars in trait ScalaInstance is deprecated: see corresponding Javadoc for more information.
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala:98:37: method libraryJar in trait ScalaInstance is deprecated: see corresponding Javadoc for more information.
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala:141:27: method libraryJar in trait ScalaInstance is deprecated: see corresponding Javadoc for more information.
[warn] /home/exoego/IdeaProjects/zinc/internal/compiler-bridge/src/main/scala/xsbt/API.scala:82:12: method isImplClass in class Symbol is deprecated (since 2.12.0): trait implementation classes have been removed in Scala 2.12
[warn] /home/exoego/IdeaProjects/zinc/internal/compiler-bridge/src/main/scala/xsbt/Analyzer.scala:51:41: method isImplClass in class Symbol is deprecated (since 2.12.0): trait implementation classes have been removed in Scala 2.12
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavaCompiler.scala:105:43: method libraryJar in trait ScalaInstance is deprecated: see corresponding Javadoc for more information.
[warn] /home/exoego/IdeaProjects/zinc/internal/compiler-bridge/src/main/scala/xsbt/ClassName.scala:94:33: method isImplClass in class Symbol is deprecated (since 2.12.0): trait implementation classes have been removed in Scala 2.12
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-core/src/main/scala/sbt/internal/inc/APIDiff.scala:155:30: The outer reference in this type test cannot be checked at run time.
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-core/src/main/scala/sbt/internal/inc/APIDiff.scala:156:30: The outer reference in this type test cannot be checked at run time.
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-core/src/main/scala/sbt/internal/inc/APIDiff.scala:157:30: The outer reference in this type test cannot be checked at run time.
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-core/src/main/scala/sbt/internal/inc/APIDiff.scala:158:30: The outer reference in this type test cannot be checked at run time.
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-ivy-integration/src/main/scala/sbt/internal/inc/ZincComponentCompiler.scala:94:30: The outer reference in this type test cannot be checked at run time.
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-benchmarks/src/main/scala/xsbt/ZincBenchmark.scala:352:24: Unused import
```

# After this PR

```bash
$ sbt -warn ";clean;compile" | grep -E "\[.*warn.*/zinc" | grep -E -v "is never used" --count
12
```

```bash
$ sbt -warn ";clean;compile" | grep -E "\[.*warn.*/zinc" | grep -E -v "is never used"
[warn] /home/exoego/IdeaProjects/zinc/internal/compiler-bridge/src/main/scala/xsbt/DelegatingReporter.scala:15:15: Unused import
[warn] /home/exoego/IdeaProjects/zinc/internal/compiler-bridge/src/main/scala/xsbt/ExtractUsedNames.scala:16:15: Unused import
[warn] /home/exoego/IdeaProjects/zinc/internal/compiler-bridge/src/main/scala/xsbt/API.scala:82:12: method isImplClass in class Symbol is deprecated (since 2.12.0): trait implementation classes have been removed in Scala 2.12
[warn] /home/exoego/IdeaProjects/zinc/internal/compiler-bridge/src/main/scala/xsbt/Analyzer.scala:51:41: method isImplClass in class Symbol is deprecated (since 2.12.0): trait implementation classes have been removed in Scala 2.12
[warn] /home/exoego/IdeaProjects/zinc/internal/compiler-bridge/src/main/scala/xsbt/ClassName.scala:94:33: method isImplClass in class Symbol is deprecated (since 2.12.0): trait implementation classes have been removed in Scala 2.12
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala:347:56: method libraryJar in trait ScalaInstance is deprecated: see corresponding Javadoc for more information.
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala:72:67: method compilerJar in trait ScalaInstance is deprecated: see corresponding Javadoc for more information.
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala:73:65: method otherJars in trait ScalaInstance is deprecated: see corresponding Javadoc for more information.
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala:98:37: method libraryJar in trait ScalaInstance is deprecated: see corresponding Javadoc for more information.
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala:141:27: method libraryJar in trait ScalaInstance is deprecated: see corresponding Javadoc for more information.
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavaCompiler.scala:105:43: method libraryJar in trait ScalaInstance is deprecated: see corresponding Javadoc for more information.
[warn] /home/exoego/IdeaProjects/zinc/internal/zinc-benchmarks/src/main/scala/xsbt/ZincBenchmark.scala:352:24: Unused import
```

The above remainings are left intentionally for compatibility, as was in the past PRs .