### PR TITLE
Improve printing of what is being compiled in benchmarks

### DIFF
--- a/internal/zinc-benchmarks/src/main/scala/xsbt/BenchmarkBase.scala
+++ b/internal/zinc-benchmarks/src/main/scala/xsbt/BenchmarkBase.scala
@@ -24,7 +24,6 @@ class BenchmarkBase {
 
   /* Data filled in by the benchmark setup. */
   var _dir: File = _
-  var _message: String = _
   var _setup: ProjectSetup = _
   var _subprojectsSetup: List[ProjectSetup] = _
 
@@ -49,17 +48,22 @@ class BenchmarkBase {
     _setup = _subprojectsSetup
       .find(p => p.subproject == id)
       .getOrElse(sys.error(s"No subproject ${_subprojectToRun} found."))
-    _message = {
-      val info = _setup.compilationInfo
-      s"""Compiling with:
-         |
-         |> Classpath: ${info.classpath}
-         |
-         |> Scalac options: ${info.scalacOptions.mkString(" ")}
-         |
-         |> Scala sources: ${info.sources.mkString(" ")}
-      """.stripMargin
+    printCompilationDetails()
+  }
+
+  private def printCompilationDetails() = {
+    val info = _setup.compilationInfo
+
+    val argsFile = new File(_tempDir, "compiler.args")
+    val argsFileContents: String = {
+      val cpArgs = if (info.classpath.isEmpty) Nil else List("-cp", info.classpath)
+      val allArgs: List[String] = cpArgs ::: info.scalacOptions.toList ::: info.sources
+      allArgs.mkString("\n")
     }
+    sbt.io.IO.write(argsFile, argsFileContents)
+    val shortSha = _project.hash.take(7)
+    println(
+      s"\nCompiling {${_project.repo}@${shortSha}}/${_subprojectToRun} using: @${argsFile.getAbsolutePath}")
   }
 
   @TearDown(Level.Trial)
@@ -70,7 +74,6 @@ class BenchmarkBase {
   }
 
   protected def compile(): Unit = {
-    println(_message.head)
     _setup.compile()
   }
 }


### PR DESCRIPTION
```
info] # Warmup Iteration   1:
[info] Compiling {scala/scala@827d69d}/library using: @/tmp/zinc-bench-baseline/compiler.args
```

```
⚡ head /tmp/zinc-bench-baseline/compiler.args
-cp

-sourcepath
/private/tmp/zinc-bench-baseline/827d69d48e96d9add75ce19e06b374610784c936/src/library
-usejavacp
/private/tmp/zinc-bench-baseline/827d69d48e96d9add75ce19e06b374610784c936/src/library/scala/AnyVal.scala
/private/tmp/zinc-bench-baseline/827d69d48e96d9add75ce19e06b374610784c936/src/library/scala/AnyValCompanion.scala
/private/tmp/zinc-bench-baseline/827d69d48e96d9add75ce19e06b374610784c936/src/library/scala/App.scala
/private/tmp/zinc-bench-baseline/827d69d48e96d9add75ce19e06b374610784c936/src/library/scala/Array.scala
/private/tmp/zinc-bench-baseline/827d69d48e96d9add75ce19e06b374610784c936/src/library/scala/Boolean.scala
```