### PR TITLE
Disable recompile all fraction for all scripted tests

### DIFF
--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -473,8 +473,14 @@ case class ProjectStructure(
       val scalacOptions =
         Option(map.get("scalac.options")).map(_.toString.split(" +")).getOrElse(Array.empty)
 
-      (IncOptionsUtil.fromStringMap(map, scriptedLog), scalacOptions)
-    } else (IncOptions.of(), Array.empty)
+      val incOptions = {
+        val opts = IncOptionsUtil.fromStringMap(map, scriptedLog)
+        if (opts.recompileAllFraction() != IncOptions.defaultRecompileAllFraction()) opts
+        else opts.withRecompileAllFraction(1.0)
+      }
+
+      (incOptions, scalacOptions)
+    } else (IncOptions.of().withRecompileAllFraction(1.0), Array.empty)
   }
 
   def getProblems(): Seq[Problem] =

--- a/zinc/src/sbt-test/source-dependencies/transitive-class/test
+++ b/zinc/src/sbt-test/source-dependencies/transitive-class/test
@@ -1,3 +1,3 @@
 > compile
 $ copy-file changes/A.scala A.scala
-> checkRecompilations 2 A B C D Hello
+> checkRecompilations 2 B C D Hello


### PR DESCRIPTION
The default for recompile all fraction is 0.5, which means that if the changes
done in an scripted test affect more than 50% of all the tests, a test could
pass because all files are recompiled even though it should fail.

To protect us from this potential issue, this patch tweaks the value of the
recompile all fraction for scripted so that full recompilation is disabled for
our scripted tests.