### PR TITLE
Fix the extraHash used when reading a V1 file

### DIFF
--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/binary/converters/ProtobufReaders.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/binary/converters/ProtobufReaders.scala
@@ -544,8 +544,8 @@ final class ProtobufReaders(mapper: ReadMapper, currentVersion: schema.Version) 
       else mkLazy(analyzedClass.api.read(fromCompanions, ExpectedCompanionsInAnalyzedClass))
 
     val apiHash = analyzedClass.apiHash
-    // Default on api hash to avoid issues when comparing hashes from two different analysis formats
-    val extraHash = if (currentVersion == schema.Version.V1) apiHash else analyzedClass.extraHash
+    // Default to 0 to avoid issues when comparing hashes from two different analysis formats
+    val extraHash = if (currentVersion == schema.Version.V1) 0 else analyzedClass.extraHash
     val nameHashes = analyzedClass.nameHashes.toZincArray(fromNameHash)
     val hasMacro = analyzedClass.hasMacro
     AnalyzedClass.of(compilationTimestamp, name, api, apiHash, nameHashes, hasMacro, extraHash)


### PR DESCRIPTION
Setting extraHash to apiHash is not safe because in
IncrementalNameHashing#sameAPI an error is emitted if the extra hashes
are different and the class is not a trait. Setting it to 0 should be
safe since that's the value used for things which are not traits.