### PR TITLE
Revert "Use Java collections"

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/ExtractAPI.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ExtractAPI.scala
@@ -9,12 +9,10 @@ package xsbt
 
 import java.io.File
 import java.util.{ Arrays, Comparator }
-
 import scala.tools.nsc.symtab.Flags
 import xsbti.api._
 
 import scala.annotation.tailrec
-import scala.collection.JavaConverters.asScalaIteratorConverter
 import scala.tools.nsc.Global
 
 /**
@@ -64,18 +62,17 @@ class ExtractAPI[GlobalType <: Global](
   // this cache reduces duplicate work both here and when persisting
   //   caches on other structures had minimal effect on time and cache size
   //   (tried: Definition, Modifier, Path, Id, String)
-
-  private[this] val typeCache = new java.util.HashMap[(Symbol, Type), xsbti.api.Type]()
+  private[this] val typeCache = perRunCaches.newAnyRefMap[(Symbol, Type), xsbti.api.Type]()
   // these caches are necessary for correctness
-  private[this] val structureCache = new java.util.HashMap[Symbol, xsbti.api.Structure]()
+  private[this] val structureCache = perRunCaches.newAnyRefMap[Symbol, xsbti.api.Structure]()
   private[this] val classLikeCache =
-    new java.util.HashMap[(Symbol, Symbol), xsbti.api.ClassLikeDef]()
-  private[this] val pending = new java.util.HashSet[xsbti.api.Lazy[_]]()
+    perRunCaches.newAnyRefMap[(Symbol, Symbol), xsbti.api.ClassLikeDef]()
+  private[this] val pending = perRunCaches.newSet[xsbti.api.Lazy[_]]()
 
   private[this] val emptyStringArray = Array.empty[String]
 
-  private[this] val allNonLocalClassesInSrc = new collection.mutable.HashSet[xsbti.api.ClassLike]()
-  private[this] val _mainClasses = new collection.mutable.HashSet[String]()
+  private[this] val allNonLocalClassesInSrc = perRunCaches.newSet[xsbti.api.ClassLike]()
+  private[this] val _mainClasses = perRunCaches.newSet[String]()
 
   /**
    * Implements a work-around for https://github.com/sbt/sbt/issues/823
@@ -156,7 +153,7 @@ class ExtractAPI[GlobalType <: Global](
    */
   private def lzy[S <: AnyRef](s: => S): xsbti.api.Lazy[S] = {
     val lazyImpl = xsbti.api.SafeLazy.apply(Message(s))
-    pending.add(lazyImpl)
+    pending += lazyImpl
     lazyImpl
   }
 
