### PR TITLE
[WIP] POC - Decouple dependency phase 

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/Dependency.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/Dependency.scala
@@ -8,15 +8,14 @@
 package xsbt
 
 import java.io.File
+import java.util.{HashMap => JavaMap, HashSet => JavaSet}
 
+import xsbti.DependencyCallback
 import xsbti.api.DependencyContext
-import DependencyContext._
+import xsbti.api.DependencyContext._
 
-import scala.tools.nsc.io.{ PlainFile, ZipArchive }
-import scala.tools.nsc.Phase
-
-import java.util.{ HashSet => JavaSet }
-import java.util.{ HashMap => JavaMap }
+import scala.tools.nsc.io.{PlainFile, ZipArchive}
+import scala.tools.nsc.{Global, Phase}
 
 object Dependency {
   def name = "xsbt-dependency"
@@ -32,7 +31,7 @@ object Dependency {
  * where it originates from. The Symbol -> Classfile mapping is implemented by
  * LocateClassFile that we inherit from.
  */
-final class Dependency(val global: CallbackGlobal) extends LocateClassFile with GlobalHelpers {
+final class Dependency(val global: CallbackGlobal) {
   import global._
 
   def newPhase(prev: Phase): Phase = new DependencyPhase(prev)
@@ -50,13 +49,27 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile with 
 
     def apply(unit: CompilationUnit): Unit = {
       if (!unit.isJava) {
-        // Process dependencies if name hashing is enabled, fail otherwise
-        val dependencyProcessor = new DependencyProcessor(unit)
-        val dependencyTraverser = new DependencyTraverser(dependencyProcessor)
-        // Traverse symbols in compilation unit and register all dependencies
-        dependencyTraverser.traverse(unit.body)
+        val analyzer =
+          new DependencyAnalyzer[Dependency.this.global.type](global, callback)
+        analyzer.process(unit)
       }
     }
+  }
+
+}
+
+class DependencyAnalyzer[G <: Global](val global: G, callback: DependencyCallback)
+    extends LocateClassFile
+    with GlobalHelpers {
+
+  import global._
+
+  def process(unit: CompilationUnit): Unit = {
+    // Process dependencies if name hashing is enabled, fail otherwise
+    val dependencyProcessor = new DependencyProcessor(unit)
+    val dependencyTraverser = new DependencyTraverser(dependencyProcessor)
+    // Traverse symbols in compilation unit and register all dependencies
+    dependencyTraverser.traverse(unit.body)
   }
 
   private class DependencyProcessor(unit: CompilationUnit) {
@@ -148,9 +161,10 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile with 
     }
   }
 
-  private case class ClassDependency(from: Symbol, to: Symbol)
+  final class DependencyTraverser(processor: DependencyProcessor) extends Traverser {
+    private val localToNonLocalClass =
+      new LocalToNonLocalClass[DependencyAnalyzer.this.global.type](global)
 
-  private final class DependencyTraverser(processor: DependencyProcessor) extends Traverser {
     // are we traversing an Import node at the moment?
     private var inImportNode = false
 
@@ -409,4 +423,6 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile with 
       case other => super.traverse(other)
     }
   }
+
+  case class ClassDependency(from: Symbol, to: Symbol)
 }

--- a/internal/compiler-bridge/src/main/scala/xsbt/LocalToNonLocalClass.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/LocalToNonLocalClass.scala
@@ -8,6 +8,7 @@
 package xsbt
 
 import collection.mutable.Map
+import scala.tools.nsc.Global
 
 /**
  * A memoized lookup of an enclosing non local class.
@@ -30,15 +31,15 @@ import collection.mutable.Map
  *
  * Additionally, you can query whether a given class is local. Check `isLocal`'s documentation.
  */
-class LocalToNonLocalClass[G <: CallbackGlobal](val global: G) {
+class LocalToNonLocalClass[G <: Global](val global: G) {
   import global._
   private val cache: Map[Symbol, Symbol] = perRunCaches.newMap()
 
   def resolveNonLocal(s: Symbol): Symbol = {
-    assert(
-      phase.id <= sbtDependency.ownPhase.id,
-      s"Tried to resolve ${s.fullName} to a  non local classes but the resolution works up to sbtDependency phase. We're at ${phase.name}"
-    )
+//    assert(
+//      phase.id <= sbtDependency.ownPhase.id,
+//      s"Tried to resolve ${s.fullName} to a  non local classes but the resolution works up to sbtDependency phase. We're at ${phase.name}"
+//    )
     resolveCached(s)
   }
 

--- a/internal/compiler-bridge/src/main/scala/xsbt/LocateClassFile.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/LocateClassFile.scala
@@ -9,14 +9,15 @@ package xsbt
 
 import scala.reflect.io.NoAbstractFile
 import scala.tools.nsc.io.AbstractFile
-
 import java.io.File
+
+import scala.tools.nsc.Global
 
 /**
  * Contains utility methods for looking up class files corresponding to Symbols.
  */
 abstract class LocateClassFile extends Compat with ClassName {
-  val global: CallbackGlobal
+  val global: Global
   import global._
 
   private[this] final val classSeparator = '.'

--- a/internal/compiler-interface/src/main/java/xsbti/AnalysisCallback.java
+++ b/internal/compiler-interface/src/main/java/xsbti/AnalysisCallback.java
@@ -11,64 +11,14 @@ import xsbti.api.DependencyContext;
 import java.io.File;
 import java.util.EnumSet;
 
-public interface AnalysisCallback {
+public interface AnalysisCallback extends DependencyCallback{
     /**
      * Set the source file mapped to a concrete {@link AnalysisCallback}.
      * @param source Source file mapped to this instance of {@link AnalysisCallback}.
      */
     void startSource(File source);
 
-    /**
-     * Indicate that the class <code>sourceClassName</code> depends on the
-     * class <code>onClassName</code>.
-     *
-     * Note that only classes defined in source files included in the current
-     * compilation will passed to this method. Dependencies on classes generated
-     * by sources not in the current compilation will be passed as binary
-     * dependencies to the `binaryDependency` method.
-     *
-     * @param onClassName Class name being depended on.
-     * @param sourceClassName Dependent class name.
-     * @param context The kind of dependency established between
-     *                <code>onClassName</code> and <code>sourceClassName</code>.
-     *
-     * @see xsbti.api.DependencyContext
-     */
-    void classDependency(String onClassName,
-                         String sourceClassName,
-                         DependencyContext context);
 
-    /**
-     * Indicate that the class <code>fromClassName</code> depends on a class
-     * named <code>onBinaryClassName</code> coming from class file or jar
-     * <code>onBinaryEntry</code>.
-     *
-     * @param onBinaryEntry A binary entry represents either the jar or the
-     *                      concrete class file from which the Scala compiler
-     *                      knows that <code>onBinaryClassName</code> comes from.
-     * @param onBinaryClassName Dependent binary name.
-     *                 Binary name with JVM-like representation. Inner classes
-     *                 are represented with '$'. For more information on the
-     *                 binary name format, check section 13.1 of the Java
-     *                 Language Specification.
-     * @param fromClassName Represent the class file name where
-     *                 <code>onBinaryClassName</code> is defined.
-     *                 Binary name with JVM-like representation. Inner classes
-     *                 are represented with '$'. For more information on the
-     *                 binary name format, check section 13.1 of the Java
-     *                 Language Specification.
-     * @param fromSourceFile Source file where <code>onBinaryClassName</code>
-     *                       is defined.
-     * @param context The kind of dependency established between
-     *                <code>onClassName</code> and <code>sourceClassName</code>.
-     *
-     * @see xsbti.api.DependencyContext for more information on the context.
-     */
-    void binaryDependency(File onBinaryEntry,
-                          String onBinaryClassName,
-                          String fromClassName,
-                          File fromSourceFile,
-                          DependencyContext context);
 
     /**
      * Map the source class name (<code>srcClassName</code>) of a top-level
@@ -151,12 +101,7 @@ public interface AnalysisCallback {
                  Severity severity,
                  boolean reported);
 
-    /**
-     * Communicate to the callback that the dependency phase has finished.
-     *
-     * For instance, you can use this method it to wait on asynchronous tasks.
-     */
-    void dependencyPhaseCompleted();
+
 
     /**
      * Communicate to the callback that the API phase has finished.

--- a/internal/compiler-interface/src/main/java/xsbti/DependencyCallback.java
+++ b/internal/compiler-interface/src/main/java/xsbti/DependencyCallback.java
@@ -1,0 +1,66 @@
+package xsbti;
+
+import xsbti.api.DependencyContext;
+
+import java.io.File;
+
+public interface DependencyCallback {
+  /**
+   * Indicate that the class <code>sourceClassName</code> depends on the
+   * class <code>onClassName</code>.
+   *
+   * Note that only classes defined in source files included in the current
+   * compilation will passed to this method. Dependencies on classes generated
+   * by sources not in the current compilation will be passed as binary
+   * dependencies to the `binaryDependency` method.
+   *
+   * @param onClassName Class name being depended on.
+   * @param sourceClassName Dependent class name.
+   * @param context The kind of dependency established between
+   *                <code>onClassName</code> and <code>sourceClassName</code>.
+   *
+   * @see xsbti.api.DependencyContext
+   */
+  void classDependency(String onClassName,
+                       String sourceClassName,
+                       DependencyContext context);
+
+  /**
+   * Indicate that the class <code>fromClassName</code> depends on a class
+   * named <code>onBinaryClassName</code> coming from class file or jar
+   * <code>onBinaryEntry</code>.
+   *
+   * @param onBinaryEntry A binary entry represents either the jar or the
+   *                      concrete class file from which the Scala compiler
+   *                      knows that <code>onBinaryClassName</code> comes from.
+   * @param onBinaryClassName Dependent binary name.
+   *                 Binary name with JVM-like representation. Inner classes
+   *                 are represented with '$'. For more information on the
+   *                 binary name format, check section 13.1 of the Java
+   *                 Language Specification.
+   * @param fromClassName Represent the class file name where
+   *                 <code>onBinaryClassName</code> is defined.
+   *                 Binary name with JVM-like representation. Inner classes
+   *                 are represented with '$'. For more information on the
+   *                 binary name format, check section 13.1 of the Java
+   *                 Language Specification.
+   * @param fromSourceFile Source file where <code>onBinaryClassName</code>
+   *                       is defined.
+   * @param context The kind of dependency established between
+   *                <code>onClassName</code> and <code>sourceClassName</code>.
+   *
+   * @see xsbti.api.DependencyContext for more information on the context.
+   */
+  void binaryDependency(File onBinaryEntry,
+                        String onBinaryClassName,
+                        String fromClassName,
+                        File fromSourceFile,
+                        DependencyContext context);
+
+  /**
+   * Communicate to the callback that the dependency phase has finished.
+   *
+   * For instance, you can use this method it to wait on asynchronous tasks.
+   */
+  void dependencyPhaseCompleted();
+}


### PR DESCRIPTION
POC - Decouple dependency phase so other build tools would be able to use it and code will not be duplicated and maintained several times. 
e.g. `bazelbuild/rules_scala` strict_deps feature. 

**changes:** 

1. CallbackGlobal can not be part of the dependency analysis phase as it is zinc-specific, so the `DependencyAnalyzer` logic should only know of Global.

2. `AnalysisCallback` interface  should be split in two, so that there will be an interface that only declare dependency related methods

**pending issues:** 

1. `LocalToNonLocalClass` cache should somehow still be shared with other phases (this branch just creates a standalone instance of the cache for the `DependencyAnalyzer` due to technical issue relating `Symbol` type conflicts).


@gkossakowski @stuhood @ittaiz @johnynek
WDYT?