### PR TITLE
Map Relations in ProtobufReader/ProtobufWriter.

### DIFF
--- a/internal/zinc-persist/src/main/java/xsbti/compile/analysis/WriteMapper.java
+++ b/internal/zinc-persist/src/main/java/xsbti/compile/analysis/WriteMapper.java
@@ -24,6 +24,14 @@ import java.nio.file.Path;
 public interface WriteMapper extends GenericMapper {
 
     /**
+     * @param binaryFile A binary file existing in the stored relations.
+     * @return True to store the binary file in the analysis, false to filter it.
+     */
+    default boolean acceptBinaryFile(File binaryFile) {
+        return true;
+    }
+
+    /**
      * Defines a mapper that writes a machine-independent analysis file.
      *
      * An analysis file is machine independent if all the paths are relative and no

--- a/internal/zinc-persist/src/main/mima-filters/1.0.0.backwards.excludes
+++ b/internal/zinc-persist/src/main/mima-filters/1.0.0.backwards.excludes
@@ -6,3 +6,5 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("sbt.internal.inc.binary.conv
 ProblemFilters.exclude[DirectMissingMethodProblem]("sbt.internal.inc.binary.converters.ProtobufReaders.fromApis")
 ProblemFilters.exclude[DirectMissingMethodProblem]("sbt.internal.inc.binary.converters.ProtobufReaders.fromApisFile")
 ProblemFilters.exclude[DirectMissingMethodProblem]("sbt.internal.inc.binary.converters.ProtobufReaders.fromAnalyzedClass")
+ProblemFilters.exclude[MissingClassProblem]("sbt.internal.inc.cached.ProjectRebasedCache$RebaseReadWriteMapper")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("sbt.internal.inc.cached.CompilationCache.mappers")

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/binary/converters/ProtobufReaders.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/binary/converters/ProtobufReaders.scala
@@ -552,7 +552,14 @@ final class ProtobufReaders(mapper: ReadMapper, currentVersion: schema.Version) 
   }
 
   private final val stringId = identity[String] _
-  private final val stringToFile = (path: String) => fromPathString(path)
+
+  private final val binaryStringToFile = (path: String) =>
+    mapper.mapBinaryFile(fromPathString(path))
+  private final val sourceStringToFile = (path: String) =>
+    mapper.mapSourceFile(fromPathString(path))
+  private final val productStringToFile = (path: String) =>
+    mapper.mapProductFile(fromPathString(path))
+
   def fromRelations(relations: schema.Relations): Relations = {
     def fromMap[K, V](map: Map[String, schema.Values],
                       fk: String => K,
@@ -584,14 +591,14 @@ final class ProtobufReaders(mapper: ReadMapper, currentVersion: schema.Version) 
 
     def expected(msg: String) = ReadersFeedback.expected(msg, Classes.Relations)
 
-    val srcProd = fromMap(relations.srcProd, stringToFile, stringToFile)
-    val libraryDep = fromMap(relations.libraryDep, stringToFile, stringToFile)
-    val libraryClassName = fromMap(relations.libraryClassName, stringToFile, stringId)
+    val srcProd = fromMap(relations.srcProd, sourceStringToFile, productStringToFile)
+    val libraryDep = fromMap(relations.libraryDep, sourceStringToFile, binaryStringToFile)
+    val libraryClassName = fromMap(relations.libraryClassName, binaryStringToFile, stringId)
     val memberRef = relations.memberRef.read(fromClassDependencies, expected("member refs"))
     val inheritance = relations.inheritance.read(fromClassDependencies, expected("inheritance"))
     val localInheritance =
       relations.localInheritance.read(fromClassDependencies, expected("local inheritance"))
-    val classes = fromMap(relations.classes, stringToFile, stringId)
+    val classes = fromMap(relations.classes, sourceStringToFile, stringId)
     val productClassName = fromMap(relations.productClassName, stringId, stringId)
     val names = fromUsedNamesMap(relations.names)
     val internal = InternalDependencies(

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/binary/converters/ProtobufWriters.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/binary/converters/ProtobufWriters.scala
@@ -43,8 +43,8 @@ final class ProtobufWriters(mapper: WriteMapper) {
   def toStamps(stamps: Stamps): schema.Stamps = {
     // Note that boilerplate here is inteded, abstraction is expensive
     def toBinarySchemaMap(data: Map[File, Stamp]): Map[String, schema.Stamps.StampType] = {
-      data.map {
-        case (binaryFile, stamp) =>
+      data.collect {
+        case (binaryFile, stamp) if mapper.acceptBinaryFile(binaryFile) =>
           val newBinaryFile = mapper.mapBinaryFile(binaryFile)
           val newPath = toStringPath(newBinaryFile)
           val newBinaryStamp = mapper.mapBinaryStamp(binaryFile, stamp)
@@ -598,6 +598,10 @@ final class ProtobufWriters(mapper: WriteMapper) {
   private final val sourceFileToString = (f: File) => toStringPath(mapper.mapSourceFile(f))
   private final val productFileToString = (f: File) => toStringPath(mapper.mapProductFile(f))
 
+  private final val binaryFileAccept = (f: File) => mapper.acceptBinaryFile(f)
+  private final val allFileAccept = (_: File) => true
+  private final val allStringAccept = (_: String) => true
+
   def toRelations(relations: Relations): schema.Relations = {
     import sbt.internal.util.Relation
 
@@ -619,26 +623,56 @@ final class ProtobufWriters(mapper: WriteMapper) {
     def toMap[K, V](
         relation: Relation[K, V],
         fk: K => String,
-        fv: V => String
+        fv: V => String,
+        kFilter: K => Boolean,
+        vFilter: V => Boolean
     ): Map[String, schema.Values] = {
-      relation.forwardMap.map {
-        case (k, vs) =>
-          val fileValues = schema.Values(values = vs.iterator.map(fv).toList)
+      relation.forwardMap.collect {
+        case (k, vs) if kFilter(k) =>
+          val fileValues = schema.Values(values = vs.iterator.collect {
+            case v if vFilter(v) => fv(v)
+          }.toList)
           fk(k) -> fileValues
       }
     }
 
-    val srcProd = toMap(relations.srcProd, sourceFileToString, productFileToString)
-    val libraryDep = toMap(relations.libraryDep, sourceFileToString, binaryFileToString)
-    val libraryClassName = toMap(relations.libraryClassName, binaryFileToString, stringId)
-    val memberRefInternal = toMap(relations.memberRef.internal, stringId, stringId)
-    val memberRefExternal = toMap(relations.memberRef.external, stringId, stringId)
-    val inheritanceInternal = toMap(relations.inheritance.internal, stringId, stringId)
-    val inheritanceExternal = toMap(relations.inheritance.external, stringId, stringId)
-    val localInheritanceInternal = toMap(relations.localInheritance.internal, stringId, stringId)
-    val localInheritanceExternal = toMap(relations.localInheritance.external, stringId, stringId)
-    val classes = toMap(relations.classes, sourceFileToString, stringId)
-    val productClassName = toMap(relations.productClassName, stringId, stringId)
+    val srcProd = toMap(relations.srcProd,
+                        sourceFileToString,
+                        productFileToString,
+                        allFileAccept,
+                        allFileAccept)
+    val libraryDep = toMap(relations.libraryDep,
+                           sourceFileToString,
+                           binaryFileToString,
+                           allFileAccept,
+                           binaryFileAccept)
+    val libraryClassName = toMap(relations.libraryClassName,
+                                 binaryFileToString,
+                                 stringId,
+                                 binaryFileAccept,
+                                 allStringAccept)
+    val memberRefInternal =
+      toMap(relations.memberRef.internal, stringId, stringId, allStringAccept, allStringAccept)
+    val memberRefExternal =
+      toMap(relations.memberRef.external, stringId, stringId, allStringAccept, allStringAccept)
+    val inheritanceInternal =
+      toMap(relations.inheritance.internal, stringId, stringId, allStringAccept, allStringAccept)
+    val inheritanceExternal =
+      toMap(relations.inheritance.external, stringId, stringId, allStringAccept, allStringAccept)
+    val localInheritanceInternal = toMap(relations.localInheritance.internal,
+                                         stringId,
+                                         stringId,
+                                         allStringAccept,
+                                         allStringAccept)
+    val localInheritanceExternal = toMap(relations.localInheritance.external,
+                                         stringId,
+                                         stringId,
+                                         allStringAccept,
+                                         allStringAccept)
+    val classes =
+      toMap(relations.classes, sourceFileToString, stringId, allFileAccept, allStringAccept)
+    val productClassName =
+      toMap(relations.productClassName, stringId, stringId, allStringAccept, allStringAccept)
     val names = toUsedNamesMap(relations.names)
     val memberRef = Some(
       schema.ClassDependencies(

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/binary/converters/ProtobufWriters.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/binary/converters/ProtobufWriters.scala
@@ -592,8 +592,12 @@ final class ProtobufWriters(mapper: WriteMapper) {
     )
   }
 
-  private final val fileToString = (f: File) => toStringPath(f)
   private final val stringId = identity[String] _
+
+  private final val binaryFileToString = (f: File) => toStringPath(mapper.mapBinaryFile(f))
+  private final val sourceFileToString = (f: File) => toStringPath(mapper.mapSourceFile(f))
+  private final val productFileToString = (f: File) => toStringPath(mapper.mapProductFile(f))
+
   def toRelations(relations: Relations): schema.Relations = {
     import sbt.internal.util.Relation
 
@@ -624,16 +628,16 @@ final class ProtobufWriters(mapper: WriteMapper) {
       }
     }
 
-    val srcProd = toMap(relations.srcProd, fileToString, fileToString)
-    val libraryDep = toMap(relations.libraryDep, fileToString, fileToString)
-    val libraryClassName = toMap(relations.libraryClassName, fileToString, stringId)
+    val srcProd = toMap(relations.srcProd, sourceFileToString, productFileToString)
+    val libraryDep = toMap(relations.libraryDep, sourceFileToString, binaryFileToString)
+    val libraryClassName = toMap(relations.libraryClassName, binaryFileToString, stringId)
     val memberRefInternal = toMap(relations.memberRef.internal, stringId, stringId)
     val memberRefExternal = toMap(relations.memberRef.external, stringId, stringId)
     val inheritanceInternal = toMap(relations.inheritance.internal, stringId, stringId)
     val inheritanceExternal = toMap(relations.inheritance.external, stringId, stringId)
     val localInheritanceInternal = toMap(relations.localInheritance.internal, stringId, stringId)
     val localInheritanceExternal = toMap(relations.localInheritance.external, stringId, stringId)
-    val classes = toMap(relations.classes, fileToString, stringId)
+    val classes = toMap(relations.classes, sourceFileToString, stringId)
     val productClassName = toMap(relations.productClassName, stringId, stringId)
     val names = toUsedNamesMap(relations.names)
     val memberRef = Some(

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/cached/CompilationCache.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/cached/CompilationCache.scala
@@ -13,56 +13,39 @@ import java.nio.file.Path
 import sbt.internal.inc._
 import sbt.internal.inc.mappers.MapperUtils
 import sbt.io.IO
-import xsbti.compile.analysis.{ ReadMapper, ReadWriteMappers, Stamp, WriteMapper }
+import xsbti.compile.analysis.ReadWriteMappers
 import xsbti.compile.{ CompileAnalysis, MiniSetup }
 
+// TODO(jvican): Consider removing this interface or at least document it.
 trait CompilationCache {
-  // TODO(jvican): Consider removing this interface or at least document it.
+  def mappers(projectLocation: File): ReadWriteMappers
   def loadCache(projectLocation: File): Option[(CompileAnalysis, MiniSetup)]
 }
 
 case class ProjectRebasedCache(remoteRoot: Path, cacheLocation: Path) extends CompilationCache {
+
+  override def mappers(projectLocation: File) =
+    ReadWriteMappers.getMachineIndependentMappers(projectLocation.toPath)
+
   override def loadCache(projectLocation: File): Option[(CompileAnalysis, MiniSetup)] = {
     import JavaInterfaceUtil.EnrichOptional
     import scala.collection.JavaConverters._
     val projectLocationPath = projectLocation.toPath
-    val readMapper = new RebaseReadWriteMapper(remoteRoot, projectLocationPath)
-    val writeMapper = new RebaseReadWriteMapper(projectLocationPath, remoteRoot)
-    val mappers = new ReadWriteMappers(readMapper, writeMapper)
-    val store = FileAnalysisStore.binary(cacheLocation.toFile, mappers)
+    val store = FileAnalysisStore.binary(cacheLocation.toFile, mappers(projectLocation))
     store.get().toOption match {
       case Some(analysisContents) =>
         val originalAnalysis = analysisContents.getAnalysis
         val originalSetup = analysisContents.getMiniSetup
         val allProductsStamps = originalAnalysis.readStamps().getAllProductStamps.keySet.asScala
-        allProductsStamps.foreach { (originalFile: File) =>
-          val targetFile = writeMapper.mapProductFile(originalFile)
-          IO.copyFile(targetFile, originalFile, preserveLastModified = true)
+        allProductsStamps.foreach { (targetFile: File) =>
+          // NB: Analysis has already been rewritten to align with the target location of the
+          // project. We rewrite the path back to the cache location here to find our input file.
+          val originalFile = MapperUtils.rebase(targetFile, projectLocationPath, remoteRoot)
+          IO.copyFile(originalFile, targetFile, preserveLastModified = true)
         }
 
         Some(originalAnalysis -> originalSetup)
       case _ => None
     }
-  }
-
-  final class RebaseReadWriteMapper(from: Path, to: Path) extends ReadMapper with WriteMapper {
-    private def rebase(file: File): File = MapperUtils.rebase(file, from, to)
-
-    override def mapSourceFile(sourceFile: File): File = rebase(sourceFile)
-    override def mapBinaryFile(binaryFile: File): File = rebase(binaryFile)
-    override def mapProductFile(productFile: File): File = rebase(productFile)
-
-    override def mapClasspathEntry(classpathEntry: File): File = rebase(classpathEntry)
-    override def mapJavacOption(javacOption: String): String = identity(javacOption)
-    override def mapScalacOption(scalacOption: String): String = identity(scalacOption)
-
-    override def mapOutputDir(outputDir: File): File = rebase(outputDir)
-    override def mapSourceDir(sourceDir: File): File = rebase(sourceDir)
-
-    override def mapProductStamp(file: File, productStamp: Stamp): Stamp = identity(productStamp)
-    override def mapSourceStamp(file: File, sourceStamp: Stamp): Stamp = identity(sourceStamp)
-    override def mapBinaryStamp(file: File, binaryStamp: Stamp): Stamp = identity(binaryStamp)
-
-    override def mapMiniSetup(miniSetup: MiniSetup): MiniSetup = identity(miniSetup)
   }
 }

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/cached/ExportableCache.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/cached/ExportableCache.scala
@@ -32,6 +32,9 @@ class ExportableCache(val cacheLocation: Path, cleanOutputMode: CleanOutputMode 
     case _ => throw new RuntimeException("Only single output is supported")
   }
 
+  override def mappers(projectLocation: File) =
+    ReadWriteMappers.getMachineIndependentMappers(projectLocation.toPath)
+
   override def loadCache(projectLocation: File): Option[(CompileAnalysis, MiniSetup)] = {
     val mappers = ReadWriteMappers.getMachineIndependentMappers(projectLocation.toPath)
     val store = FileAnalysisStore.binary(analysisFile.toFile, mappers)

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/mappers/MapperUtils.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/mappers/MapperUtils.scala
@@ -21,6 +21,9 @@ object MapperUtils {
   private final val RELATIVE_MARKER = "\u2603\u2603\u2603"
   private final val MARKER_LENGTH = RELATIVE_MARKER.length()
 
+  private final def relativeWriteError(file: File, from: Path) =
+    s"Path $file is not located below path $from, and so cannot be safely relativized to it."
+
   private final def relativeReadError(path: String) =
     s"Unexpected path $path was not written by a relative write mapper. Paths have to start with $RELATIVE_MARKER"
 
@@ -44,6 +47,9 @@ object MapperUtils {
    */
   private[inc] def makeRelative(file: File, from: Path): File = {
     val relativePath = from.relativize(file.toPath)
+    if (relativePath.startsWith("..")) {
+      throw new RelativePathAssumptionBroken(relativeWriteError(file, from))
+    }
     new File(s"$RELATIVE_MARKER${relativePath}")
   }
 

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/mappers/RelativeWriteMappers.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/mappers/RelativeWriteMappers.scala
@@ -18,6 +18,10 @@ import xsbti.compile.analysis.{ RootPaths, Stamp, WriteMapper }
 final class NaiveRelativeWriteMapper(rootProjectPath: Path) extends WriteMapper {
   private def makeRelative(file: File): File = MapperUtils.makeRelative(file, rootProjectPath)
 
+  private[this] val javaHome = System.getProperty("java.home")
+
+  override def acceptBinaryFile(binaryFile: File) = !binaryFile.toString.startsWith(javaHome)
+
   override def mapSourceFile(sourceFile: File): File = makeRelative(sourceFile)
   override def mapBinaryFile(binaryFile: File): File = makeRelative(binaryFile)
   override def mapProductFile(productFile: File): File = makeRelative(productFile)
@@ -41,6 +45,10 @@ final class RelativeWriteMapper(rootPaths: RootPaths) extends WriteMapper {
   private final val sourcesRoot = rootPaths.getSourcesRootPath.toPath
   private final val librariesRoot = rootPaths.getLibrariesRootPath.toPath
   private final val productsRoot = rootPaths.getProductsRootPath.toPath
+
+  private[this] val javaHome = System.getProperty("java.home")
+
+  override def acceptBinaryFile(binaryFile: File) = !binaryFile.toString.startsWith(javaHome)
 
   override def mapSourceFile(sourceFile: File): File = makeRelative(sourceFile, sourcesRoot)
   override def mapBinaryFile(binaryFile: File): File = makeRelative(binaryFile, librariesRoot)

--- a/zinc/src/test/scala/sbt/inc/BaseCompilerSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/BaseCompilerSpec.scala
@@ -14,7 +14,7 @@ import java.util.Optional
 
 import sbt.internal.inc._
 import sbt.internal.inc.classpath.ClassLoaderCache
-import sbt.io.IO
+import sbt.io.{ IO, CopyOptions }
 import sbt.io.syntax._
 import sbt.util.{ InterfaceUtil, Logger }
 import xsbti.compile.{ ScalaInstance => _, _ }
@@ -24,6 +24,9 @@ class BaseCompilerSpec extends BridgeProviderSpecification {
 
   val scalaVersion = scala.util.Properties.versionNumberString
   val maxErrors = 100
+
+  private[this] val copyOptions =
+    CopyOptions().withPreserveLastModified(true).withPreserveExecutable(true)
 
   case class MockedLookup(am: File => Optional[CompileAnalysis]) extends PerClasspathEntryLookup {
     override def analysis(classpathEntry: File): Optional[CompileAnalysis] =
@@ -53,7 +56,7 @@ class BaseCompilerSpec extends BridgeProviderSpecification {
       sourceFile <- sourceFiles
     } yield {
       val targetFile = sourceRoot.resolve(sourceFile).toFile
-      IO.copyFile(fromResource(sourcesPrefix)(sourceFile), targetFile)
+      IO.copyFile(fromResource(sourcesPrefix)(sourceFile), targetFile, copyOptions)
       targetFile
     }
     val classpathBase = baseLocation.resolve("bin")
@@ -67,7 +70,7 @@ class BaseCompilerSpec extends BridgeProviderSpecification {
         existingFile.toFile
       case jarPath =>
         val newJar = classpathBase.resolve(jarPath).toFile
-        IO.copyFile(fromResource(binPrefix)(jarPath), newJar)
+        IO.copyFile(fromResource(binPrefix)(jarPath), newJar, copyOptions)
         newJar
     }
 

--- a/zinc/src/test/scala/sbt/inc/cached/CommonCachedCompilation.scala
+++ b/zinc/src/test/scala/sbt/inc/cached/CommonCachedCompilation.scala
@@ -91,7 +91,12 @@ abstract class CommonCachedCompilation(name: String)
     remoteProject =
       ProjectSetup(basePath, SetupCommons.baseSourceMapping, SetupCommons.baseCpMapping)
     remoteCompilerSetup = remoteProject.createCompiler()
-    remoteAnalysisStore = FileAnalysisStore.binary(remoteProject.defaultStoreLocation)
+
+    // NB: We instantiate a `CompilationCache` here in order to get access to the
+    // appropriate mappers for the compilation.
+    val mappers =
+      remoteCacheProvider().findCache(None).get.mappers(basePath.toFile)
+    remoteAnalysisStore = FileAnalysisStore.binary(remoteProject.defaultStoreLocation, mappers)
 
     val result = remoteCompilerSetup.doCompileWithStore(remoteAnalysisStore)
     assert(result.hasModified)

--- a/zinc/src/test/scala/sbt/inc/cached/ExportedCacheSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/cached/ExportedCacheSpec.scala
@@ -18,8 +18,11 @@ class ExportedCacheSpec extends CommonCachedCompilation("Exported Cache") {
 
   var cacheLocation: Path = _
   override protected def beforeAll(): Unit = {
+    cacheLocation = IO
+      .createUniqueDirectory(new java.io.File("target").getAbsoluteFile)
+      .toPath
+      .resolve("exported-cache")
     super.beforeAll()
-    cacheLocation = remoteProject.baseLocation.resolveSibling("cache")
     val remoteCache = new ExportableCache(cacheLocation)
 
     remoteCache.exportCache(remoteProject.baseLocation.toFile, remoteAnalysisStore) match {


### PR DESCRIPTION
This resolves https://github.com/pantsbuild/pants/issues/6239 with regard to the builtin `CompilationCache` and `ExportableCache` classes. It also unblocks external projects using a similar interface to filter analysis of non-portable values.