### PR TITLE
Cleanup DiagnosticsReporter.PositionImpl & upgrade to JDK7+

### DIFF
--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/DiagnosticsReporter.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/DiagnosticsReporter.scala
@@ -142,8 +142,7 @@ object DiagnosticsReporter {
               case _ => None
             }
           } catch {
-            // TODO - catch ReflectiveOperationException once sbt is migrated to JDK7
-            case _: Throwable => None
+            case _: ReflectiveOperationException => None
           }
 
         def getExpression: String =


### PR DESCRIPTION
I was having a look at https://github.com/sbt/zinc/issues/459.

Looks like we depend (via reflection) on private JDK APIs that haven't since been made public.. so the fix isn't as straightforward as one would hope.