### PR TITLE
Notify analysis callback of generated non-local classes before genbcode

### DIFF
--- a/internal/compiler-bridge-test/src/test/scala/xsbt/ClassNameSpecification.scala
+++ b/internal/compiler-bridge-test/src/test/scala/xsbt/ClassNameSpecification.scala
@@ -1,61 +1,199 @@
 package xsbt
 
+import java.io.File
+
+import org.scalactic.source.Position
 import sbt.internal.inc.UnitSpec
 
 class ClassNameSpecification extends UnitSpec {
-
   "ClassName" should "create correct binary names for top level object" in {
-    val src = "object A"
+    expectBinaryClassNames("object A", Set("A" -> "A", "A" -> "A$"))
+  }
 
-    val compilerForTesting = new ScalaCompilerForUnitTesting
-    val binaryClassNames = compilerForTesting.extractBinaryClassNamesFromSrc(src)
-
-    assert(binaryClassNames === Set("A" -> "A", "A" -> "A$"))
+  it should "create binary names for top level class" in {
+    expectBinaryClassNames("class A", Set("A" -> "A"))
   }
 
   it should "create binary names for top level companions" in {
     val src = "class A; object A"
+    expectBinaryClassNames(src, Set("A" -> "A", "A" -> "A$"))
+  }
 
-    val compilerForTesting = new ScalaCompilerForUnitTesting
-    val binaryClassNames = compilerForTesting.extractBinaryClassNamesFromSrc(src)
+  it should "create binary names for case classes with no companions" in {
+    expectBinaryClassNames(
+      "case class LonelyCaseClass(paramA: String)",
+      Set("LonelyCaseClass" -> "LonelyCaseClass", "LonelyCaseClass" -> "LonelyCaseClass$")
+    )
+  }
 
-    assert(binaryClassNames === Set("A" -> "A", "A" -> "A$"))
+  it should "create binary names for case classes with companions" in {
+    expectBinaryClassNames(
+      "case class LonelyCaseClass2(paramA: String);object LonelyCaseClass2 { val z: Int = 1 }",
+      Set("LonelyCaseClass2" -> "LonelyCaseClass2", "LonelyCaseClass2" -> "LonelyCaseClass2$")
+    )
+  }
+
+  it should "create a correct binary name for names with encoded symbols" in {
+    val src = "package `package with spaces` { class :: }"
+    expectBinaryClassNames(
+      src,
+      Set(
+        "package$u0020with$u0020spaces.$colon$colon" -> "package$u0020with$u0020spaces.$colon$colon"
+      )
+    )
+  }
+
+  it should "create a correct binary name for names that are expanded" in {
+    val src =
+      """class Fooo {
+        |  // This one is problematic because of expanded names
+        |  private[Fooo] object Bar
+        |}
+        |
+        |package issue127 {
+        |  object Foo {
+        |    private[issue127] class Bippy
+        |    // This one is problematic because of expanded names
+        |    private[issue127] object Bippy
+        |  }
+        |}
+        |""".stripMargin
+    expectBinaryClassNames(
+      src,
+      Set(
+        "Fooo" -> "Fooo",
+        "Fooo.Bar" -> "Fooo$Bar$",
+        "issue127.Foo" -> "issue127.Foo",
+        "issue127.Foo" -> "issue127.Foo$",
+        "issue127.Foo.Bippy" -> "issue127.Foo$Bippy",
+        "issue127.Foo.Bippy" -> "issue127.Foo$Bippy$"
+      )
+    )
   }
 
   it should "create correct binary names for nested object" in {
+    expectBinaryClassNames(
+      "object A { object C { object D } }; class B { object E }",
+      Set(
+        "A" -> "A$",
+        "A" -> "A",
+        "A.C" -> "A$C$",
+        "A.C.D" -> "A$C$D$",
+        "B" -> "B",
+        "B.E" -> "B$E$"
+      )
+    )
+  }
+
+  it should "handle names of anonymous functions" in {
+    val scalaVersion = scala.util.Properties.versionNumberString
+    expectBinaryClassNames(
+      "object A { val a: Unit = { println((a: String) => a) }}",
+      Set(
+        "A" -> "A$",
+        "A" -> "A"
+      ),
+      if (scalaVersion.startsWith("2.10") || scalaVersion.startsWith("2.11")) Set("A$$anonfun$1")
+      else Set.empty
+    )
+  }
+
+  it should "handle advanced scenarios of nested classes and objects" in {
     val src =
-      """|object A {
-         |  object C {
-         |    object D
-         |  }
-         |}
-         |class B {
-         |  object E
-         |}
+      """
+        |package foo.bar
+        |
+        |class A {
+        |  class A2 {
+        |    class A3 {
+        |      object A4
+        |    }
+        |  }
+        |}
+        |object A {
+        |  class B
+        |  object B {
+        |    class C
+        |  }
+        |}
       """.stripMargin
 
-    val compilerForTesting = new ScalaCompilerForUnitTesting
-    val binaryClassNames = compilerForTesting.extractBinaryClassNamesFromSrc(src)
+    expectBinaryClassNames(
+      src,
+      Set(
+        "foo.bar.A" -> "foo.bar.A",
+        "foo.bar.A" -> "foo.bar.A$",
+        "foo.bar.A.A2" -> "foo.bar.A$A2",
+        "foo.bar.A.A2.A3" -> "foo.bar.A$A2$A3",
+        "foo.bar.A.A2.A3.A4" -> "foo.bar.A$A2$A3$A4$",
+        "foo.bar.A.B" -> "foo.bar.A$B",
+        "foo.bar.A.B" -> "foo.bar.A$B$",
+        "foo.bar.A.B.C" -> "foo.bar.A$B$C"
+      )
+    )
+  }
 
-    assert(
-      binaryClassNames === Set("A" -> "A$",
-                               "A" -> "A",
-                               "A.C" -> "A$C$",
-                               "A.C.D" -> "A$C$D$",
-                               "B" -> "B",
-                               "B.E" -> "B$E$"))
+  it should "create a binary name for both class of the package objects and its classes" in {
+    val src = "package object po { class B; object C }"
+    expectBinaryClassNames(
+      src,
+      Set(
+        "po.package" -> "po.package",
+        "po.package" -> "po.package$",
+        "po.B" -> "po.package$B",
+        "po.C" -> "po.package$C$"
+      )
+    )
   }
 
   it should "create a binary name for a trait" in {
-    val src =
-      """|trait A
-      """.stripMargin
-
-    val compilerForTesting = new ScalaCompilerForUnitTesting
-    val binaryClassNames = compilerForTesting.extractBinaryClassNamesFromSrc(src)
-
     // we do not track $impl classes because nobody can depend on them directly
-    assert(binaryClassNames === Set("A" -> "A"))
+    expectBinaryClassNames("trait A", Set("A" -> "A"))
+  }
+
+  it should "not create binary names nor class files for class of early inits" in {
+    val src = """
+      |class M extends {
+      |  val a = 1
+      |} with C
+      |
+      |abstract class C {
+      |  val a: Int
+      |}
+      |""".stripMargin
+
+    expectBinaryClassNames(
+      src,
+      Set(
+        "M" -> "M",
+        "C" -> "C"
+      )
+    )
+  }
+
+  it should "not create binary names for a refinement class but register its class file" in {
+    val src = """
+      |object UseSite {
+      |  val rc: C with C2 { val a: Int } = new C with C2 {
+      |    val a: Int = 1
+      |  }
+      |}
+      |
+      |abstract class C
+      |trait C2
+      |""".stripMargin
+
+    expectBinaryClassNames(
+      src,
+      Set(
+        "UseSite" -> "UseSite",
+        "UseSite" -> "UseSite$",
+        "C" -> "C",
+        "C2" -> "C2"
+      ),
+      // The anonymous
+      Set("UseSite$$anon$1")
+    )
   }
 
   it should "not create binary names for local classes" in {
@@ -63,6 +201,11 @@ class ClassNameSpecification extends UnitSpec {
       |class Container {
       |  def foo = {
       |    class C
+      |  }
+      |  def baz = {
+      |    class D(i: Int)
+      |    object D
+      |    new D(1)
       |  }
       |  def bar = {
       |    // anonymous class
@@ -72,9 +215,60 @@ class ClassNameSpecification extends UnitSpec {
       |
       |trait T
       |""".stripMargin
-    val compilerForTesting = new ScalaCompilerForUnitTesting
-    val binaryClassNames = compilerForTesting.extractBinaryClassNamesFromSrc(src)
-    assert(binaryClassNames === Set("Container" -> "Container", "T" -> "T"))
+
+    expectBinaryClassNames(
+      src,
+      Set(
+        "Container" -> "Container",
+        "T" -> "T"
+      ),
+      Set(
+        "Container$$anon$1",
+        "Container$C$1",
+        "Container$D$2",
+        "Container$D$3$"
+      )
+    )
   }
 
+  private def expectBinaryClassNames(
+      src: String,
+      expectedNames: Set[(String, String)],
+      expectedLocalNames: Set[String] = Set.empty
+  )(implicit p: Position): Unit = {
+    val compilerForTesting = new ScalaCompilerForUnitTesting
+    val (Seq(tempSrcFile), analysisCallback) = compilerForTesting.compileSrcs(src)
+    val binaryClassNames = analysisCallback.classNames(tempSrcFile).toSet
+    val generatedProducts = analysisCallback.productClassesToSources.keySet.toSet
+
+    if (binaryClassNames === expectedNames) {
+      val paths = (expectedLocalNames.map(n => s"${n}.class") ++
+        expectedNames.map(n => s"${n._2.replace('.', File.separatorChar)}.class"))
+      val generatedProductNames = generatedProducts.map(_.getName)
+      val missing = {
+        val ms = generatedProducts.map(gn => gn -> paths.find(p => gn.getAbsolutePath.endsWith(p)))
+        ms.filter(_._2.isEmpty).map(_._1)
+      }
+
+      val extra = paths.map(_.split(File.separatorChar).last).diff(generatedProductNames)
+      if (missing.isEmpty && extra.isEmpty) ()
+      else {
+        fail(
+          if (missing.nonEmpty && extra.nonEmpty) s"Missing classes $missing; extra classes $extra"
+          else if (missing.nonEmpty) s"Missing classes ${missing}"
+          else s"Extra classes ${extra}"
+        )
+      }
+    } else {
+      val isDisjoint = binaryClassNames.intersect(expectedNames).isEmpty
+      val missing = binaryClassNames.diff(expectedNames).mkString
+      val extra = expectedNames.diff(binaryClassNames).mkString
+      fail(
+        if (isDisjoint) s"Received ${binaryClassNames}; expected ${expectedNames}"
+        else if (missing.nonEmpty && extra.nonEmpty) s"Missing names $missing; extra names $extra"
+        else if (missing.nonEmpty) s"Missing names ${missing}"
+        else s"Extra names ${extra}"
+      )
+    }
+  }
 }

