### PR TITLE
Fix equal / hashCode inconsistencies around Array

### DIFF
--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/Annotated.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/Annotated.java
@@ -39,11 +39,11 @@ public final class Annotated extends xsbti.api.Type {
             return false;
         } else {
             Annotated o = (Annotated)obj;
-            return baseType().equals(o.baseType()) && java.util.Arrays.deepEquals(annotations(), o.annotations());
+            return this.baseType().equals(o.baseType()) && java.util.Arrays.deepEquals(this.annotations(), o.annotations());
         }
     }
     public int hashCode() {
-        return 37 * (37 * (37 * (17 + "xsbti.api.Annotated".hashCode()) + baseType().hashCode()) + annotations().hashCode());
+        return 37 * (37 * (37 * (17 + "xsbti.api.Annotated".hashCode()) + baseType().hashCode()) + java.util.Arrays.deepHashCode(annotations()));
     }
     public String toString() {
         return "Annotated("  + "baseType: " + baseType() + ", " + "annotations: " + annotations() + ")";

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/Annotation.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/Annotation.java
@@ -39,11 +39,11 @@ public final class Annotation implements java.io.Serializable {
             return false;
         } else {
             Annotation o = (Annotation)obj;
-            return base().equals(o.base()) && java.util.Arrays.deepEquals(arguments(), o.arguments());
+            return this.base().equals(o.base()) && java.util.Arrays.deepEquals(this.arguments(), o.arguments());
         }
     }
     public int hashCode() {
-        return 37 * (37 * (37 * (17 + "xsbti.api.Annotation".hashCode()) + base().hashCode()) + arguments().hashCode());
+        return 37 * (37 * (37 * (17 + "xsbti.api.Annotation".hashCode()) + base().hashCode()) + java.util.Arrays.deepHashCode(arguments()));
     }
     public String toString() {
         return "Annotation("  + "base: " + base() + ", " + "arguments: " + arguments() + ")";

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/AnnotationArgument.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/AnnotationArgument.java
@@ -39,7 +39,7 @@ public final class AnnotationArgument implements java.io.Serializable {
             return false;
         } else {
             AnnotationArgument o = (AnnotationArgument)obj;
-            return name().equals(o.name()) && value().equals(o.value());
+            return this.name().equals(o.name()) && this.value().equals(o.value());
         }
     }
     public int hashCode() {

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/ClassDefinition.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/ClassDefinition.java
@@ -20,11 +20,11 @@ public abstract class ClassDefinition extends xsbti.api.Definition {
             return false;
         } else {
             ClassDefinition o = (ClassDefinition)obj;
-            return name().equals(o.name()) && access().equals(o.access()) && modifiers().equals(o.modifiers()) && java.util.Arrays.deepEquals(annotations(), o.annotations());
+            return this.name().equals(o.name()) && this.access().equals(o.access()) && this.modifiers().equals(o.modifiers()) && java.util.Arrays.deepEquals(this.annotations(), o.annotations());
         }
     }
     public int hashCode() {
-        return 37 * (37 * (37 * (37 * (37 * (17 + "xsbti.api.ClassDefinition".hashCode()) + name().hashCode()) + access().hashCode()) + modifiers().hashCode()) + annotations().hashCode());
+        return 37 * (37 * (37 * (37 * (37 * (17 + "xsbti.api.ClassDefinition".hashCode()) + name().hashCode()) + access().hashCode()) + modifiers().hashCode()) + java.util.Arrays.deepHashCode(annotations()));
     }
     public String toString() {
         return "ClassDefinition("  + "name: " + name() + ", " + "access: " + access() + ", " + "modifiers: " + modifiers() + ", " + "annotations: " + annotations() + ")";

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/ClassLikeDef.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/ClassLikeDef.java
@@ -46,11 +46,11 @@ public final class ClassLikeDef extends xsbti.api.ParameterizedDefinition {
             return false;
         } else {
             ClassLikeDef o = (ClassLikeDef)obj;
-            return name().equals(o.name()) && access().equals(o.access()) && modifiers().equals(o.modifiers()) && java.util.Arrays.deepEquals(annotations(), o.annotations()) && java.util.Arrays.deepEquals(typeParameters(), o.typeParameters()) && definitionType().equals(o.definitionType());
+            return this.name().equals(o.name()) && this.access().equals(o.access()) && this.modifiers().equals(o.modifiers()) && java.util.Arrays.deepEquals(this.annotations(), o.annotations()) && java.util.Arrays.deepEquals(this.typeParameters(), o.typeParameters()) && this.definitionType().equals(o.definitionType());
         }
     }
     public int hashCode() {
-        return 37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.api.ClassLikeDef".hashCode()) + name().hashCode()) + access().hashCode()) + modifiers().hashCode()) + annotations().hashCode()) + typeParameters().hashCode()) + definitionType().hashCode());
+        return 37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.api.ClassLikeDef".hashCode()) + name().hashCode()) + access().hashCode()) + modifiers().hashCode()) + java.util.Arrays.deepHashCode(annotations())) + java.util.Arrays.deepHashCode(typeParameters())) + definitionType().hashCode());
     }
     public String toString() {
         return "ClassLikeDef("  + "name: " + name() + ", " + "access: " + access() + ", " + "modifiers: " + modifiers() + ", " + "annotations: " + annotations() + ", " + "typeParameters: " + typeParameters() + ", " + "definitionType: " + definitionType() + ")";

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/Companions.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/Companions.java
@@ -39,7 +39,7 @@ public final class Companions implements java.io.Serializable {
             return false;
         } else {
             Companions o = (Companions)obj;
-            return classApi().equals(o.classApi()) && objectApi().equals(o.objectApi());
+            return this.classApi().equals(o.classApi()) && this.objectApi().equals(o.objectApi());
         }
     }
     public int hashCode() {

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/Constant.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/Constant.java
@@ -39,7 +39,7 @@ public final class Constant extends xsbti.api.Type {
             return false;
         } else {
             Constant o = (Constant)obj;
-            return baseType().equals(o.baseType()) && value().equals(o.value());
+            return this.baseType().equals(o.baseType()) && this.value().equals(o.value());
         }
     }
     public int hashCode() {

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/Def.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/Def.java
@@ -54,11 +54,11 @@ public final class Def extends xsbti.api.ParameterizedDefinition {
             return false;
         } else {
             Def o = (Def)obj;
-            return name().equals(o.name()) && access().equals(o.access()) && modifiers().equals(o.modifiers()) && java.util.Arrays.deepEquals(annotations(), o.annotations()) && java.util.Arrays.deepEquals(typeParameters(), o.typeParameters()) && java.util.Arrays.deepEquals(valueParameters(), o.valueParameters()) && returnType().equals(o.returnType());
+            return this.name().equals(o.name()) && this.access().equals(o.access()) && this.modifiers().equals(o.modifiers()) && java.util.Arrays.deepEquals(this.annotations(), o.annotations()) && java.util.Arrays.deepEquals(this.typeParameters(), o.typeParameters()) && java.util.Arrays.deepEquals(this.valueParameters(), o.valueParameters()) && this.returnType().equals(o.returnType());
         }
     }
     public int hashCode() {
-        return 37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.api.Def".hashCode()) + name().hashCode()) + access().hashCode()) + modifiers().hashCode()) + annotations().hashCode()) + typeParameters().hashCode()) + valueParameters().hashCode()) + returnType().hashCode());
+        return 37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.api.Def".hashCode()) + name().hashCode()) + access().hashCode()) + modifiers().hashCode()) + java.util.Arrays.deepHashCode(annotations())) + java.util.Arrays.deepHashCode(typeParameters())) + java.util.Arrays.deepHashCode(valueParameters())) + returnType().hashCode());
     }
     public String toString() {
         return "Def("  + "name: " + name() + ", " + "access: " + access() + ", " + "modifiers: " + modifiers() + ", " + "annotations: " + annotations() + ", " + "typeParameters: " + typeParameters() + ", " + "valueParameters: " + valueParameters() + ", " + "returnType: " + returnType() + ")";

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/Definition.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/Definition.java
@@ -38,11 +38,11 @@ public abstract class Definition implements java.io.Serializable {
             return false;
         } else {
             Definition o = (Definition)obj;
-            return name().equals(o.name()) && access().equals(o.access()) && modifiers().equals(o.modifiers()) && java.util.Arrays.deepEquals(annotations(), o.annotations());
+            return this.name().equals(o.name()) && this.access().equals(o.access()) && this.modifiers().equals(o.modifiers()) && java.util.Arrays.deepEquals(this.annotations(), o.annotations());
         }
     }
     public int hashCode() {
-        return 37 * (37 * (37 * (37 * (37 * (17 + "xsbti.api.Definition".hashCode()) + name().hashCode()) + access().hashCode()) + modifiers().hashCode()) + annotations().hashCode());
+        return 37 * (37 * (37 * (37 * (37 * (17 + "xsbti.api.Definition".hashCode()) + name().hashCode()) + access().hashCode()) + modifiers().hashCode()) + java.util.Arrays.deepHashCode(annotations()));
     }
     public String toString() {
         return "Definition("  + "name: " + name() + ", " + "access: " + access() + ", " + "modifiers: " + modifiers() + ", " + "annotations: " + annotations() + ")";

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/Existential.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/Existential.java
@@ -39,11 +39,11 @@ public final class Existential extends xsbti.api.Type {
             return false;
         } else {
             Existential o = (Existential)obj;
-            return baseType().equals(o.baseType()) && java.util.Arrays.deepEquals(clause(), o.clause());
+            return this.baseType().equals(o.baseType()) && java.util.Arrays.deepEquals(this.clause(), o.clause());
         }
     }
     public int hashCode() {
-        return 37 * (37 * (37 * (17 + "xsbti.api.Existential".hashCode()) + baseType().hashCode()) + clause().hashCode());
+        return 37 * (37 * (37 * (17 + "xsbti.api.Existential".hashCode()) + baseType().hashCode()) + java.util.Arrays.deepHashCode(clause()));
     }
     public String toString() {
         return "Existential("  + "baseType: " + baseType() + ", " + "clause: " + clause() + ")";

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/ExternalDependency.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/ExternalDependency.java
@@ -55,7 +55,7 @@ public final class ExternalDependency implements java.io.Serializable {
             return false;
         } else {
             ExternalDependency o = (ExternalDependency)obj;
-            return sourceClassName().equals(o.sourceClassName()) && targetProductClassName().equals(o.targetProductClassName()) && targetClass().equals(o.targetClass()) && context().equals(o.context());
+            return this.sourceClassName().equals(o.sourceClassName()) && this.targetProductClassName().equals(o.targetProductClassName()) && this.targetClass().equals(o.targetClass()) && this.context().equals(o.context());
         }
     }
     public int hashCode() {

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/FieldLike.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/FieldLike.java
@@ -23,11 +23,11 @@ public abstract class FieldLike extends xsbti.api.ClassDefinition {
             return false;
         } else {
             FieldLike o = (FieldLike)obj;
-            return name().equals(o.name()) && access().equals(o.access()) && modifiers().equals(o.modifiers()) && java.util.Arrays.deepEquals(annotations(), o.annotations()) && tpe().equals(o.tpe());
+            return this.name().equals(o.name()) && this.access().equals(o.access()) && this.modifiers().equals(o.modifiers()) && java.util.Arrays.deepEquals(this.annotations(), o.annotations()) && this.tpe().equals(o.tpe());
         }
     }
     public int hashCode() {
-        return 37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.api.FieldLike".hashCode()) + name().hashCode()) + access().hashCode()) + modifiers().hashCode()) + annotations().hashCode()) + tpe().hashCode());
+        return 37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.api.FieldLike".hashCode()) + name().hashCode()) + access().hashCode()) + modifiers().hashCode()) + java.util.Arrays.deepHashCode(annotations())) + tpe().hashCode());
     }
     public String toString() {
         return "FieldLike("  + "name: " + name() + ", " + "access: " + access() + ", " + "modifiers: " + modifiers() + ", " + "annotations: " + annotations() + ", " + "tpe: " + tpe() + ")";

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/Id.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/Id.java
@@ -31,7 +31,7 @@ public final class Id extends xsbti.api.PathComponent {
             return false;
         } else {
             Id o = (Id)obj;
-            return id().equals(o.id());
+            return this.id().equals(o.id());
         }
     }
     public int hashCode() {

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/IdQualifier.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/IdQualifier.java
@@ -31,7 +31,7 @@ public final class IdQualifier extends xsbti.api.Qualifier {
             return false;
         } else {
             IdQualifier o = (IdQualifier)obj;
-            return value().equals(o.value());
+            return this.value().equals(o.value());
         }
     }
     public int hashCode() {

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/InternalDependency.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/InternalDependency.java
@@ -47,7 +47,7 @@ public final class InternalDependency implements java.io.Serializable {
             return false;
         } else {
             InternalDependency o = (InternalDependency)obj;
-            return sourceClassName().equals(o.sourceClassName()) && targetClassName().equals(o.targetClassName()) && context().equals(o.context());
+            return this.sourceClassName().equals(o.sourceClassName()) && this.targetClassName().equals(o.targetClassName()) && this.context().equals(o.context());
         }
     }
     public int hashCode() {

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/MethodParameter.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/MethodParameter.java
@@ -55,7 +55,7 @@ public final class MethodParameter implements java.io.Serializable {
             return false;
         } else {
             MethodParameter o = (MethodParameter)obj;
-            return name().equals(o.name()) && tpe().equals(o.tpe()) && (hasDefault() == o.hasDefault()) && modifier().equals(o.modifier());
+            return this.name().equals(o.name()) && this.tpe().equals(o.tpe()) && (this.hasDefault() == o.hasDefault()) && this.modifier().equals(o.modifier());
         }
     }
     public int hashCode() {

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/NameHash.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/NameHash.java
@@ -47,7 +47,7 @@ public final class NameHash implements java.io.Serializable {
             return false;
         } else {
             NameHash o = (NameHash)obj;
-            return name().equals(o.name()) && scope().equals(o.scope()) && (hash() == o.hash());
+            return this.name().equals(o.name()) && this.scope().equals(o.scope()) && (this.hash() == o.hash());
         }
     }
     public int hashCode() {

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/Package.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/Package.java
@@ -31,7 +31,7 @@ public final class Package implements java.io.Serializable {
             return false;
         } else {
             Package o = (Package)obj;
-            return name().equals(o.name());
+            return this.name().equals(o.name());
         }
     }
     public int hashCode() {

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/ParameterList.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/ParameterList.java
@@ -39,11 +39,11 @@ public final class ParameterList implements java.io.Serializable {
             return false;
         } else {
             ParameterList o = (ParameterList)obj;
-            return java.util.Arrays.deepEquals(parameters(), o.parameters()) && (isImplicit() == o.isImplicit());
+            return java.util.Arrays.deepEquals(this.parameters(), o.parameters()) && (this.isImplicit() == o.isImplicit());
         }
     }
     public int hashCode() {
-        return 37 * (37 * (37 * (17 + "xsbti.api.ParameterList".hashCode()) + parameters().hashCode()) + (new Boolean(isImplicit())).hashCode());
+        return 37 * (37 * (37 * (17 + "xsbti.api.ParameterList".hashCode()) + java.util.Arrays.deepHashCode(parameters())) + (new Boolean(isImplicit())).hashCode());
     }
     public String toString() {
         return "ParameterList("  + "parameters: " + parameters() + ", " + "isImplicit: " + isImplicit() + ")";

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/ParameterRef.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/ParameterRef.java
@@ -31,7 +31,7 @@ public final class ParameterRef extends xsbti.api.Type {
             return false;
         } else {
             ParameterRef o = (ParameterRef)obj;
-            return id().equals(o.id());
+            return this.id().equals(o.id());
         }
     }
     public int hashCode() {

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/Parameterized.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/Parameterized.java
@@ -39,11 +39,11 @@ public final class Parameterized extends xsbti.api.Type {
             return false;
         } else {
             Parameterized o = (Parameterized)obj;
-            return baseType().equals(o.baseType()) && java.util.Arrays.deepEquals(typeArguments(), o.typeArguments());
+            return this.baseType().equals(o.baseType()) && java.util.Arrays.deepEquals(this.typeArguments(), o.typeArguments());
         }
     }
     public int hashCode() {
-        return 37 * (37 * (37 * (17 + "xsbti.api.Parameterized".hashCode()) + baseType().hashCode()) + typeArguments().hashCode());
+        return 37 * (37 * (37 * (17 + "xsbti.api.Parameterized".hashCode()) + baseType().hashCode()) + java.util.Arrays.deepHashCode(typeArguments()));
     }
     public String toString() {
         return "Parameterized("  + "baseType: " + baseType() + ", " + "typeArguments: " + typeArguments() + ")";

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/ParameterizedDefinition.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/ParameterizedDefinition.java
@@ -23,11 +23,11 @@ public abstract class ParameterizedDefinition extends xsbti.api.ClassDefinition 
             return false;
         } else {
             ParameterizedDefinition o = (ParameterizedDefinition)obj;
-            return name().equals(o.name()) && access().equals(o.access()) && modifiers().equals(o.modifiers()) && java.util.Arrays.deepEquals(annotations(), o.annotations()) && java.util.Arrays.deepEquals(typeParameters(), o.typeParameters());
+            return this.name().equals(o.name()) && this.access().equals(o.access()) && this.modifiers().equals(o.modifiers()) && java.util.Arrays.deepEquals(this.annotations(), o.annotations()) && java.util.Arrays.deepEquals(this.typeParameters(), o.typeParameters());
         }
     }
     public int hashCode() {
-        return 37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.api.ParameterizedDefinition".hashCode()) + name().hashCode()) + access().hashCode()) + modifiers().hashCode()) + annotations().hashCode()) + typeParameters().hashCode());
+        return 37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.api.ParameterizedDefinition".hashCode()) + name().hashCode()) + access().hashCode()) + modifiers().hashCode()) + java.util.Arrays.deepHashCode(annotations())) + java.util.Arrays.deepHashCode(typeParameters()));
     }
     public String toString() {
         return "ParameterizedDefinition("  + "name: " + name() + ", " + "access: " + access() + ", " + "modifiers: " + modifiers() + ", " + "annotations: " + annotations() + ", " + "typeParameters: " + typeParameters() + ")";

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/Path.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/Path.java
@@ -31,11 +31,11 @@ public final class Path implements java.io.Serializable {
             return false;
         } else {
             Path o = (Path)obj;
-            return java.util.Arrays.deepEquals(components(), o.components());
+            return java.util.Arrays.deepEquals(this.components(), o.components());
         }
     }
     public int hashCode() {
-        return 37 * (37 * (17 + "xsbti.api.Path".hashCode()) + components().hashCode());
+        return 37 * (37 * (17 + "xsbti.api.Path".hashCode()) + java.util.Arrays.deepHashCode(components()));
     }
     public String toString() {
         return "Path("  + "components: " + components() + ")";

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/Polymorphic.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/Polymorphic.java
@@ -39,11 +39,11 @@ public final class Polymorphic extends xsbti.api.Type {
             return false;
         } else {
             Polymorphic o = (Polymorphic)obj;
-            return baseType().equals(o.baseType()) && java.util.Arrays.deepEquals(parameters(), o.parameters());
+            return this.baseType().equals(o.baseType()) && java.util.Arrays.deepEquals(this.parameters(), o.parameters());
         }
     }
     public int hashCode() {
-        return 37 * (37 * (37 * (17 + "xsbti.api.Polymorphic".hashCode()) + baseType().hashCode()) + parameters().hashCode());
+        return 37 * (37 * (37 * (17 + "xsbti.api.Polymorphic".hashCode()) + baseType().hashCode()) + java.util.Arrays.deepHashCode(parameters()));
     }
     public String toString() {
         return "Polymorphic("  + "baseType: " + baseType() + ", " + "parameters: " + parameters() + ")";

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/Private.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/Private.java
@@ -28,7 +28,7 @@ public final class Private extends xsbti.api.Qualified {
             return false;
         } else {
             Private o = (Private)obj;
-            return qualifier().equals(o.qualifier());
+            return this.qualifier().equals(o.qualifier());
         }
     }
     public int hashCode() {

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/Projection.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/Projection.java
@@ -39,7 +39,7 @@ public final class Projection extends xsbti.api.Type {
             return false;
         } else {
             Projection o = (Projection)obj;
-            return prefix().equals(o.prefix()) && id().equals(o.id());
+            return this.prefix().equals(o.prefix()) && this.id().equals(o.id());
         }
     }
     public int hashCode() {

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/Protected.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/Protected.java
@@ -28,7 +28,7 @@ public final class Protected extends xsbti.api.Qualified {
             return false;
         } else {
             Protected o = (Protected)obj;
-            return qualifier().equals(o.qualifier());
+            return this.qualifier().equals(o.qualifier());
         }
     }
     public int hashCode() {

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/Qualified.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/Qualified.java
@@ -23,7 +23,7 @@ public abstract class Qualified extends xsbti.api.Access {
             return false;
         } else {
             Qualified o = (Qualified)obj;
-            return qualifier().equals(o.qualifier());
+            return this.qualifier().equals(o.qualifier());
         }
     }
     public int hashCode() {

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/Singleton.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/Singleton.java
@@ -31,7 +31,7 @@ public final class Singleton extends xsbti.api.Type {
             return false;
         } else {
             Singleton o = (Singleton)obj;
-            return path().equals(o.path());
+            return this.path().equals(o.path());
         }
     }
     public int hashCode() {

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/Super.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/Super.java
@@ -31,7 +31,7 @@ public final class Super extends xsbti.api.PathComponent {
             return false;
         } else {
             Super o = (Super)obj;
-            return qualifier().equals(o.qualifier());
+            return this.qualifier().equals(o.qualifier());
         }
     }
     public int hashCode() {

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/TypeAlias.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/TypeAlias.java
@@ -46,11 +46,11 @@ public final class TypeAlias extends xsbti.api.TypeMember {
             return false;
         } else {
             TypeAlias o = (TypeAlias)obj;
-            return name().equals(o.name()) && access().equals(o.access()) && modifiers().equals(o.modifiers()) && java.util.Arrays.deepEquals(annotations(), o.annotations()) && java.util.Arrays.deepEquals(typeParameters(), o.typeParameters()) && tpe().equals(o.tpe());
+            return this.name().equals(o.name()) && this.access().equals(o.access()) && this.modifiers().equals(o.modifiers()) && java.util.Arrays.deepEquals(this.annotations(), o.annotations()) && java.util.Arrays.deepEquals(this.typeParameters(), o.typeParameters()) && this.tpe().equals(o.tpe());
         }
     }
     public int hashCode() {
-        return 37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.api.TypeAlias".hashCode()) + name().hashCode()) + access().hashCode()) + modifiers().hashCode()) + annotations().hashCode()) + typeParameters().hashCode()) + tpe().hashCode());
+        return 37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.api.TypeAlias".hashCode()) + name().hashCode()) + access().hashCode()) + modifiers().hashCode()) + java.util.Arrays.deepHashCode(annotations())) + java.util.Arrays.deepHashCode(typeParameters())) + tpe().hashCode());
     }
     public String toString() {
         return "TypeAlias("  + "name: " + name() + ", " + "access: " + access() + ", " + "modifiers: " + modifiers() + ", " + "annotations: " + annotations() + ", " + "typeParameters: " + typeParameters() + ", " + "tpe: " + tpe() + ")";

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/TypeDeclaration.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/TypeDeclaration.java
@@ -54,11 +54,11 @@ public final class TypeDeclaration extends xsbti.api.TypeMember {
             return false;
         } else {
             TypeDeclaration o = (TypeDeclaration)obj;
-            return name().equals(o.name()) && access().equals(o.access()) && modifiers().equals(o.modifiers()) && java.util.Arrays.deepEquals(annotations(), o.annotations()) && java.util.Arrays.deepEquals(typeParameters(), o.typeParameters()) && lowerBound().equals(o.lowerBound()) && upperBound().equals(o.upperBound());
+            return this.name().equals(o.name()) && this.access().equals(o.access()) && this.modifiers().equals(o.modifiers()) && java.util.Arrays.deepEquals(this.annotations(), o.annotations()) && java.util.Arrays.deepEquals(this.typeParameters(), o.typeParameters()) && this.lowerBound().equals(o.lowerBound()) && this.upperBound().equals(o.upperBound());
         }
     }
     public int hashCode() {
-        return 37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.api.TypeDeclaration".hashCode()) + name().hashCode()) + access().hashCode()) + modifiers().hashCode()) + annotations().hashCode()) + typeParameters().hashCode()) + lowerBound().hashCode()) + upperBound().hashCode());
+        return 37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.api.TypeDeclaration".hashCode()) + name().hashCode()) + access().hashCode()) + modifiers().hashCode()) + java.util.Arrays.deepHashCode(annotations())) + java.util.Arrays.deepHashCode(typeParameters())) + lowerBound().hashCode()) + upperBound().hashCode());
     }
     public String toString() {
         return "TypeDeclaration("  + "name: " + name() + ", " + "access: " + access() + ", " + "modifiers: " + modifiers() + ", " + "annotations: " + annotations() + ", " + "typeParameters: " + typeParameters() + ", " + "lowerBound: " + lowerBound() + ", " + "upperBound: " + upperBound() + ")";

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/TypeMember.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/TypeMember.java
@@ -20,11 +20,11 @@ public abstract class TypeMember extends xsbti.api.ParameterizedDefinition {
             return false;
         } else {
             TypeMember o = (TypeMember)obj;
-            return name().equals(o.name()) && access().equals(o.access()) && modifiers().equals(o.modifiers()) && java.util.Arrays.deepEquals(annotations(), o.annotations()) && java.util.Arrays.deepEquals(typeParameters(), o.typeParameters());
+            return this.name().equals(o.name()) && this.access().equals(o.access()) && this.modifiers().equals(o.modifiers()) && java.util.Arrays.deepEquals(this.annotations(), o.annotations()) && java.util.Arrays.deepEquals(this.typeParameters(), o.typeParameters());
         }
     }
     public int hashCode() {
-        return 37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.api.TypeMember".hashCode()) + name().hashCode()) + access().hashCode()) + modifiers().hashCode()) + annotations().hashCode()) + typeParameters().hashCode());
+        return 37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.api.TypeMember".hashCode()) + name().hashCode()) + access().hashCode()) + modifiers().hashCode()) + java.util.Arrays.deepHashCode(annotations())) + java.util.Arrays.deepHashCode(typeParameters()));
     }
     public String toString() {
         return "TypeMember("  + "name: " + name() + ", " + "access: " + access() + ", " + "modifiers: " + modifiers() + ", " + "annotations: " + annotations() + ", " + "typeParameters: " + typeParameters() + ")";

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/TypeParameter.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/TypeParameter.java
@@ -71,11 +71,11 @@ public final class TypeParameter implements java.io.Serializable {
             return false;
         } else {
             TypeParameter o = (TypeParameter)obj;
-            return id().equals(o.id()) && java.util.Arrays.deepEquals(annotations(), o.annotations()) && java.util.Arrays.deepEquals(typeParameters(), o.typeParameters()) && variance().equals(o.variance()) && lowerBound().equals(o.lowerBound()) && upperBound().equals(o.upperBound());
+            return this.id().equals(o.id()) && java.util.Arrays.deepEquals(this.annotations(), o.annotations()) && java.util.Arrays.deepEquals(this.typeParameters(), o.typeParameters()) && this.variance().equals(o.variance()) && this.lowerBound().equals(o.lowerBound()) && this.upperBound().equals(o.upperBound());
         }
     }
     public int hashCode() {
-        return 37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.api.TypeParameter".hashCode()) + id().hashCode()) + annotations().hashCode()) + typeParameters().hashCode()) + variance().hashCode()) + lowerBound().hashCode()) + upperBound().hashCode());
+        return 37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.api.TypeParameter".hashCode()) + id().hashCode()) + java.util.Arrays.deepHashCode(annotations())) + java.util.Arrays.deepHashCode(typeParameters())) + variance().hashCode()) + lowerBound().hashCode()) + upperBound().hashCode());
     }
     public String toString() {
         return "TypeParameter("  + "id: " + id() + ", " + "annotations: " + annotations() + ", " + "typeParameters: " + typeParameters() + ", " + "variance: " + variance() + ", " + "lowerBound: " + lowerBound() + ", " + "upperBound: " + upperBound() + ")";

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/Val.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/Val.java
@@ -40,11 +40,11 @@ public final class Val extends xsbti.api.FieldLike {
             return false;
         } else {
             Val o = (Val)obj;
-            return name().equals(o.name()) && access().equals(o.access()) && modifiers().equals(o.modifiers()) && java.util.Arrays.deepEquals(annotations(), o.annotations()) && tpe().equals(o.tpe());
+            return this.name().equals(o.name()) && this.access().equals(o.access()) && this.modifiers().equals(o.modifiers()) && java.util.Arrays.deepEquals(this.annotations(), o.annotations()) && this.tpe().equals(o.tpe());
         }
     }
     public int hashCode() {
-        return 37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.api.Val".hashCode()) + name().hashCode()) + access().hashCode()) + modifiers().hashCode()) + annotations().hashCode()) + tpe().hashCode());
+        return 37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.api.Val".hashCode()) + name().hashCode()) + access().hashCode()) + modifiers().hashCode()) + java.util.Arrays.deepHashCode(annotations())) + tpe().hashCode());
     }
     public String toString() {
         return "Val("  + "name: " + name() + ", " + "access: " + access() + ", " + "modifiers: " + modifiers() + ", " + "annotations: " + annotations() + ", " + "tpe: " + tpe() + ")";

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/api/Var.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/api/Var.java
@@ -40,11 +40,11 @@ public final class Var extends xsbti.api.FieldLike {
             return false;
         } else {
             Var o = (Var)obj;
-            return name().equals(o.name()) && access().equals(o.access()) && modifiers().equals(o.modifiers()) && java.util.Arrays.deepEquals(annotations(), o.annotations()) && tpe().equals(o.tpe());
+            return this.name().equals(o.name()) && this.access().equals(o.access()) && this.modifiers().equals(o.modifiers()) && java.util.Arrays.deepEquals(this.annotations(), o.annotations()) && this.tpe().equals(o.tpe());
         }
     }
     public int hashCode() {
-        return 37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.api.Var".hashCode()) + name().hashCode()) + access().hashCode()) + modifiers().hashCode()) + annotations().hashCode()) + tpe().hashCode());
+        return 37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.api.Var".hashCode()) + name().hashCode()) + access().hashCode()) + modifiers().hashCode()) + java.util.Arrays.deepHashCode(annotations())) + tpe().hashCode());
     }
     public String toString() {
         return "Var("  + "name: " + name() + ", " + "access: " + access() + ", " + "modifiers: " + modifiers() + ", " + "annotations: " + annotations() + ", " + "tpe: " + tpe() + ")";

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/compile/ClasspathOptions.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/compile/ClasspathOptions.java
@@ -87,7 +87,7 @@ public final class ClasspathOptions implements java.io.Serializable {
             return false;
         } else {
             ClasspathOptions o = (ClasspathOptions)obj;
-            return (bootLibrary() == o.bootLibrary()) && (compiler() == o.compiler()) && (extra() == o.extra()) && (autoBoot() == o.autoBoot()) && (filterLibrary() == o.filterLibrary());
+            return (this.bootLibrary() == o.bootLibrary()) && (this.compiler() == o.compiler()) && (this.extra() == o.extra()) && (this.autoBoot() == o.autoBoot()) && (this.filterLibrary() == o.filterLibrary());
         }
     }
     public int hashCode() {

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/compile/CompileOptions.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/compile/CompileOptions.java
@@ -115,11 +115,11 @@ public final class CompileOptions implements java.io.Serializable {
             return false;
         } else {
             CompileOptions o = (CompileOptions)obj;
-            return java.util.Arrays.deepEquals(classpath(), o.classpath()) && java.util.Arrays.deepEquals(sources(), o.sources()) && classesDirectory().equals(o.classesDirectory()) && java.util.Arrays.deepEquals(scalacOptions(), o.scalacOptions()) && java.util.Arrays.deepEquals(javacOptions(), o.javacOptions()) && (maxErrors() == o.maxErrors()) && sourcePositionMapper().equals(o.sourcePositionMapper()) && order().equals(o.order());
+            return java.util.Arrays.deepEquals(this.classpath(), o.classpath()) && java.util.Arrays.deepEquals(this.sources(), o.sources()) && this.classesDirectory().equals(o.classesDirectory()) && java.util.Arrays.deepEquals(this.scalacOptions(), o.scalacOptions()) && java.util.Arrays.deepEquals(this.javacOptions(), o.javacOptions()) && (this.maxErrors() == o.maxErrors()) && this.sourcePositionMapper().equals(o.sourcePositionMapper()) && this.order().equals(o.order());
         }
     }
     public int hashCode() {
-        return 37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.compile.CompileOptions".hashCode()) + classpath().hashCode()) + sources().hashCode()) + classesDirectory().hashCode()) + scalacOptions().hashCode()) + javacOptions().hashCode()) + (new Integer(maxErrors())).hashCode()) + sourcePositionMapper().hashCode()) + order().hashCode());
+        return 37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.compile.CompileOptions".hashCode()) + java.util.Arrays.deepHashCode(classpath())) + java.util.Arrays.deepHashCode(sources())) + classesDirectory().hashCode()) + java.util.Arrays.deepHashCode(scalacOptions())) + java.util.Arrays.deepHashCode(javacOptions())) + (new Integer(maxErrors())).hashCode()) + sourcePositionMapper().hashCode()) + order().hashCode());
     }
     public String toString() {
         return "CompileOptions("  + "classpath: " + classpath() + ", " + "sources: " + sources() + ", " + "classesDirectory: " + classesDirectory() + ", " + "scalacOptions: " + scalacOptions() + ", " + "javacOptions: " + javacOptions() + ", " + "maxErrors: " + maxErrors() + ", " + "sourcePositionMapper: " + sourcePositionMapper() + ", " + "order: " + order() + ")";

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/compile/CompileResult.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/compile/CompileResult.java
@@ -48,7 +48,7 @@ public final class CompileResult implements java.io.Serializable {
             return false;
         } else {
             CompileResult o = (CompileResult)obj;
-            return analysis().equals(o.analysis()) && setup().equals(o.setup()) && (hasModified() == o.hasModified());
+            return this.analysis().equals(o.analysis()) && this.setup().equals(o.setup()) && (this.hasModified() == o.hasModified());
         }
     }
     public int hashCode() {

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/compile/Compilers.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/compile/Compilers.java
@@ -44,7 +44,7 @@ public final class Compilers implements java.io.Serializable {
             return false;
         } else {
             Compilers o = (Compilers)obj;
-            return scalac().equals(o.scalac()) && javaTools().equals(o.javaTools());
+            return this.scalac().equals(o.scalac()) && this.javaTools().equals(o.javaTools());
         }
     }
     public int hashCode() {

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/compile/FileHash.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/compile/FileHash.java
@@ -39,7 +39,7 @@ public final class FileHash implements java.io.Serializable {
             return false;
         } else {
             FileHash o = (FileHash)obj;
-            return file().equals(o.file()) && (hash() == o.hash());
+            return this.file().equals(o.file()) && (this.hash() == o.hash());
         }
     }
     public int hashCode() {

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/compile/IncOptions.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/compile/IncOptions.java
@@ -265,7 +265,7 @@ public final class IncOptions implements java.io.Serializable {
             return false;
         } else {
             IncOptions o = (IncOptions)obj;
-            return (transitiveStep() == o.transitiveStep()) && (recompileAllFraction() == o.recompileAllFraction()) && (relationsDebug() == o.relationsDebug()) && (apiDebug() == o.apiDebug()) && (apiDiffContextSize() == o.apiDiffContextSize()) && apiDumpDirectory().equals(o.apiDumpDirectory()) && classfileManagerType().equals(o.classfileManagerType()) && (useCustomizedFileManager() == o.useCustomizedFileManager()) && recompileOnMacroDef().equals(o.recompileOnMacroDef()) && (useOptimizedSealed() == o.useOptimizedSealed()) && (storeApis() == o.storeApis()) && (enabled() == o.enabled()) && extra().equals(o.extra()) && (logRecompileOnMacro() == o.logRecompileOnMacro()) && externalHooks().equals(o.externalHooks());
+            return (this.transitiveStep() == o.transitiveStep()) && (this.recompileAllFraction() == o.recompileAllFraction()) && (this.relationsDebug() == o.relationsDebug()) && (this.apiDebug() == o.apiDebug()) && (this.apiDiffContextSize() == o.apiDiffContextSize()) && this.apiDumpDirectory().equals(o.apiDumpDirectory()) && this.classfileManagerType().equals(o.classfileManagerType()) && (this.useCustomizedFileManager() == o.useCustomizedFileManager()) && this.recompileOnMacroDef().equals(o.recompileOnMacroDef()) && (this.useOptimizedSealed() == o.useOptimizedSealed()) && (this.storeApis() == o.storeApis()) && (this.enabled() == o.enabled()) && this.extra().equals(o.extra()) && (this.logRecompileOnMacro() == o.logRecompileOnMacro()) && this.externalHooks().equals(o.externalHooks());
         }
     }
     public int hashCode() {

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/compile/IncToolOptions.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/compile/IncToolOptions.java
@@ -48,7 +48,7 @@ public final class IncToolOptions implements java.io.Serializable {
             return false;
         } else {
             IncToolOptions o = (IncToolOptions)obj;
-            return classFileManager().equals(o.classFileManager()) && (useCustomizedFileManager() == o.useCustomizedFileManager());
+            return this.classFileManager().equals(o.classFileManager()) && (this.useCustomizedFileManager() == o.useCustomizedFileManager());
         }
     }
     public int hashCode() {

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/compile/Inputs.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/compile/Inputs.java
@@ -59,7 +59,7 @@ public final class Inputs implements java.io.Serializable {
             return false;
         } else {
             Inputs o = (Inputs)obj;
-            return compilers().equals(o.compilers()) && options().equals(o.options()) && setup().equals(o.setup()) && previousResult().equals(o.previousResult());
+            return this.compilers().equals(o.compilers()) && this.options().equals(o.options()) && this.setup().equals(o.setup()) && this.previousResult().equals(o.previousResult());
         }
     }
     public int hashCode() {

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/compile/MiniOptions.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/compile/MiniOptions.java
@@ -53,11 +53,11 @@ public final class MiniOptions implements java.io.Serializable {
             return false;
         } else {
             MiniOptions o = (MiniOptions)obj;
-            return java.util.Arrays.deepEquals(classpathHash(), o.classpathHash()) && java.util.Arrays.deepEquals(scalacOptions(), o.scalacOptions()) && java.util.Arrays.deepEquals(javacOptions(), o.javacOptions());
+            return java.util.Arrays.deepEquals(this.classpathHash(), o.classpathHash()) && java.util.Arrays.deepEquals(this.scalacOptions(), o.scalacOptions()) && java.util.Arrays.deepEquals(this.javacOptions(), o.javacOptions());
         }
     }
     public int hashCode() {
-        return 37 * (37 * (37 * (37 * (17 + "xsbti.compile.MiniOptions".hashCode()) + classpathHash().hashCode()) + scalacOptions().hashCode()) + javacOptions().hashCode());
+        return 37 * (37 * (37 * (37 * (17 + "xsbti.compile.MiniOptions".hashCode()) + java.util.Arrays.deepHashCode(classpathHash())) + java.util.Arrays.deepHashCode(scalacOptions())) + java.util.Arrays.deepHashCode(javacOptions()));
     }
     public String toString() {
         return "MiniOptions("  + "classpathHash: " + classpathHash() + ", " + "scalacOptions: " + scalacOptions() + ", " + "javacOptions: " + javacOptions() + ")";

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/compile/MiniSetup.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/compile/MiniSetup.java
@@ -72,11 +72,11 @@ public final class MiniSetup implements java.io.Serializable {
             return false;
         } else {
             MiniSetup o = (MiniSetup)obj;
-            return output().equals(o.output()) && options().equals(o.options()) && compilerVersion().equals(o.compilerVersion()) && order().equals(o.order()) && (storeApis() == o.storeApis()) && java.util.Arrays.deepEquals(extra(), o.extra());
+            return this.output().equals(o.output()) && this.options().equals(o.options()) && this.compilerVersion().equals(o.compilerVersion()) && this.order().equals(o.order()) && (this.storeApis() == o.storeApis()) && java.util.Arrays.deepEquals(this.extra(), o.extra());
         }
     }
     public int hashCode() {
-        return 37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.compile.MiniSetup".hashCode()) + output().hashCode()) + options().hashCode()) + compilerVersion().hashCode()) + order().hashCode()) + (new Boolean(storeApis())).hashCode()) + extra().hashCode());
+        return 37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.compile.MiniSetup".hashCode()) + output().hashCode()) + options().hashCode()) + compilerVersion().hashCode()) + order().hashCode()) + (new Boolean(storeApis())).hashCode()) + java.util.Arrays.deepHashCode(extra()));
     }
     public String toString() {
         return "MiniSetup("  + "output: " + output() + ", " + "options: " + options() + ", " + "compilerVersion: " + compilerVersion() + ", " + "order: " + order() + ", " + "storeApis: " + storeApis() + ", " + "extra: " + extra() + ")";

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/compile/PreviousResult.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/compile/PreviousResult.java
@@ -40,7 +40,7 @@ public final class PreviousResult implements java.io.Serializable {
             return false;
         } else {
             PreviousResult o = (PreviousResult)obj;
-            return analysis().equals(o.analysis()) && setup().equals(o.setup());
+            return this.analysis().equals(o.analysis()) && this.setup().equals(o.setup());
         }
     }
     public int hashCode() {

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/compile/Setup.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/compile/Setup.java
@@ -96,11 +96,11 @@ public final class Setup implements java.io.Serializable {
             return false;
         } else {
             Setup o = (Setup)obj;
-            return perClasspathEntryLookup().equals(o.perClasspathEntryLookup()) && (skip() == o.skip()) && cacheFile().equals(o.cacheFile()) && cache().equals(o.cache()) && incrementalCompilerOptions().equals(o.incrementalCompilerOptions()) && reporter().equals(o.reporter()) && progress().equals(o.progress()) && java.util.Arrays.deepEquals(extra(), o.extra());
+            return this.perClasspathEntryLookup().equals(o.perClasspathEntryLookup()) && (this.skip() == o.skip()) && this.cacheFile().equals(o.cacheFile()) && this.cache().equals(o.cache()) && this.incrementalCompilerOptions().equals(o.incrementalCompilerOptions()) && this.reporter().equals(o.reporter()) && this.progress().equals(o.progress()) && java.util.Arrays.deepEquals(this.extra(), o.extra());
         }
     }
     public int hashCode() {
-        return 37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.compile.Setup".hashCode()) + perClasspathEntryLookup().hashCode()) + (new Boolean(skip())).hashCode()) + cacheFile().hashCode()) + cache().hashCode()) + incrementalCompilerOptions().hashCode()) + reporter().hashCode()) + progress().hashCode()) + extra().hashCode());
+        return 37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.compile.Setup".hashCode()) + perClasspathEntryLookup().hashCode()) + (new Boolean(skip())).hashCode()) + cacheFile().hashCode()) + cache().hashCode()) + incrementalCompilerOptions().hashCode()) + reporter().hashCode()) + progress().hashCode()) + java.util.Arrays.deepHashCode(extra()));
     }
     public String toString() {
         return "Setup("  + "perClasspathEntryLookup: " + perClasspathEntryLookup() + ", " + "skip: " + skip() + ", " + "cacheFile: " + cacheFile() + ", " + "cache: " + cache() + ", " + "incrementalCompilerOptions: " + incrementalCompilerOptions() + ", " + "reporter: " + reporter() + ", " + "progress: " + progress() + ", " + "extra: " + extra() + ")";

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/compile/TransactionalManagerType.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/compile/TransactionalManagerType.java
@@ -44,7 +44,7 @@ public final class TransactionalManagerType extends xsbti.compile.ClassFileManag
             return false;
         } else {
             TransactionalManagerType o = (TransactionalManagerType)obj;
-            return backupDirectory().equals(o.backupDirectory()) && logger().equals(o.logger());
+            return this.backupDirectory().equals(o.backupDirectory()) && this.logger().equals(o.logger());
         }
     }
     public int hashCode() {

--- a/internal/zinc-compile-core/src/main/contraband-java/xsbti/ReporterConfig.java
+++ b/internal/zinc-compile-core/src/main/contraband-java/xsbti/ReporterConfig.java
@@ -79,11 +79,11 @@ public final class ReporterConfig implements java.io.Serializable {
             return false;
         } else {
             ReporterConfig o = (ReporterConfig)obj;
-            return loggerName().equals(o.loggerName()) && (maximumErrors() == o.maximumErrors()) && (useColor() == o.useColor()) && java.util.Arrays.deepEquals(msgFilters(), o.msgFilters()) && java.util.Arrays.deepEquals(fileFilters(), o.fileFilters()) && logLevel().equals(o.logLevel()) && positionMapper().equals(o.positionMapper());
+            return this.loggerName().equals(o.loggerName()) && (this.maximumErrors() == o.maximumErrors()) && (this.useColor() == o.useColor()) && java.util.Arrays.deepEquals(this.msgFilters(), o.msgFilters()) && java.util.Arrays.deepEquals(this.fileFilters(), o.fileFilters()) && this.logLevel().equals(o.logLevel()) && this.positionMapper().equals(o.positionMapper());
         }
     }
     public int hashCode() {
-        return 37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.ReporterConfig".hashCode()) + loggerName().hashCode()) + (new Integer(maximumErrors())).hashCode()) + (new Boolean(useColor())).hashCode()) + msgFilters().hashCode()) + fileFilters().hashCode()) + logLevel().hashCode()) + positionMapper().hashCode());
+        return 37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.ReporterConfig".hashCode()) + loggerName().hashCode()) + (new Integer(maximumErrors())).hashCode()) + (new Boolean(useColor())).hashCode()) + java.util.Arrays.deepHashCode(msgFilters())) + java.util.Arrays.deepHashCode(fileFilters())) + logLevel().hashCode()) + positionMapper().hashCode());
     }
     public String toString() {
         return "ReporterConfig("  + "loggerName: " + loggerName() + ", " + "maximumErrors: " + maximumErrors() + ", " + "useColor: " + useColor() + ", " + "msgFilters: " + msgFilters() + ", " + "fileFilters: " + fileFilters() + ", " + "logLevel: " + logLevel() + ", " + "positionMapper: " + positionMapper() + ")";

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,9 +7,9 @@ object Dependencies {
   val scala212 = "2.12.4"
   val scala213 = "2.13.0-M2"
 
-  private val ioVersion = "1.1.3"
-  private val utilVersion = "1.1.2"
-  private val lmVersion = "1.1.2"
+  private val ioVersion = "1.1.4"
+  private val utilVersion = "1.1.3"
+  private val lmVersion = "1.1.4"
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.scala-sbt" % "sbt-houserules" % "0.3.5")
-addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.3.2")
+addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.4.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.3")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "3.0.2")
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.12-rc5")


### PR DESCRIPTION
This bumps Contraband to 0.4.0 to fix equal/hashCode inconsistencies (https://github.com/sbt/contraband/issues/119).

originally reported by @smarter on zinc-contrib Gitter:

> Observe: https://github.com/sbt/zinc/blob/1.x/internal/compiler-interface/src/main/contraband-java/xsbti/api/Path.java
`equals` uses `Arrays.deepEquals` to compare arrays, but `hashcode` uses the regular array `hashCode` instead of `Arrays.deepHashCode`.


