### PR TITLE
Fix logic for adding external class file manager

### DIFF
--- a/internal/compiler-interface/src/main/java/xsbti/compile/DefaultExternalHooks.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/DefaultExternalHooks.java
@@ -30,17 +30,15 @@ public class DefaultExternalHooks implements ExternalHooks {
 
     @Override
     public ExternalHooks withExternalClassFileManager(ClassFileManager externalClassFileManager) {
-        Optional<ClassFileManager> currentManager = this.getExternalClassFileManager();
-        Optional<ClassFileManager> mixedManager = currentManager;
-        if (currentManager.isPresent()) {
-            Optional<ClassFileManager> external = Optional.of(externalClassFileManager);
-            mixedManager = Optional.of(WrappedClassFileManager.of(currentManager.get(), external));
-        }
-        return new DefaultExternalHooks(this.getExternalLookup(), mixedManager);
+        Optional<ClassFileManager> external = Optional.of(externalClassFileManager);
+        Optional<ClassFileManager> mixedManager = classFileManager.isPresent()
+            ? Optional.of(WrappedClassFileManager.of(classFileManager.get(), external))
+            : external;
+        return new DefaultExternalHooks(lookup, mixedManager);
     }
 
     @Override
     public ExternalHooks withExternalLookup(ExternalHooks.Lookup externalLookup) {
-        return new DefaultExternalHooks(Optional.of(externalLookup), this.getExternalClassFileManager());
+        return new DefaultExternalHooks(Optional.of(externalLookup), classFileManager);
     }
 }

--- a/zinc/src/test/scala/sbt/inc/ClassFileManagerHookSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/ClassFileManagerHookSpec.scala
@@ -1,0 +1,39 @@
+package sbt.inc
+
+import java.io.File
+
+import sbt.io.IO
+
+import xsbti.compile.ClassFileManager
+import xsbti.compile.IncOptions
+
+class ClassFileManagerHookSpec extends BaseCompilerSpec {
+  it should "allow client to add their own class file manager" in {
+    IO.withTemporaryDirectory { tempDir =>
+      val setup = ProjectSetup.simple(tempDir.toPath, SourceFiles.Foo :: Nil)
+
+      var callbackCalled = 0
+      val myClassFileManager = new ClassFileManager {
+        override def delete(classes: Array[File]): Unit = {
+          callbackCalled += 1
+        }
+        override def generated(classes: Array[File]): Unit = {
+          callbackCalled += 1
+        }
+        override def complete(success: Boolean): Unit = {
+          callbackCalled += 1
+        }
+      }
+
+      val incOptions = IncOptions.of()
+      val newExternalHooks =
+        incOptions.externalHooks.withExternalClassFileManager(myClassFileManager)
+
+      val compiler =
+        setup.createCompiler().copy(incOptions = incOptions.withExternalHooks(newExternalHooks))
+      compiler.doCompile()
+
+      callbackCalled.shouldEqual(3)
+    }
+  }
+}


### PR DESCRIPTION
If the current external class file manager was empty, the new one was
ignored. Now if the current external is empty, the new one becomes the
current one, otherwise the two are mixed (as specified bu the
documentation in `ExternalHooks.java`).