### PR TITLE
Fix the several typos detected by github.com/client9/misspell

### DIFF
--- a/internal/compiler-interface/src/main/java/xsbti/compile/CachedCompiler.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/CachedCompiler.java
@@ -35,7 +35,7 @@ public interface CachedCompiler {
 	 * Run the cached Scala compiler with inputs of incremental compilation.
 	 *
 	 * @param sources The source files to be compiled.
-	 * @param changes The changes that have occured since last compilation.
+	 * @param changes The changes that have occurred since last compilation.
 	 * @param callback The callback injected by the incremental compiler.
 	 * @param logger The logger of the incremental compilation.
 	 * @param delegate The reporter that informs on the compiler's output.

--- a/internal/compiler-interface/src/main/java/xsbti/compile/ClassFileManager.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/ClassFileManager.java
@@ -47,7 +47,7 @@ public interface ClassFileManager {
      * If it has not succeeded, the class file manager will handle the current
      * generated and the previous class files as per the underlying algorithm.
      *
-     * @param success Whether the compilation run has succeded or not.
+     * @param success Whether the compilation run has succeeded or not.
      */
     void complete(boolean success);
 }

--- a/internal/zinc-apiinfo/src/test/scala/xsbt/api/NameHashingSpecification.scala
+++ b/internal/zinc-apiinfo/src/test/scala/xsbt/api/NameHashingSpecification.scala
@@ -274,7 +274,7 @@ class NameHashingSpecification extends UnitSpec {
    * Checks that name hashes are being calculated for top level private classes.
    * A class cannot be top level and private in Java but it can be in Scala (it's package private).
    */
-  it should "calcualte name hashes for private top level class" in {
+  it should "calculate name hashes for private top level class" in {
     /* class Foo { def foo: String } */
     val fooDef =
       Def.of("foo", publicAccess, defaultModifiers, Array.empty, Array.empty, Array.empty, strTpe)

--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/ScalaInstance.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/ScalaInstance.scala
@@ -101,7 +101,7 @@ final class ScalaInstance(
 
 object ScalaInstance {
   /*
-   * Structural extention for the ScalaProvider post 1.0.3 launcher.
+   * Structural extension for the ScalaProvider post 1.0.3 launcher.
    * See https://github.com/sbt/zinc/pull/505.
    */
   private type ScalaProvider2 = { def loaderLibraryOnly: ClassLoader }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Compile.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Compile.scala
@@ -45,7 +45,7 @@ object IncrementalCompile {
    * @param output The configured output directory/directory mapping for source files.
    * @param log Where all log messages should go
    * @param options Incremental compiler options (like name hashing vs. not).
-   * @return A flag of whether or not compilation completed succesfully, and the resulting
+   * @return A flag of whether or not compilation completed successfully, and the resulting
    *         dependency analysis object.
    */
   def apply(

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -48,7 +48,7 @@ object Incremental {
    * @param options  Incremental compilation options
    * @param equivS  The means of testing whether two "Stamps" are the same.
    * @return
-   *         A flag of whether or not compilation completed succesfully, and the resulting dependency analysis object.
+   *         A flag of whether or not compilation completed successfully, and the resulting dependency analysis object.
    */
   def compile(
       sources: Set[File],

--- a/internal/zinc-ivy-integration/src/main/java/xsbti/compile/ZincBridgeProvider.java
+++ b/internal/zinc-ivy-integration/src/main/java/xsbti/compile/ZincBridgeProvider.java
@@ -35,7 +35,7 @@ public interface ZincBridgeProvider {
      * Returns a global lock that does nothing but calling the callable to synchronize
      * across threads. The lock file is used to resolve and download dependencies via ivy.
      * <p>
-     * This operation is necesary to invoke {@link ZincBridgeProvider#getProvider(File, GlobalLock, ComponentProvider, IvyConfiguration, Logger)}.
+     * This operation is necessary to invoke {@link ZincBridgeProvider#getProvider(File, GlobalLock, ComponentProvider, IvyConfiguration, Logger)}.
      *
      * @return A default global lock.
      */


### PR DESCRIPTION
This pull request fixes the typos in this repository. Although I am not a native English speaker, [misspell](https://github.com/client9/misspell) detected obvious mistakes for us. I've fixed them except for false positives.

```
$ misspell .
internal/compiler-interface/src/main/java/xsbti/compile/CachedCompiler.java:38:41: "occured" is a misspelling of "occurred"
internal/compiler-interface/src/main/java/xsbti/compile/ClassFileManager.java:50:54: "succeded" is a misspelling of "succeeded"
internal/zinc-apiinfo/src/test/scala/xsbt/api/NameHashingSpecification.scala:277:13: "calcualte" is a misspelling of "calculate"
internal/zinc-classpath/src/main/scala/sbt/internal/inc/ScalaInstance.scala:104:16: "extention" is a misspelling of "extension"
internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala:51:60: "succesfully" is a misspelling of "successfully"
internal/zinc-core/src/main/scala/sbt/internal/inc/Compile.scala:48:60: "succesfully" is a misspelling of "successfully"
internal/zinc-ivy-integration/src/main/java/xsbti/compile/ZincBridgeProvider.java:38:25: "necesary" is a misspelling of "necessary"
```