### PR TITLE
Fix header task name in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ Contributing to Zinc requires you or your employer to sign the
 [Lightbend Contributor License Agreement](https://www.lightbend.com/contribute/cla).
 
 To make it easier to respect our license agreements, we have added an sbt task
-that takes care of adding the LICENSE headers to new files. Run `createHeaders`
+that takes care of adding the LICENSE headers to new files. Run `headerCreate`
 and sbt will put a copyright notice into it.
 
 [sbt/zinc-contrib]: https://gitter.im/sbt/zinc-contrib


### PR DESCRIPTION
`sbt-header` task name has changed from `createHeaders` to `headerCreate` in version 2.x. 

Refer to "Changed task names and settings keys" section in `sbt-header` project [README](https://github.com/sbt/sbt-header/blob/master/README.md)