@@ -168,7 +165,7 @@ class ExtractAPI[GlobalType <: Global](
     if (pending.isEmpty)
       structureCache.clear()
     else {
-      val toProcess = pending.iterator().asScala.toList
+      val toProcess = pending.toList
       pending.clear()
       toProcess foreach { _.get() }
       forceStructures()
@@ -361,13 +358,9 @@ class ExtractAPI[GlobalType <: Global](
   }
 
   private def structure(info: Type, s: Symbol): xsbti.api.Structure =
-    structureCache.computeIfAbsent(s, new java.util.function.Function[Symbol, xsbti.api.Structure] {
-      def apply(key: Symbol) = mkStructure(info, s)
-    })
+    structureCache.getOrElseUpdate(s, mkStructure(info, s))
   private def structureWithInherited(info: Type, s: Symbol): xsbti.api.Structure =
-    structureCache.computeIfAbsent(s, new java.util.function.Function[Symbol, xsbti.api.Structure] {
-      def apply(key: Symbol) = mkStructureWithInherited(info, s)
-    })
+    structureCache.getOrElseUpdate(s, mkStructureWithInherited(info, s))
 
   private def removeConstructors(ds: List[Symbol]): List[Symbol] = ds filter { !_.isConstructor }
 
@@ -499,13 +492,10 @@ class ExtractAPI[GlobalType <: Global](
       else mapOver(tp)
   }
 
-  private def processType(in: Symbol, t: Type): xsbti.api.Type = {
-    typeCache.computeIfAbsent((in, t),
-                              new java.util.function.Function[(Symbol, Type), xsbti.api.Type] {
-                                def apply(key: (Symbol, Type)) = makeType(in, t)
-                              })
-  }
+  private def processType(in: Symbol, t: Type): xsbti.api.Type =
+    typeCache.getOrElseUpdate((in, t), makeType(in, t))
   private def makeType(in: Symbol, t: Type): xsbti.api.Type = {
+
     val dealiased = t match {
       case TypeRef(_, sym, _) if sym.isAliasType => t.dealias
       case _                                     => t
@@ -656,10 +646,7 @@ class ExtractAPI[GlobalType <: Global](
   }
 
   private def classLike(in: Symbol, c: Symbol): ClassLikeDef =
-    classLikeCache.computeIfAbsent((in, c), mkClassLike0)
-  private val mkClassLike0 = new java.util.function.Function[(Symbol, Symbol), ClassLikeDef] {
-    def apply(k: ((Symbol, Symbol))) = mkClassLike(k._1, k._2)
-  }
+    classLikeCache.getOrElseUpdate((in, c), mkClassLike(in, c))
   private def mkClassLike(in: Symbol, c: Symbol): ClassLikeDef = {
     // Normalize to a class symbol, and initialize it.
     // (An object -- aka module -- also has a term symbol,

--- a/internal/compiler-bridge/src/main/scala/xsbt/ExtractAPI.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ExtractAPI.scala
@@ -62,11 +62,11 @@ class ExtractAPI[GlobalType <: Global](
   // this cache reduces duplicate work both here and when persisting
   //   caches on other structures had minimal effect on time and cache size
   //   (tried: Definition, Modifier, Path, Id, String)
-  private[this] val typeCache = perRunCaches.newAnyRefMap[(Symbol, Type), xsbti.api.Type]()
+  private[this] val typeCache = perRunCaches.newMap[(Symbol, Type), xsbti.api.Type]()
   // these caches are necessary for correctness
-  private[this] val structureCache = perRunCaches.newAnyRefMap[Symbol, xsbti.api.Structure]()
+  private[this] val structureCache = perRunCaches.newMap[Symbol, xsbti.api.Structure]()
   private[this] val classLikeCache =
-    perRunCaches.newAnyRefMap[(Symbol, Symbol), xsbti.api.ClassLikeDef]()
+    perRunCaches.newMap[(Symbol, Symbol), xsbti.api.ClassLikeDef]()
   private[this] val pending = perRunCaches.newSet[xsbti.api.Lazy[_]]()
 
   private[this] val emptyStringArray = Array.empty[String]

--- a/internal/zinc-apiinfo/src/main/scala/xsbt/api/HashAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/xsbt/api/HashAPI.scala
@@ -62,19 +62,14 @@ final class HashAPI private (
 
   private[this] val visitedStructures = visitedMap[Structure]
   private[this] val visitedClassLike = visitedMap[ClassLike]
-  private[this] def visitedMap[T <: AnyRef] = new java.util.HashMap[T, List[Hash]]
-  private[this] def visit[T](map: java.util.HashMap[T, List[Hash]], t: T)(
-      hashF: T => Unit): Unit = {
-    val newVal = hash :: map.computeIfAbsent(t, new java.util.function.Function[T, List[Hash]] {
-      def apply(key: T) = Nil
-    })
-    map.put(t, newVal) match {
-      case x :: _ => extend(x)
+  private[this] def visitedMap[T <: AnyRef] = new mutable.AnyRefMap[T, List[Hash]]
+  private[this] def visit[T](map: mutable.Map[T, List[Hash]], t: T)(hashF: T => Unit): Unit = {
+    map.put(t, hash :: map.getOrElse(t, Nil)) match {
+      case Some(x :: _) => extend(x)
       case _ =>
         hashF(t)
-        map.get(t).foreach { hs =>
+        for (hs <- map(t))
           extend(hs)
-        }
         map.put(t, hash :: Nil)
         ()
     }

--- a/internal/zinc-apiinfo/src/main/scala/xsbt/api/HashAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/xsbt/api/HashAPI.scala
@@ -62,7 +62,7 @@ final class HashAPI private (
 
   private[this] val visitedStructures = visitedMap[Structure]
   private[this] val visitedClassLike = visitedMap[ClassLike]
-  private[this] def visitedMap[T <: AnyRef] = new mutable.AnyRefMap[T, List[Hash]]
+  private[this] def visitedMap[T] = new mutable.HashMap[T, List[Hash]]
   private[this] def visit[T](map: mutable.Map[T, List[Hash]], t: T)(hashF: T => Unit): Unit = {
     map.put(t, hash :: map.getOrElse(t, Nil)) match {
       case Some(x :: _) => extend(x)


### PR DESCRIPTION
This reverts commit 52959c9e40be56d17fdf92c8d3c2662911d3e4bd.
Fixes https://github.com/sbt/zinc/issues/538

The use of `java.util.HashMap` causes `java.util.ConcurrentModificationException` on JDK 9 and JDK 10. This is likely because `processType` recursively end up calling `processType` while modifying `typeCache`.