### PR TITLE
Don't print stack traces for pending exceptions

### DIFF
--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/ScriptedTests.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/ScriptedTests.scala
@@ -189,7 +189,7 @@ final class ScriptedTests(resourceBaseDirectory: File,
     def testFailed(t: Throwable): Option[String] = {
       if (pending) {
         import sbt.internal.util.codec.JsonProtocol._
-        // Use trace but in debug mode (default trace in `ManagedLogger` prints as error
+        // Use trace but in debug mode (default trace in `ManagedLogger` prints at the error level)
         logger.logEvent(Level.Debug, TraceEvent("Debug", t, logger.channelName, logger.execId))
         buffer.clearBuffer()
 


### PR DESCRIPTION
Instead of:

```
Running reporter / errors-reported
[info] Log files can be found at /tmp/scripted-logs-35db5343
[error] sbt.internal.inc.BatchScriptRunner$PreciseScriptedError: Command failed: 'checkErrors 1'
[error] Caused by: org.scalatest.exceptions.TestFailedException: List() had length 0 instead of expected length 1 Expected 1 messages with severity Error but 0 found:
[error] 
[error] 	at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:528)
[error] 	at org.scalatest.Assertions.newAssertionFailedException$(Assertions.scala:527)
[error] 	at org.scalatest.FlatSpec.newAssertionFailedException(FlatSpec.scala:1685)
[error] 	at org.scalatest.Assertions$AssertionsHelper.macroAssert(Assertions.scala:501)
[error] 	at sbt.internal.inc.ProjectStructure.checkMessages(IncHandler.scala:515)
[error] 	at sbt.internal.inc.IncHandler$$anonfun$commands$lzycompute$14.applyOrElse(IncHandler.scala:199)
[error] 	at sbt.internal.inc.IncHandler$$anonfun$commands$lzycompute$14.applyOrElse(IncHandler.scala:198)
[error] 	at sbt.internal.inc.IncHandler.applyOrElse(IncHandler.scala:221)
[error] 	at sbt.internal.inc.IncHandler.$anonfun$onArgs$1(IncHandler.scala:213)
[error] 	at sbt.internal.inc.IncHandler.$anonfun$onArgs$1$adapted(IncHandler.scala:213)
[error] 	at sbt.internal.inc.IncHandler.$anonfun$apply$1(IncHandler.scala:122)
[error] 	at sbt.internal.inc.IncHandler.$anonfun$apply$1$adapted(IncHandler.scala:122)
[error] 	at sbt.internal.inc.IncHandler.onIncInstance(IncHandler.scala:129)
[error] 	at sbt.internal.inc.IncHandler.apply(IncHandler.scala:123)
[error] 	at sbt.internal.inc.IncHandler.apply(IncHandler.scala:53)
[error] 	at sbt.internal.inc.BatchScriptRunner.processStatement(BatchScriptRunner.scala:35)
[error] 	at sbt.internal.inc.BatchScriptRunner.$anonfun$apply$1(BatchScriptRunner.scala:18)
[error] 	at sbt.internal.inc.BatchScriptRunner.$anonfun$apply$1$adapted(BatchScriptRunner.scala:18)
[error] 	at scala.collection.immutable.List.foreach(List.scala:389)
[error] 	at sbt.internal.inc.BatchScriptRunner.apply(BatchScriptRunner.scala:18)
[error] 	at sbt.internal.inc.ScriptedTests.$anonfun$commonRunTest$8(ScriptedTests.scala:212)
[error] 	at scala.util.control.Exception$Catch.apply(Exception.scala:224)
[error] 	at sbt.internal.inc.ScriptedTests.commonRunTest(ScriptedTests.scala:209)
[error] 	at sbt.internal.inc.ScriptedTests.$anonfun$runBatchedTests$2(ScriptedTests.scala:143)
[error] 	at sbt.internal.inc.ScriptedTests.runOrHandleDisabled(ScriptedTests.scala:161)
[error] 	at sbt.internal.inc.ScriptedTests.$anonfun$runBatchedTests$1(ScriptedTests.scala:144)
[error] 	at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:234)
[error] 	at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:59)
[error] 	at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:52)
[error] 	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:48)
[error] 	at scala.collection.TraversableLike.map(TraversableLike.scala:234)
[error] 	at scala.collection.TraversableLike.map$(TraversableLike.scala:227)
[error] 	at scala.collection.AbstractTraversable.map(Traversable.scala:104)
[error] 	at sbt.internal.inc.ScriptedTests.runBatchTests$1(ScriptedTests.scala:127)
[error] 	at sbt.internal.inc.ScriptedTests.runBatchedTests(ScriptedTests.scala:150)
[error] 	at sbt.internal.inc.ScriptedTests.$anonfun$batchScriptedRunner$8(ScriptedTests.scala:66)
[error] 	at sbt.io.IO$.withTemporaryDirectory(IO.scala:376)
[error] 	at sbt.io.IO$.withTemporaryDirectory(IO.scala:383)
[error] 	at sbt.internal.inc.ScriptedTests.$anonfun$batchScriptedRunner$7(ScriptedTests.scala:66)
[error] 	at sbt.internal.inc.ScriptedRunnerImpl$.$anonfun$runAllInParallel$1(IncScriptedRunner.scala:55)
[error] 	at scala.collection.parallel.mutable.ParArray$ParArrayIterator.flatmap2combiner(ParArray.scala:416)
[error] 	at scala.collection.parallel.ParIterableLike$FlatMap.leaf(ParIterableLike.scala:1070)
[error] 	at scala.collection.parallel.Task.$anonfun$tryLeaf$1(Tasks.scala:49)
[error] 	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
[error] 	at scala.util.control.Breaks$$anon$1.catchBreak(Breaks.scala:63)
[error] 	at scala.collection.parallel.Task.tryLeaf(Tasks.scala:52)
[error] 	at scala.collection.parallel.Task.tryLeaf$(Tasks.scala:46)
[error] 	at scala.collection.parallel.ParIterableLike$FlatMap.tryLeaf(ParIterableLike.scala:1066)
[error] 	at scala.collection.parallel.AdaptiveWorkStealingTasks$WrappedTask.compute(Tasks.scala:149)
[error] 	at scala.collection.parallel.AdaptiveWorkStealingTasks$WrappedTask.compute$(Tasks.scala:145)
[error] 	at scala.collection.parallel.AdaptiveWorkStealingForkJoinTasks$WrappedTask.compute(Tasks.scala:436)
[error] 	at java.util.concurrent.RecursiveAction.exec(RecursiveAction.java:189)
[error] 	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
[error] 	at java.util.concurrent.ForkJoinTask.doJoin(ForkJoinTask.java:389)
[error] 	at java.util.concurrent.ForkJoinTask.join(ForkJoinTask.java:719)
[error] 	at scala.collection.parallel.ForkJoinTasks$WrappedTask.sync(Tasks.scala:375)
[error] 	at scala.collection.parallel.ForkJoinTasks$WrappedTask.sync$(Tasks.scala:375)
[error] 	at scala.collection.parallel.AdaptiveWorkStealingForkJoinTasks$WrappedTask.sync(Tasks.scala:436)
[error] 	at scala.collection.parallel.ForkJoinTasks.executeAndWaitResult(Tasks.scala:419)
[error] 	at scala.collection.parallel.ForkJoinTasks.executeAndWaitResult$(Tasks.scala:412)
[error] 	at scala.collection.parallel.ForkJoinTaskSupport.executeAndWaitResult(TaskSupport.scala:56)
[error] 	at scala.collection.parallel.ParIterableLike$ResultMapping.leaf(ParIterableLike.scala:956)
[error] 	at scala.collection.parallel.Task.$anonfun$tryLeaf$1(Tasks.scala:49)
[error] 	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
[error] 	at scala.util.control.Breaks$$anon$1.catchBreak(Breaks.scala:63)
[error] 	at scala.collection.parallel.Task.tryLeaf(Tasks.scala:52)
[error] 	at scala.collection.parallel.Task.tryLeaf$(Tasks.scala:46)
[error] 	at scala.collection.parallel.ParIterableLike$ResultMapping.tryLeaf(ParIterableLike.scala:951)
[error] 	at scala.collection.parallel.AdaptiveWorkStealingTasks$WrappedTask.compute(Tasks.scala:149)
[error] 	at scala.collection.parallel.AdaptiveWorkStealingTasks$WrappedTask.compute$(Tasks.scala:145)
[error] 	at scala.collection.parallel.AdaptiveWorkStealingForkJoinTasks$WrappedTask.compute(Tasks.scala:436)
[error] 	at java.util.concurrent.RecursiveAction.exec(RecursiveAction.java:189)
[error] 	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
[error] 	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
[error] 	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
[error] 	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
[error] Pending cause: 'Command failed: 'checkErrors 1''
[error] x reporter / errors-reported [PENDING]
```

Scripted now prints:

```
Running reporter / errors-reported
[error] Pending cause: 'Command failed: 'checkErrors 1''
[error] x reporter / errors-reported [PENDING]
```

Note that this was happening only for scripted pending tests, not for failures.