### PR TITLE
More readable logs

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/APIDiff.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/APIDiff.scala
@@ -144,9 +144,8 @@ private[inc] class APIDiff {
       val lastTokens = splitTokens(lastCode, Nil).toArray
 
       val diff = hirschberg(lastTokens, tokens)
-      val cleanDiff = dropNonChangedLines(diff)
 
-      cleanDiff.collect {
+      diff.collect {
         case Unmodified(str) => str
         case Inserted(str)   => ADDITION_COLOR + str + ANSI_DEFAULT
         case Modified(old, str) if printDiffDel =>
@@ -154,24 +153,6 @@ private[inc] class APIDiff {
         case Modified(_, str)             => ADDITION_COLOR + str + ANSI_DEFAULT
         case Deleted(str) if printDiffDel => DELETION_COLOR + str + ANSI_DEFAULT
       }.mkString
-    }
-
-    private def dropNonChangedLines(patches: Array[Patch]): Seq[Patch] = {
-      def recur(patches: List[Patch], result: List[List[Patch]]): List[List[Patch]] = {
-        if (patches.isEmpty) result.reverse
-        else {
-          val (line, rest) = patches.span {
-            case Modified(_, "\n") | Deleted("\n") | Inserted("\n") | Unmodified("\n") => false
-            case _                                                                     => true
-          }
-          val hasChanges = line.exists {
-            case _: Modified | _: Deleted | _: Inserted => true
-            case _: Unmodified                          => false
-          }
-          recur(rest.drop(1), if (hasChanges) (line ++ rest.take(1)) :: result else result)
-        }
-      }
-      recur(patches.toList, Nil).flatten
     }
 
     private sealed trait Patch

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Changes.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Changes.scala
@@ -73,7 +73,7 @@ final case class ModifiedNames(names: Set[UsedName]) {
     usedName.scopes.asScala.exists(scope => lookupMap.contains(usedName.name -> scope))
 
   override def toString: String =
-    s"ModifiedNames(changes = ${names.mkString(", ")})"
+    s"ModifiedNames(${names.mkString(", ")})"
 }
 object ModifiedNames {
   def compareTwoNameHashes(a: Array[NameHash], b: Array[NameHash]): ModifiedNames = {

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -76,7 +76,7 @@ object Incremental {
       else
         incremental.log.debug(
           "All initially invalidated classes: " + initialInvClasses + "\n" +
-            "All initially invalidated sources:" + initialInvSources + "\n")
+            "All initially invalidated sources: " + initialInvSources + "\n")
     val analysis = manageClassfiles(options) { classfileManager =>
       incremental.cycle(initialInvClasses,
                         initialInvSources,

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
@@ -111,16 +111,21 @@ private[inc] abstract class IncrementalCommon(val log: sbt.util.Logger, options:
     val invalidatedSources = classes.flatMap(previous.relations.definesClass) ++ modifiedSrcs
     val invalidatedSourcesForCompilation = expand(invalidatedSources, allSources)
     val pruned = Incremental.prune(invalidatedSourcesForCompilation, previous, classfileManager)
-    debug("********* Pruned: \n" + pruned.relations + "\n*********")
+    debugSection("Pruned")(pruned.relations)
 
     val fresh = doCompile(invalidatedSourcesForCompilation, binaryChanges)
     // For javac as class files are added to classfileManager as they are generated, so
     // this step is redundant. For scalac this is still necessary. TODO: do the same for scalac.
     classfileManager.generated(fresh.relations.allProducts.toArray)
-    debug("********* Fresh: \n" + fresh.relations + "\n*********")
+    debugSection("Fresh")(fresh.relations)
     val merged = pruned ++ fresh //.copy(relations = pruned.relations ++ fresh.relations, apis = pruned.apis ++ fresh.apis)
-    debug("********* Merged: \n" + merged.relations + "\n*********")
+    debugSection("Merged")(merged.relations)
     (merged, invalidatedSourcesForCompilation)
+  }
+
+  private[this] def debugSection(header: String)(content: => Any): Unit = {
+    import Console._
+    debug(s"$CYAN************* $header:$RESET\n$content\n$CYAN************* (end of $header)$RESET")
   }
 
   private[this] def emptyChanges: DependencyChanges = new DependencyChanges {

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
@@ -285,7 +285,7 @@ private[inc] abstract class IncrementalCommon(val log: sbt.util.Logger, options:
     val inv: Set[String] = propagated ++ dups
     val newlyInvalidated = (inv -- recompiledClasses) ++ dups
     log.debug(
-      "All newly invalidated classes after taking into account (previously) recompiled classes:" + newlyInvalidated)
+      "All newly invalidated classes after taking into account (previously) recompiled classes: " + newlyInvalidated)
     if (newlyInvalidated.isEmpty) Set.empty else inv
   }
 

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
@@ -118,9 +118,14 @@ private[inc] abstract class IncrementalCommon(val log: sbt.util.Logger, options:
     // For javac as class files are added to classfileManager as they are generated, so
     // this step is redundant. For scalac this is still necessary. TODO: do the same for scalac.
     classfileManager.generated(fresh.relations.allProducts.toArray)
-    debugInnerSection("Fresh")(fresh.relations)
     val merged = pruned ++ fresh //.copy(relations = pruned.relations ++ fresh.relations, apis = pruned.apis ++ fresh.apis)
-    debugInnerSection("Merged")(merged.relations)
+
+    if (fresh.relations == merged.relations) {
+      debugInnerSection("Fresh [== Merged]")(fresh.relations)
+    } else {
+      debugInnerSection("Fresh")(fresh.relations)
+      debugInnerSection("Merged")(merged.relations)
+    }
     (merged, invalidatedSourcesForCompilation)
   }
 

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/MemberRefInvalidator.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/MemberRefInvalidator.scala
@@ -67,17 +67,15 @@ private[inc] class MemberRefInvalidator(log: Logger, logRecompileOnMacro: Boolea
 
   def invalidationReason(apiChange: APIChange): String = apiChange match {
     case TraitPrivateMembersModified(modifiedClass) =>
-      s"The private signature of trait ${modifiedClass} changed."
+      s"the private signature of trait $modifiedClass changed."
     case APIChangeDueToMacroDefinition(modifiedSrcFile) =>
-      s"The $modifiedSrcFile source file declares a macro."
+      s"the $modifiedSrcFile source file declares a macro."
     case NamesChange(modifiedClass, modifiedNames) =>
       modifiedNames.in(UseScope.Implicit) match {
         case changedImplicits if changedImplicits.isEmpty =>
-          s"""|The $modifiedClass has the following regular definitions changed:
-              |\t${modifiedNames.names.mkString(", ")}.""".stripMargin
+          s"the $modifiedClass has the following regular definitions changed: ${modifiedNames.names}"
         case changedImplicits =>
-          s"""|The $modifiedClass has the following implicit definitions changed:
-              |\t${changedImplicits.mkString(", ")}.""".stripMargin
+          s"""the $modifiedClass has the following implicit definitions changed: $changedImplicits""".stripMargin
       }
   }
 

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Relations.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Relations.scala
@@ -518,9 +518,9 @@ private abstract class MRelationsCommon(
     }
   }
   protected def relation_s(r: Relation[_, _], indentation: String): String = {
-    if (r.forwardMap.isEmpty) "Relation [ ]"
+    if (r.forwardMap.isEmpty) "[]"
     else
-      formatAsLines(r.all.toSeq, indentation).sorted.mkString("Relation [\n", "", indentation + "]")
+      formatAsLines(r.all.toSeq, indentation).sorted.mkString("[\n", "", indentation + "]")
   }
   protected def relation_s(r: Relation[_, _]): String = relation_s(r, "  ")
 }
@@ -673,7 +673,7 @@ private class MRelationsNameHashing(
   override def toString: String = {
     def color(s: String) = Console.YELLOW + s + Console.RESET
     def nestedRelation(deps: Map[_, Relation[_, _]]): String = {
-      if (deps.isEmpty) "Relation [ ]"
+      if (deps.isEmpty) "[]"
       else {
         val indentation = "    "
         deps

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/UsedName.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/UsedName.scala
@@ -11,7 +11,13 @@ import java.util
 
 import xsbti.UseScope
 
-case class UsedName private (name: String, scopes: util.EnumSet[UseScope])
+case class UsedName private (name: String, scopes: util.EnumSet[UseScope]) {
+
+  override def toString: String = {
+    val formattedScopes = if (scopes == UsedName.DefaultScope) "" else " " + scopes
+    name + formattedScopes
+  }
+}
 
 object UsedName {
 
@@ -25,4 +31,7 @@ object UsedName {
   private def escapeControlChars(name: String) = {
     name.replaceAllLiterally("\n", "\u26680A")
   }
+
+  private val DefaultScope = java.util.EnumSet.of(UseScope.Default)
+
 }


### PR DESCRIPTION
I am working on improving the debug logs (https://github.com/sbt/zinc/issues/338). I changed a couple of things

## diff
There is this diff thing displayed for interface changes. "Detected a change in a public API" and so on. Most of the lines there are not changed. Also there and those things that are always present and quite ugly like:
```
^inherited^ final def asInstanceOf[ scala.Any.T0 >: scala.this#Nothing <: scala.this#Any]: <scala.Any.T0>
```
What I done here is to only display lines with changes. I am not 100% sure about that change though as if there is a class and companion object, this context can be lost if those lines are unchanged.

## UsedName
I noticed it kind of clutters the log, especially used in Relation. It prints like `UsedName($this,[Default])`, while the scopes are almost always (I actually could not get it to be something else than singleton set with Default scope) the same. I replaced it to simply display `$this`. The actual scopes would only be displayed if they are something else e.g. `$this [Default, implicit]`.

## Pruned, Fresh, Merged
I added colors to those section markers and information at the end about which section ended. Similarly to https://github.com/sbt/zinc/pull/407

## Vertical alignment
I implemented vertical alignment for relations i.e. something like:
```
A   -> X
BBB -> Y
CC  -> Z
```
This happens in scope of single relation

## Indentation in relations
I added proper indentation when printing a Relation. Before the `]` was always at the beginning of the line and members were indented with 4 spaces. Now everything is indented according to nesting level (as there also are relations inside relations), by 2 spaces.

## MRelationsNameHashing
The main thing that is printing relations for products, library dependencies, class names, used names, etc. I added colors for names of those relations (also similar to https://github.com/sbt/zinc/pull/407)

## Cycles
One more thing I found difficult to identify is which compile cycle the logs belong to and where it starts, so I added a log message to show those.

I used different colors for everything. Maybe it is too much, but I think it is easier to scroll through logs like that.

I am open to any suggestions on how to improve this. Also, don't worry about the messy code, I will refactor it once the code looks as intended. I primarly would like to hear some opinion or suggestions.

I am adding some screenshots:
![1](https://i.imgur.com/tdrQx1M.png)
![2](https://i.imgur.com/i8p2QL7.png)
![3](https://i.imgur.com/gAueiSa.png)
