### PR TITLE
Provide separate PrintWriters for errors and warnings

### DIFF
--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/LocalJava.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/LocalJava.scala
@@ -93,13 +93,15 @@ final class LocalJavadoc() extends XJavadoc {
     val nonJArgs = options.filterNot(_.startsWith("-J"))
     val allArguments = nonJArgs ++ sources.map(_.getAbsolutePath)
     val javacLogger = new JavacLogger(log, reporter, cwd)
-    val warnOrError = new PrintWriter(new ProcessLoggerWriter(javacLogger, Level.Error))
+    val errorWriter = new PrintWriter(new ProcessLoggerWriter(javacLogger, Level.Error))
+    val warnWriter = new PrintWriter(new ProcessLoggerWriter(javacLogger, Level.Warn))
     val infoWriter = new PrintWriter(new ProcessLoggerWriter(javacLogger, Level.Info))
     var exitCode = -1
     try {
-      exitCode = LocalJava.unsafeJavadoc(allArguments, warnOrError, warnOrError, infoWriter)
+      exitCode = LocalJava.unsafeJavadoc(allArguments, errorWriter, warnWriter, infoWriter)
     } finally {
-      warnOrError.close()
+      errorWriter.close()
+      warnWriter.close()
       infoWriter.close()
       javacLogger.flush("javadoc", exitCode)
     }


### PR DESCRIPTION
I generate javadoc using the sbt-unidoc plugin. When using sbt 1.x, it is impossible to distinguish between errors and warnings in the console. All messages are printed out with the "error" level.

After investigation, it turned out that the problem is that the same print writer (Level.Error) is used for both errors and writers in _LocalJava.scala._.

I suggest to use two separate writers, and log warning and error messages with Level.Warn and Level.Error respectively.