### PR TITLE
[1.2.x] Avoid regex in UsedName for the common case of names without newlines

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/UsedName.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/UsedName.scala
@@ -23,6 +23,9 @@ object UsedName {
   }
 
   private def escapeControlChars(name: String) = {
-    name.replaceAllLiterally("\n", "\u26680A")
+    if (name.indexOf('\n') > 0) // optimize for common case to regex overhead
+      name.replaceAllLiterally("\n", "\u26680A")
+    else
+      name
   }
 }


### PR DESCRIPTION
This is a backport of https://github.com/sbt/zinc/pull/583 to 1.2.x.

