### PR TITLE
Benchmark the API extract phase in isolation

### DIFF
--- a/internal/zinc-benchmarks/src/main/scala/xsbt/ScalacBenchmark.scala
+++ b/internal/zinc-benchmarks/src/main/scala/xsbt/ScalacBenchmark.scala
@@ -53,3 +53,21 @@ class HotScalacBenchmark extends ScalacBenchmark {
     super.compile()
   }
 }
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.SampleTime))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 6, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 6, time = 10, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
+class HotScalacApiExtractBenchmark extends ScalacBenchmark {
+  _subprojectToRun = _project.subprojects.head
+  var _body: () => Unit = null
+  @Setup(Level.Trial)
+  def runCompiler(): Unit = {
+    _body = _setup.apiExtract()
+  }
+  @Benchmark
+  override def compile(): Unit = {
+    _body.apply()
+  }
+}


### PR DESCRIPTION
Demo:

```
sbt:zinc Root> zincBenchmarks/jmh:run -p _tempDir=/tmp/zinc-bench-baseline HotScalacApiExtractBenchmark -wi 10 -i 6 -f1 -prof jmh.extras.JFR:flameGraphOpts=--minwidth,1;verbose=true

[info] # Run complete. Total time: 00:04:24
[info] Benchmark                                                           (_tempDir)  (zincEnabled)    Mode  Cnt     Score     Error  Units
[info] HotScalacApiExtractBenchmark.compile                  /tmp/zinc-bench-baseline           true  sample   16  4962.386 ± 119.982  ms/op
[info] HotScalacApiExtractBenchmark.compile:JFR              /tmp/zinc-bench-baseline           true  sample            NaN              N/A
[info] HotScalacApiExtractBenchmark.compile:compile·p0.00    /tmp/zinc-bench-baseline           true  sample       4823.450            ms/op
[info] HotScalacApiExtractBenchmark.compile:compile·p0.50    /tmp/zinc-bench-baseline           true  sample       4928.307            ms/op
[info] HotScalacApiExtractBenchmark.compile:compile·p0.90    /tmp/zinc-bench-baseline           true  sample       5163.188            ms/op
[info] HotScalacApiExtractBenchmark.compile:compile·p0.95    /tmp/zinc-bench-baseline           true  sample       5192.548            ms/op
[info] HotScalacApiExtractBenchmark.compile:compile·p0.99    /tmp/zinc-bench-baseline           true  sample       5192.548            ms/op
[info] HotScalacApiExtractBenchmark.compile:compile·p0.999   /tmp/zinc-bench-baseline           true  sample       5192.548            ms/op
[info] HotScalacApiExtractBenchmark.compile:compile·p0.9999  /tmp/zinc-bench-baseline           true  sample       5192.548            ms/op
[info] HotScalacApiExtractBenchmark.compile:compile·p1.00    /tmp/zinc-bench-baseline           true  sample       5192.548            ms/op
```

https://www.dropbox.com/sh/f06rz1ykteaalxz/AAB1myNOxMOZ9Rjsq6XBDSfHa?dl=0

Which after optimizations in https://github.com/sbt/zinc/pull/492

Looks like:

```
[info] Benchmark                                                      (_tempDir)  (zincEnabled)    Mode  Cnt     Score     Error  Units
[info] HotScalacMicroBenchmark.compile                  /tmp/zinc-bench-baseline           true  sample   18  4290.773 ± 206.870  ms/op
[info] HotScalacMicroBenchmark.compile:JFR              /tmp/zinc-bench-baseline           true  sample            NaN              N/A
[info] HotScalacMicroBenchmark.compile:compile·p0.00    /tmp/zinc-bench-baseline           true  sample       3976.200            ms/op
[info] HotScalacMicroBenchmark.compile:compile·p0.50    /tmp/zinc-bench-baseline           true  sample       4188.013            ms/op
[info] HotScalacMicroBenchmark.compile:compile·p0.90    /tmp/zinc-bench-baseline           true  sample       4684.199            ms/op
[info] HotScalacMicroBenchmark.compile:compile·p0.95    /tmp/zinc-bench-baseline           true  sample       4714.398            ms/op
[info] HotScalacMicroBenchmark.compile:compile·p0.99    /tmp/zinc-bench-baseline           true  sample       4714.398            ms/op
[info] HotScalacMicroBenchmark.compile:compile·p0.999   /tmp/zinc-bench-baseline           true  sample       4714.398            ms/op
[info] HotScalacMicroBenchmark.compile:compile·p0.9999  /tmp/zinc-bench-baseline           true  sample       4714.398            ms/op
[info] HotScalacMicroBenchmark.compile:compile·p1.00    /tmp/zinc-bench-baseline           true  sample       4714.398            ms/op
```

https://www.dropbox.com/sh/41o382xb19y331v/AADMmaFBajbEuG_yysprM6zAa?dl=0