### PR TITLE
Fixes the reflection fallback for ScalaInstance

### DIFF
--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/ScalaInstance.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/ScalaInstance.scala
@@ -167,7 +167,7 @@ object ScalaInstance {
           case p: ScalaProvider2 @unchecked => Option((provider.loader, p.loaderLibraryOnly))
         }
       } catch {
-        case _: NoSuchMethodError => None
+        case _: NoSuchMethodException => None
       }) getOrElse fallbackClassLoaders
     }
     new ScalaInstance(version, loader, loaderLibraryOnly, libraryJar, compilerJar, jars, None)


### PR DESCRIPTION
I think I've made a mistake in https://github.com/sbt/zinc/pull/505 by using NoSuchMethodError. When trying to use Zinc 1.1.2, I ran into `java.lang.NoSuchMethodException`.
This is because `NoSuchMethodException` would be thrown for reflective calls, not `NoSuchMethodError`.