--- a/internal/compiler-bridge/src/main/scala/xsbt/API.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/API.scala
@@ -15,8 +15,11 @@ object API {
   val name = "xsbt-api"
 }
 
-final class API(val global: CallbackGlobal) extends Compat with GlobalHelpers {
+final class API(val global: CallbackGlobal) extends Compat with GlobalHelpers with ClassName {
   import global._
+
+  import scala.collection.mutable
+  private val nonLocalClassSymbolsInCurrentUnits = new mutable.HashSet[Symbol]()
 
   def newPhase(prev: Phase) = new ApiPhase(prev)
   class ApiPhase(prev: Phase) extends GlobalPhase(prev) {
@@ -25,15 +28,18 @@ final class API(val global: CallbackGlobal) extends Compat with GlobalHelpers {
     override def run(): Unit = {
       val start = System.currentTimeMillis
       super.run()
+
+      // After processing all units, register generated classes
+      registerGeneratedClasses(nonLocalClassSymbolsInCurrentUnits.iterator)
+      nonLocalClassSymbolsInCurrentUnits.clear()
+
       callback.apiPhaseCompleted()
       val stop = System.currentTimeMillis
       debuglog("API phase took : " + ((stop - start) / 1000.0) + " s")
     }
 
     def apply(unit: global.CompilationUnit): Unit = processUnit(unit)
-
     private def processUnit(unit: CompilationUnit) = if (!unit.isJava) processScalaUnit(unit)
-
     private def processScalaUnit(unit: CompilationUnit): Unit = {
       val sourceFile = unit.source.file.file
       debuglog("Traversing " + sourceFile)
@@ -58,6 +64,133 @@ final class API(val global: CallbackGlobal) extends Compat with GlobalHelpers {
       val mainClassesIt = mainClasses.iterator
       while (mainClassesIt.hasNext) {
         callback.mainClass(sourceFile, mainClassesIt.next())
+      }
+
+      extractApi.allExtractedNonLocalSymbols.foreach { cs =>
+        // Only add the class symbols defined in this compilation unit
+        if (cs.sourceFile != null) nonLocalClassSymbolsInCurrentUnits.+=(cs)
+      }
+    }
+  }
+
+  private case class FlattenedNames(binaryName: String, className: String)
+
+  /**
+   * Replicate the behaviour of `fullName` with a few changes to the code to produce
+   * correct file-system compatible full names for non-local classes. It mimics the
+   * paths of the class files produced by genbcode.
+   *
+   * Changes compared to the normal version in the compiler:
+   *
+   * 1. It will use the encoded name instead of the normal name.
+   * 2. It will not skip the name of the package object class (required for the class file path).
+   *
+   * Note that using `javaBinaryName` is not useful for these symbols because we
+   * need the encoded names. Zinc keeps track of encoded names in both the binary
+   * names and the Zinc names.
+   *
+   * @param symbol The symbol for which we extract the full name.
+   * @param separator The separator that we will apply between every name.
+   * @param suffix The suffix to add at the end (in case it's a module).
+   * @param includePackageObjectClassNames Include package object class names or not.
+   * @return The full name.
+   */
+  def fullName(
+      symbol: Symbol,
+      separator: Char,
+      suffix: CharSequence,
+      includePackageObjectClassNames: Boolean
+  ): String = {
+    var b: java.lang.StringBuffer = null
+    def loop(size: Int, sym: Symbol): Unit = {
+      val symName = sym.name
+      // Use of encoded to produce correct paths for names that have symbols
+      val encodedName = symName.encoded
+      val nSize = encodedName.length - (if (symName.endsWith(nme.LOCAL_SUFFIX_STRING)) 1 else 0)
+      if (sym.isRoot || sym.isRootPackage || sym == NoSymbol || sym.owner.isEffectiveRoot) {
+        val capacity = size + nSize
+        b = new java.lang.StringBuffer(capacity)
+        b.append(chrs, symName.start, nSize)
+      } else {
+        val next = if (sym.owner.isPackageObjectClass) sym.owner else sym.effectiveOwner.enclClass
+        loop(size + nSize + 1, next)
+        // Addition to normal `fullName` to produce correct names for nested non-local classes
+        if (sym.isNestedClass) b.append(nme.MODULE_SUFFIX_STRING) else b.append(separator)
+        b.append(chrs, symName.start, nSize)
+      }
+    }
+    loop(suffix.length(), symbol)
+    b.append(suffix)
+    b.toString
+  }
+
+  /**
+   * Registers only non-local generated classes in the callback by extracting
+   * information about its names and using the names to generate class file paths.
+   *
+   * Mimics the previous logic that was present in `Analyzer`, despite the fact
+   * that now we construct the names that the compiler will give to every non-local
+   * class independently of genbcode.
+   *
+   * Why do we do this? The motivation is that we want to run the incremental algorithm
+   * independently of the compiler pipeline. This independence enables us to:
+   *
+   * 1. Offload the incremental compiler logic out of the primary pipeline and
+   *    run the incremental phases concurrently.
+   * 2. Know before the compilation is completed whether another compilation will or
+   *    will not be required. This is important to make incremental compilation work
+   *    with pipelining and enables further optimizations; for example, we can start
+   *    subsequent incremental compilations before (!) the initial compilation is done.
+   *    This can buy us ~30-40% faster incremental compiler iterations.
+   *
+   * This method only takes care of non-local classes because local clsases have no
+   * relevance in the correctness of the algorithm and can be registered after genbcode.
+   * Local classes are only used to contruct the relations of products and to produce
+   * the list of generated files + stamps, but names referring to local classes **never**
+   * show up in the name hashes of classes' APIs, hence never considered for name hashing.
+   *
+   * As local class files are owned by other classes that change whenever they change,
+   * we could most likely live without adding their class files to the products relation
+   * and registering their stamps. However, to be on the safe side, we will continue to
+   * register the local products in `Analyzer`.
+   *
+   * @param allClassSymbols The class symbols found in all the compilation units.
+   */
+  def registerGeneratedClasses(classSymbols: Iterator[Symbol]): Unit = {
+    classSymbols.foreach { symbol =>
+      val sourceFile = symbol.sourceFile
+      val sourceJavaFile =
+        if (sourceFile == null) symbol.enclosingTopLevelClass.sourceFile.file else sourceFile.file
+
+      def registerProductNames(names: FlattenedNames): Unit = {
+        // Guard against a local class in case it surreptitiously leaks here
+        if (!symbol.isLocalClass) {
+          val classFileName = s"${names.binaryName}.class"
+          val outputDir = global.settings.outputDirs.outputDirFor(sourceFile).file
+          val classFile = new java.io.File(outputDir, classFileName)
+          val zincClassName = names.className
+          val srcClassName = classNameAsString(symbol)
+          callback.generatedNonLocalClass(sourceJavaFile, classFile, zincClassName, srcClassName)
+        } else ()
+      }
+
+      val names = FlattenedNames(
+        //flattenedNames(symbol)
+        fullName(symbol, java.io.File.separatorChar, symbol.moduleSuffix, true),
+        fullName(symbol, '.', symbol.moduleSuffix, false)
+      )
+
+      registerProductNames(names)
+
+      // Register the names of top-level module symbols that emit two class files
+      val isTopLevelUniqueModule =
+        symbol.owner.isPackageClass && symbol.isModuleClass && symbol.companionClass == NoSymbol
+      if (isTopLevelUniqueModule || symbol.isPackageObject) {
+        val names = FlattenedNames(
+          fullName(symbol, java.io.File.separatorChar, "", true),
+          fullName(symbol, '.', "", false)
+        )
+        registerProductNames(names)
       }
     }
   }

--- a/internal/compiler-bridge/src/main/scala/xsbt/API.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/API.scala
@@ -143,7 +143,7 @@ final class API(val global: CallbackGlobal) extends Compat with GlobalHelpers wi
    *    subsequent incremental compilations before (!) the initial compilation is done.
    *    This can buy us ~30-40% faster incremental compiler iterations.
    *
-   * This method only takes care of non-local classes because local clsases have no
+   * This method only takes care of non-local classes because local classes have no
    * relevance in the correctness of the algorithm and can be registered after genbcode.
    * Local classes are only used to contruct the relations of products and to produce
    * the list of generated files + stamps, but names referring to local classes **never**
@@ -175,7 +175,6 @@ final class API(val global: CallbackGlobal) extends Compat with GlobalHelpers wi
       }
 
       val names = FlattenedNames(
-        //flattenedNames(symbol)
         fullName(symbol, java.io.File.separatorChar, symbol.moduleSuffix, true),
         fullName(symbol, '.', symbol.moduleSuffix, false)
       )

--- a/internal/compiler-bridge/src/main/scala/xsbt/Analyzer.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/Analyzer.scala
@@ -12,6 +12,7 @@ import scala.tools.nsc.Phase
 object Analyzer {
   def name = "xsbt-analyzer"
 }
+
 final class Analyzer(val global: CallbackGlobal) extends LocateClassFile {
   import global._
 
@@ -20,34 +21,25 @@ final class Analyzer(val global: CallbackGlobal) extends LocateClassFile {
     override def description =
       "Finds concrete instances of provided superclasses, and application entry points."
     def name = Analyzer.name
+
     def apply(unit: CompilationUnit): Unit = {
       if (!unit.isJava) {
         val sourceFile = unit.source.file.file
-        // build list of generated classes
         for (iclass <- unit.icode) {
           val sym = iclass.symbol
+          val outputDir = settings.outputDirs.outputDirFor(sym.sourceFile).file
           def addGenerated(separatorRequired: Boolean): Unit = {
-            for (classFile <- outputDirs map (fileForClass(_, sym, separatorRequired)) find (_.exists)) {
+            val classFile = fileForClass(outputDir, sym, separatorRequired)
+            if (classFile.exists()) {
               assert(sym.isClass, s"${sym.fullName} is not a class")
-              // we would like to use Symbol.isLocalClass but that relies on Symbol.owner which
-              // is lost at this point due to lambdalift
-              // the LocalNonLocalClass.isLocal can return None, which means, we're asking about
-              // the class it has not seen before. How's that possible given we're performing a lookup
-              // for every declared class in Dependency phase? We can have new classes introduced after
-              // Dependency phase has ran. For example, the implementation classes for traits.
-              val isLocalClass = localToNonLocalClass.isLocal(sym).getOrElse(true)
-              if (!isLocalClass) {
-                val srcClassName = classNameAsString(sym)
-                val binaryClassName = flatclassName(sym, '.', separatorRequired)
-                callback.generatedNonLocalClass(sourceFile,
-                                                classFile,
-                                                binaryClassName,
-                                                srcClassName)
-              } else {
+              // Use own map of local classes computed before lambdalift to ascertain class locality
+              if (localToNonLocalClass.isLocal(sym).getOrElse(true)) {
+                // Inform callback about local classes, non-local classes have been reported in API
                 callback.generatedLocalClass(sourceFile, classFile)
               }
             }
           }
+
           if (sym.isModuleClass && !sym.isImplClass) {
             if (isTopLevelModule(sym) && sym.companionClass == NoSymbol)
               addGenerated(false)

--- a/internal/compiler-bridge/src/main/scala/xsbt/LocalToNonLocalClass.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/LocalToNonLocalClass.scala
@@ -57,6 +57,7 @@ class LocalToNonLocalClass[G <: CallbackGlobal](val global: G) {
     assert(s.isClass, s"The ${s.fullName} is not a class.")
     cache.getOrElseUpdate(s, lookupNonLocal(s))
   }
+
   private def lookupNonLocal(s: Symbol): Symbol = {
     if (s.owner.isPackageClass) s
     else if (s.owner.isClass) {

--- a/internal/compiler-interface/src/test/scala/xsbti/TestCallback.scala
+++ b/internal/compiler-interface/src/test/scala/xsbti/TestCallback.scala
@@ -12,7 +12,7 @@ class TestCallback extends AnalysisCallback {
 
   val classDependencies = new ArrayBuffer[(String, String, DependencyContext)]
   val binaryDependencies = new ArrayBuffer[(File, String, String, DependencyContext)]
-  val products = new ArrayBuffer[(File, File)]
+  val productClassesToSources = scala.collection.mutable.Map.empty[File, File]
   val usedNamesAndScopes =
     scala.collection.mutable.Map.empty[String, Set[TestUsedName]].withDefaultValue(Set.empty)
   val classNames =
@@ -42,17 +42,17 @@ class TestCallback extends AnalysisCallback {
     binaryDependencies += ((onBinary, onBinaryClassName, fromClassName, context))
     ()
   }
-  def generatedNonLocalClass(source: File,
-                             module: File,
+  def generatedNonLocalClass(sourceFile: File,
+                             classFile: File,
                              binaryClassName: String,
                              srcClassName: String): Unit = {
-    products += ((source, module))
-    classNames(source) += ((srcClassName, binaryClassName))
+    productClassesToSources += ((classFile, sourceFile))
+    classNames(sourceFile) += ((srcClassName, binaryClassName))
     ()
   }
 
-  def generatedLocalClass(source: File, module: File): Unit = {
-    products += ((source, module))
+  def generatedLocalClass(sourceFile: File, classFile: File): Unit = {
+    productClassesToSources += ((classFile, sourceFile))
     ()
   }
 


### PR DESCRIPTION
This is my first step towards making incremental compilation more efficient. I plan to do this task in several pull requests. There will be two kind of changes: the first kind will improve the implementation of our current infrastructure (e.g. merging `Dependency` and `API` together, reducing the memory overhead of names by creating a name table, etc); the second will make structural changes to Zinc to improve performance globally. This pull request is the second kind.

The idea of this pull request is to run the incremental algorithm as soon as possible in the pipeline. We extract all compiler information right after pickler so that:
  
1. Zinc can play nicely with pipelining both at the build and target level.
2. We can run the incremental algorithm in parallel with the main compilation pipeline. (This is left as future work and requires further investigation, however the idea is to remove shared state with the main compilation pipeline (no info transformers, no symbol dependencies) so that both pipelines are independent of each other and build tools can run them independently.)
  
In this pull request, I focus on the first item: making Zinc work together with pipelining. The current problem with pipelining and incremental compilations is that they don't work well together: incremental compilation requires the main compilation pipeline to finish (before this PR it depended on information created by the last compiler phase, genbcode) and pipelining yields no benefit if we are blocked on the full compilation pipeline. The fix in this PR reconciles this situation by removing the dependency on genbcode and instead generating the names for non-local classes before flatten and genbcode are run.
  
<img width="636" alt="zinc current pipelining diagram" src="https://user-images.githubusercontent.com/2462974/44488100-36b58a00-a658-11e8-80d0-6b1388226fc6.png">
  
The benefit is that with this change, we can run the incremental compiler right after pickler. If Zinc decides to recompile more sources, we don't spawn compilation in downstream projects; otherwise, we do. 
  
This workflow has the great advantage that we can pipeline the incremental compiler runs themselves! If we know that we need to compile again the project with more sources, we can start that compilation before the first compilation is over. In general, this allows us to aggregate a ~40% faster incremental compilation per run. An implementor of this technique must carefully make sure that the parallel compiler runs write class files/IR files to the file system in order.
  
## Implementation details
  
I added a thorough test suite to check the proper behavior of class names *before* replacing the implementation, so that we can check that it works before and after the migration of the logic from `Analyzer` to `API`. The pull request contains complete docs describing what the implementation does, but the most important thing to keep in mind is that to run the Zinc incremental algorithm we don't need to know what the local products (the class files associated with local classes) are.
  
Local classes never show up in name hashes of `AnalyzedClass`es, **meaning that they don't have any effect on the correctness of the algorithm**. Before and after this PR, a change in a local class will always be picked up. Local class files are registered in their owners, whose class file change whenever the local classes and their names change. As they don't have any effect on the correctness, we don't fully remove the logic in `API` and instead notify of their creation there. Conversely, the names and paths of non-local classes are notified in `API`, right after pickler, so that we can execute the incremental algorithm with the data collected in the analysis callback right after `pickler` has run.
  
We keep notifying about local class files not to break tools consuming the class files specified in the analysis. This approach is the best as we cannot reliably guess what the class file names of local classes will be without running the info transformer in flatten. In the case of non-local classes, guessing the class file names is much simpler and therefore allows us to remove the dependency on `genbcode`. Ideally, the compiler would provide us the information required to know what the class file path of a class symbol will be without the need of running the backend.
  
I elect @retronym and @smarter to review this pull request. I'd like to gauge some feedback on this approach.