### PR TITLE
Track added products for cache invalidation

### DIFF
--- a/zinc/src/test/resources/sources/naha/ClientWithImplicitNotUsed.scala
+++ b/zinc/src/test/resources/sources/naha/ClientWithImplicitNotUsed.scala
@@ -1,5 +1,5 @@
 package naha
 
 object ClientWithImplicitNotUsed {
-  Seq(NormalDependecy.implicitMember, NormalDependecy.standardMember, WithImplicits.standardMember)
+  Seq(NormalDependency.implicitMember, NormalDependency.standardMember, WithImplicits.standardMember)
 }

--- a/zinc/src/test/resources/sources/naha/ClientWithImplicitUsed.scala
+++ b/zinc/src/test/resources/sources/naha/ClientWithImplicitUsed.scala
@@ -3,7 +3,7 @@ package naha
 object ClientWithImplicitUsed {
   def add(nr: Any)(implicit no: ImplicitWrapper[_]) = nr.toString + no.a.toString
 
-  val vals: Seq[Any] = Seq(NormalDependecy.implicitMember, NormalDependecy.standardMember)
+  val vals: Seq[Any] = Seq(NormalDependency.implicitMember, NormalDependency.standardMember)
 
   import WithImplicits._
   vals.map(add)

--- a/zinc/src/test/resources/sources/naha/ClientWithoutAnythingUsed.scala
+++ b/zinc/src/test/resources/sources/naha/ClientWithoutAnythingUsed.scala
@@ -1,7 +1,7 @@
 package naha
 
 object ClientWithoutAnythingUsed {
-  val objects = Seq(NormalDependecy)
+  val objects = Seq(NormalDependency)
 }
 
 object ClientWithoutAnythingUsed2 {

--- a/zinc/src/test/resources/sources/naha/ClientWithoutImplicit.scala
+++ b/zinc/src/test/resources/sources/naha/ClientWithoutImplicit.scala
@@ -1,5 +1,5 @@
 package naha
 
 object ClientWithoutImplicit {
-  Seq(NormalDependecy.standardMember, WithImplicits.standardMember)
+  Seq(NormalDependency.standardMember, WithImplicits.standardMember)
 }

--- a/zinc/src/test/resources/sources/naha/NormalDependency.scala
+++ b/zinc/src/test/resources/sources/naha/NormalDependency.scala
@@ -1,6 +1,6 @@
 package naha
 
-object NormalDependecy {
+object NormalDependency {
   def implicitMember = "implicitMemberValue"
   def standardMember = "standardMemberValue"
 }

--- a/zinc/src/test/scala/sbt/inc/NameHashingCompilerSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/NameHashingCompilerSpec.scala
@@ -77,12 +77,12 @@ class NameHashingCompilerSpec extends BaseCompilerSpec {
         Set(ClientWithImplicitUsed, ClientWithImplicitNotUsed, ClientWithoutImplicit)
     )
     testIncrementalCompilation(
-      changes = Seq(SourceFiles.Naha.NormalDependecy -> changeStandardMemberType),
+      changes = Seq(SourceFiles.Naha.NormalDependency -> changeStandardMemberType),
       transitiveChanges =
         Set(ClientWithImplicitUsed, ClientWithImplicitNotUsed, ClientWithoutImplicit)
     )
     testIncrementalCompilation(
-      changes = Seq(SourceFiles.Naha.NormalDependecy -> changeImplicitMemberType),
+      changes = Seq(SourceFiles.Naha.NormalDependency -> changeImplicitMemberType),
       transitiveChanges = Set(ClientWithImplicitUsed, ClientWithImplicitNotUsed)
     )
     testIncrementalCompilation(

--- a/zinc/src/test/scala/sbt/inc/SourceFiles.scala
+++ b/zinc/src/test/scala/sbt/inc/SourceFiles.scala
@@ -16,7 +16,7 @@ object SourceFiles {
     val ClientWithoutImplicit = "ClientWithoutImplicit.scala"
     val ClientWithoutAnythingUsed = "ClientWithoutAnythingUsed.scala"
 
-    val NormalDependecy = "NormalDependecy.scala"
+    val NormalDependency = "NormalDependency.scala"
     val WithImplicits = "WithImplicits.scala"
     val Other = "Other.scala"
     val Other2 = "Other2.scala"
@@ -27,7 +27,7 @@ object SourceFiles {
       ClientWithImplicitNotUsed,
       ClientWithoutImplicit,
       ClientWithoutAnythingUsed,
-      NormalDependecy,
+      NormalDependency,
       WithImplicits,
       Other,
       Other2,


### PR DESCRIPTION
I discovered that in sbt, the scripted tests/internal-tracking test
would fail if run with -Dsbt.resident.limit=$NUM where $NUM > 0. This
was because the test introduced a dependent project b, that depended on
a, but was set to not track a. If the b project was compiled before the
a project, the compilation would fail, but a cache entry would be added
to the compiler cache with a key that included a's target directory in
its classpath. If a was then independently compiled, the expectation
would be that b would also compile, but this actually failed. The reason
was that when zinc looked for the cached compiler, it found a hit and
did not create a new compiler instance. This was a problem because the
previous instance was unaware of the newly generated classes from the a
project. To get b to compile, it is necessary to invalidate the compiler
cache entry.

To invalidate the entry, we must detect that there are changes to the
project's dependencies. Previously, zinc did not even look at new
classes in a dependencies target directory. It did look at
removedProducts, but did not actually consider the removed products when
constructing the DependencyChanges instance in Incremental.scala. This
commit adds an addedProducts* field to InitialChanges with alternate
constructors and apply methods for binary compatibility. I then update
Incremental.scala to append both the removed and added products to the
DependencyChanges.modifiedBinaries parameter. After those two changes,
the scripted test passes with or without using cached compilers. Note
that this behavior was never detected in the past because all of the
scripted tests are run without setting sbt.resident.limit so every
single run of compile is guaranteed to have a fresh compiler.

* I could have left InitialChanges as it was and just appended the new
products to the removedProducts set, but that seems liable to lead to
confusion.