### PR TITLE
Add Bloop scripted integration

### DIFF
--- a/bin/run-ci.sh
+++ b/bin/run-ci.sh
@@ -12,6 +12,7 @@ sbt -Dfile.encoding=UTF-8 \
   whitesourceCheckPolicies \
   compilerInterfaceJava6Compat/compile \
   zincRoot/test:compile \
+  bloopScripted/compile \
   crossTestBridges \
   "publishBridgesAndSet $SCALA_VERSION" \
   zincRoot/test \

--- a/build.sbt
+++ b/build.sbt
@@ -502,6 +502,21 @@ lazy val zincScripted = (project in internalPath / "zinc-scripted")
   )
   .configure(addSbtUtilScripted)
 
+// re-implementation of scripted engine as a standalone main
+lazy val bloopScripted = (project in internalPath / "zinc-scripted-bloop")
+  .dependsOn(zinc, zincScripted % "compile->test")
+  .settings(
+    minimalSettings,
+    noPublish,
+    name := "zinc Scripted Bloop",
+    scalaVersion := scala212,
+    crossScalaVersions := List(scala212),
+    libraryDependencies ++= List(
+      "org.scala-sbt" %% "completion" % sbtVersion.value,
+      "ch.epfl.scala" %% "bloop-config" % "1.0.0-M9",
+    )
+  )
+
 lazy val crossTestBridges = {
   Command.command("crossTestBridges") { state =>
     (compilerBridgeTestScalaVersions.flatMap { (bridgeVersion: String) =>

--- a/internal/zinc-scripted-bloop/src/main/scala/ScriptedMain.scala
+++ b/internal/zinc-scripted-bloop/src/main/scala/ScriptedMain.scala
@@ -1,0 +1,110 @@
+package sbt.inc
+
+import java.io.File
+import java.nio.file.Path
+
+import sbt.io.syntax._
+import sbt.internal.util.complete.Parser
+import sbt.internal.util.complete.Parser._
+import sbt.internal.util.complete.Parsers._
+import sbt.io.{ AllPassFilter, NameFilter }
+import bloop.config.{ Config, ConfigDecoders }
+import metaconfig.{ Conf, Configured }
+import org.langmeta.inputs.Input
+
+object ScriptedMain {
+  def main(args: Array[String]): Unit = {
+    val workingDirectory = file(System.getProperty("user.dir"))
+    val bloopDir = workingDirectory./(".bloop")
+    if (!bloopDir.exists()) {
+      System.err.println(s"Bloop config files missing in ${bloopDir.getAbsolutePath}")
+      System.exit(1)
+    } else {
+      val scripted = configFromFile(bloopDir./("zincScripted-test.json"))
+      val zinc = configFromFile(workingDirectory./(".bloop")./("zinc.json"))
+      val sourceDir = zinc.project.directory.resolve("src").resolve("sbt-test")
+      val fullClasspath = scripted.project.classesDir :: scripted.project.classpath.toList
+      val parser = scriptedParser(sourceDir.toFile)
+      val toParse = args.headOption.map(s => s" $s").getOrElse("")
+      Parser.parse(toParse, parser) match {
+        case Left(error) => System.err.println(s"Parser error: $error")
+        case Right(scriptedArgs) =>
+          val buffer: Boolean =
+            if (toParse.isEmpty) true
+            else args.tail.headOption.map(java.lang.Boolean.getBoolean(_)).getOrElse(true)
+          runScripted(fullClasspath, sourceDir, scriptedArgs, buffer)
+      }
+    }
+  }
+
+  private def configFromFile(config: File): Config.File = {
+    import metaconfig.typesafeconfig.typesafeConfigMetaconfigParser
+    println(s"Loading project from '$config'")
+    val input = Input.File(config)
+    val configured = Conf.parseInput(input)(typesafeConfigMetaconfigParser)
+    ConfigDecoders.allConfigDecoder.read(configured) match {
+      case Configured.Ok(file)     => file
+      case Configured.NotOk(error) => sys.error(error.toString())
+    }
+  }
+
+  private def scriptedParser(scriptedBase: File): Parser[Seq[String]] = {
+    case class ScriptedTestPage(page: Int, total: Int)
+    val scriptedFiles: NameFilter = ("test": NameFilter) | "pending"
+    val pairs = (scriptedBase * AllPassFilter * AllPassFilter * scriptedFiles).get map {
+      (f: File) =>
+        val p = f.getParentFile
+        (p.getParentFile.getName, p.getName)
+    }
+    val pairMap = pairs.groupBy(_._1).mapValues(_.map(_._2).toSet);
+
+    val id = charClass(c => !c.isWhitespace && c != '/').+.string
+    val groupP = token(id.examples(pairMap.keySet.toSet)) <~ token('/')
+
+    // A parser for page definitions
+    val pageP: Parser[ScriptedTestPage] = ("*" ~ NatBasic ~ "of" ~ NatBasic) map {
+      case _ ~ page ~ _ ~ total => ScriptedTestPage(page, total)
+    }
+
+    // Grabs the filenames from a given test group in the current page definition.
+    def pagedFilenames(group: String, page: ScriptedTestPage): Seq[String] = {
+      val files = pairMap(group).toSeq.sortBy(_.toLowerCase)
+      val pageSize = files.size / page.total
+      // The last page may loose some values, so we explicitly keep them
+      val dropped = files.drop(pageSize * (page.page - 1))
+      if (page.page == page.total) dropped
+      else dropped.take(pageSize)
+    }
+
+    def nameP(group: String) = {
+      token("*".id | id.examples(pairMap(group)))
+    }
+
+    val PagedIds: Parser[Seq[String]] =
+      for {
+        group <- groupP
+        page <- pageP
+        files = pagedFilenames(group, page)
+      } yield files map (f => group + '/' + f)
+
+    val testID = (for (group <- groupP; name <- nameP(group)) yield (group, name))
+    val testIdAsGroup = matched(testID) map (test => Seq(test))
+    (token(Space) ~> (PagedIds | testIdAsGroup)).* map (_.flatten)
+  }
+
+  type IncScriptedRunner = {
+    def run(resourceBaseDirectory: File, bufferLog: Boolean, tests: Array[String]): Unit
+  }
+
+  import sbt.internal.inc.classpath.ClasspathUtilities
+  def runScripted(classpath: Seq[Path], source: Path, args: Seq[String], buffer: Boolean): Unit = {
+    println(s"About to run tests: ${args.mkString("\n * ", "\n * ", "\n")}")
+    // Force Log4J to not use a thread context classloader otherwise it throws a CCE
+    sys.props(org.apache.logging.log4j.util.LoaderUtil.IGNORE_TCCL_PROPERTY) = "true"
+    val loader = ClasspathUtilities.toLoader(classpath.map(_.toFile))
+    val bridgeClass = Class.forName("sbt.internal.inc.IncScriptedRunner", true, loader)
+    val bridge = bridgeClass.newInstance.asInstanceOf[IncScriptedRunner]
+    try bridge.run(source.toFile, buffer, args.toArray)
+    catch { case ite: java.lang.reflect.InvocationTargetException => throw ite.getCause }
+  }
+}

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/ScriptedHandlers.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/ScriptedHandlers.scala
@@ -18,7 +18,7 @@ class SleepingHandler(val handler: StatementHandler, delay: Long) extends Statem
 
 class IncScriptedHandlers(globalCacheDir: File) extends HandlersProvider {
   def getHandlers(config: ScriptConfig): Map[Char, StatementHandler] = Map(
-    '$' -> new SleepingHandler(new FileCommands(config.testDirectory()), 500),
+    '$' -> new SleepingHandler(new ZincFileCommands(config.testDirectory()), 500),
     '#' -> CommentHandler,
     '>' -> {
       val logger: ManagedLogger =

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/ZincFileCommands.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/ZincFileCommands.scala
@@ -1,0 +1,18 @@
+package sbt.internal.inc
+
+import java.io.File
+
+import sbt.internal.scripted.FileCommands
+
+class ZincFileCommands(baseDirectory: File) extends FileCommands(baseDirectory) {
+  override def commandMap: Map[String, List[String] => Unit] = {
+    super.commandMap + {
+      "pause" noArg {
+        // Redefine pause not to use `System.console`, which is too restrictive
+        println(s"Pausing in $baseDirectory. Press enter to continue.")
+        scala.io.StdIn.readLine()
+        println("Restarting the execution.")
+      }
+    }
+  }
+}


### PR DESCRIPTION
I'd like to add upstream this tiny bloop scripted integration that extends the
zinc scripted infrastructure to be able to run it with bloop.

These are the benefits of running it with bloop:

1. Faster turnaround time and startup.
2. No need to publish jars before running.
3. Small maintenance cost.

This script still needs to be tweaked so that we can test different compiler
bridges at the same time. I think this is possible and I'd like to make this
change in a future PR.

Since @Duhemm and I hack on Zinc, we'd like to merge this upstream because
we believe it gives value to future contributors. We take ownership of it and
are happy to maintain it as bloop evolves.