### PR TITLE
Remove unnecessary, and incorrect, Java error message translation

### DIFF
--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/DiagnosticsReporter.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/DiagnosticsReporter.scala
@@ -31,30 +31,6 @@ final class DiagnosticsReporter(reporter: Reporter) extends DiagnosticListener[J
   private[this] var errorEncountered = false
   def hasErrors: Boolean = errorEncountered
 
-  private def fixedDiagnosticMessage(d: Diagnostic[_ <: JavaFileObject]): String = {
-    def getRawMessage = d.getMessage(null)
-    def fixWarnOrErrorMessage = {
-      val tmp = getRawMessage
-      // we fragment off the line/source/type report from the message.
-      // NOTE - End of line handling may be off.
-      val lines: Seq[String] =
-        tmp.split(END_OF_LINE_MATCHER) match {
-          case Array(head, tail @ _*) =>
-            val newHead = head.split(":").last
-            newHead +: tail
-          case Array(head) =>
-            head.split(":").last :: Nil
-          case Array() => Seq.empty[String]
-        }
-      lines.mkString(EOL)
-    }
-    d.getKind match {
-      case Diagnostic.Kind.ERROR | Diagnostic.Kind.WARNING | Diagnostic.Kind.MANDATORY_WARNING =>
-        fixWarnOrErrorMessage
-      case _ => getRawMessage
-    }
-  }
-
   override def report(d: Diagnostic[_ <: JavaFileObject]): Unit = {
     val severity: Severity = {
       d.getKind match {
@@ -65,7 +41,7 @@ final class DiagnosticsReporter(reporter: Reporter) extends DiagnosticListener[J
     }
 
     import sbt.util.InterfaceUtil.problem
-    val msg = fixedDiagnosticMessage(d)
+    val msg = d.getMessage(null)
     val pos: xsbti.Position = PositionImpl(d)
     if (severity == Severity.Error) errorEncountered = true
     reporter.log(problem("", pos, msg, severity))


### PR DESCRIPTION
Given:

```java
class C {
    class D {}
    void test() {
        D.this.toString();
    }
}
```

Before:

```
⚡ sbt compile
[info] Loading settings from dirtymoney.sbt,gpg.sbt,idea.sbt ...
[info] Loading global plugins from /Users/jz/.sbt/1.0/plugins
[info] Loading project definition from /private/tmp/javac-diagnostic/project
[info] Set current project to javac-diagnostic (in build file:/private/tmp/javac-diagnostic/)
[info] Executing in batch mode. For better performance use sbt's shell
[info] Compiling 1 Java source to /private/tmp/javac-diagnostic/target/scala-2.12/classes ...
[error] /private/tmp/javac-diagnostic/src/main/java/example/Test.java:4:1:  C.D
[error]         D.this.toString();
[error] (Compile / compileIncremental) javac returned non-zero exit code
[error] Total time: 0 s, completed 05/04/2018 12:52:16 PM
/tmp/javac-diagnostic
```

After:

```
⚡ sbt -sbt-version 1.1.3-pre-98d08039e
Getting org.scala-sbt sbt 1.1.3-pre-98d08039e  (this may take some time)...
:: retrieving :: org.scala-sbt#boot-app
    confs: [default]
    77 artifacts copied, 0 already retrieved (27803kB/251ms)
...
[info] Set current project to javac-diagnostic (in build file:/private/tmp/javac-diagnostic/)
[info] sbt server started at local:///Users/jz/.sbt/1.0/server/3cc671e1c4b514e4d201/sock
sbt:javac-diagnostic> compile
[info] Compiling 1 Java source to /private/tmp/javac-diagnostic/target/scala-2.12/classes ...
[error] /private/tmp/javac-diagnostic/src/main/java/example/Test.java:4:1: not an enclosing class: C.D
[error]         D.this.toString();
[error] (Compile / compileIncremental) javac returned non-zero exit code
[error] Total time: 0 s, completed 05/04/2018 1:02:53 PM
sbt:javac-diagnostic>
```

Fixes #523