### PR TITLE
Make CachedHashingSpec more lenient

### DIFF
--- a/zinc/src/test/scala/sbt/inc/cached/CachedHashingSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/cached/CachedHashingSpec.scala
@@ -58,8 +58,8 @@ class CachedHashingSpec extends BaseCompilerSpec {
 
       val hashingTime = timeMs(genConfig)
       val cachedHashingTime = timeMs(genConfig)
-      assert(cachedHashingTime < (hashingTime * 0.20),
-             s"Cache jar didn't work: $cachedHashingTime is >= than 20% of $hashingTime.")
+      assert(cachedHashingTime < (hashingTime * 0.50),
+             s"Cache jar didn't work: $cachedHashingTime is >= than 50% of $hashingTime.")
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/sbt/zinc/issues/552

The 20% assersion is failing often. https://github.com/sbt/zinc/pull/551 for example failed the PR validation 3 times in a row because one of two Scala versions failed this test.