### PR TITLE
Parse classfile to extract inner class info

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -479,6 +479,13 @@ lazy val zincClassfile = (project in internalPath / "zinc-classfile")
     crossScalaVersions := compilerBridgeTestScalaVersions,
     relaxNon212,
     mimaSettings,
+    mimaBinaryIssueFilters ++= {
+      import com.typesafe.tools.mima.core._
+      import com.typesafe.tools.mima.core.ProblemFilters._
+      Seq(
+        exclude[ReversedMissingMethodProblem]("sbt.internal.inc.classfile.ClassFile.innerClasses"),
+      )
+    },
   )
   .configure(addSbtIO, addSbtUtilLogging)
 

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/ClassFile.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/ClassFile.scala
@@ -26,6 +26,7 @@ private[sbt] trait ClassFile {
   val sourceFile: Option[String]
   def types: Set[String]
   def stringValue(a: AttributeInfo): String
+  def innerClasses: Array[InnerClassInfo]
 
   /**
    * If the given fieldName represents a ConstantValue field, parses its representation from
@@ -85,7 +86,17 @@ private[sbt] final case class AttributeInfo(name: Option[String], value: Array[B
   def isNamed(s: String) = name.exists(s == _)
   def isSignature = isNamed("Signature")
   def isSourceFile = isNamed("SourceFile")
+  def isInnerClasses = isNamed("InnerClasses")
 }
+
+private[sbt] final case class InnerClassInfo(accessFlags: Int,
+                                             innerName: Option[String],
+                                             innerClassName: String,
+                                             outerClassName: String) {
+  def isStatic = (accessFlags & ACC_STATIC) == ACC_STATIC
+  def isPublic = (accessFlags & ACC_PUBLIC) == ACC_PUBLIC
+}
+
 private[sbt] object Constants {
   final val ACC_STATIC = 0x0008
   final val ACC_PUBLIC = 0x0001


### PR DESCRIPTION
Fixes sbt/sbt#117

I was browsing around old sbt issue, and still was able to reproduce sbt/sbt#117 using https://github.com/duboisf/sbt_issue_117_example, so I fixed it.

Inside `ClassToAPI`, Java reflection is used to calculate the inner classes. Under certain circumstances this fails to load some of the classes and result to a `NoClassDefFoundError`.
I've switched to parse the classfile manually, and wrapped `cl.loadClass` with a try-catch. I was able to confirm the fix using sbt_issue_117_example.
