### PR TITLE
Enable straight-to-jar compilation

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,9 @@
 matrix:
   CI_SCALA_VERSION:
     - 2.12.6
+  RUN_SCRIPTED:
+    - ./bin/run-ci-scripted.sh
+    - ./bin/run-ci-scripted-to-jar.sh
 
 clone:
   git:
@@ -30,24 +33,7 @@ pipeline:
       - export DRONE_DIR="/drone"
       - git fetch --tags && git log | head -n 20
       - ./bin/run-ci.sh
-
-  scripted_normal:
-    group: scripted
-    image: scalacenter/scala-docs:1.3
-    when:
-      ref: [ refs/heads/1.x, refs/tags/*, refs/pull/*/head ]
-    commands:
-    - export DRONE_DIR="/drone"
-    - ./bin/run-ci-scripted.sh
-
-  scripted_to_jar:
-    group: scripted
-    image: scalacenter/scala-docs:1.3
-    when:
-      ref: [ refs/heads/1.x, refs/tags/*, refs/pull/*/head ]
-    commands:
-    - export DRONE_DIR="/drone"
-    - ./bin/run-ci-scripted-to-jar.sh
+      - ${RUN_SCRIPTED}
 
   rebuild_cache:
     image: appleboy/drone-sftp-cache

--- a/.drone.yml
+++ b/.drone.yml
@@ -31,6 +31,24 @@ pipeline:
       - git fetch --tags && git log | head -n 20
       - ./bin/run-ci.sh
 
+  scripted_normal:
+    group: scripted
+    image: scalacenter/scala-docs:1.3
+    when:
+      ref: [ refs/heads/1.x, refs/tags/*, refs/pull/*/head ]
+    commands:
+    - export DRONE_DIR="/drone"
+    - ./bin/run-ci-scripted.sh
+
+  scripted_to_jar:
+    group: scripted
+    image: scalacenter/scala-docs:1.3
+    when:
+      ref: [ refs/heads/1.x, refs/tags/*, refs/pull/*/head ]
+    commands:
+    - export DRONE_DIR="/drone"
+    - ./bin/run-ci-scripted-to-jar.sh
+
   rebuild_cache:
     image: appleboy/drone-sftp-cache
     when:

--- a/bin/run-ci-scripted-to-jar.sh
+++ b/bin/run-ci-scripted-to-jar.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -eu
+set -o nounset
+
+PROJECT_ROOT="zincRoot"
+sbt -Dfile.encoding=UTF-8 \
+  -J-XX:ReservedCodeCacheSize=512M \
+  -J-Xms1024M -J-Xmx4096M -J-server \
+  "zincScripted/test:run --to-jar"

--- a/bin/run-ci-scripted.sh
+++ b/bin/run-ci-scripted.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -eu
+set -o nounset
+
+PROJECT_ROOT="zincRoot"
+sbt -Dfile.encoding=UTF-8 \
+  -J-XX:ReservedCodeCacheSize=512M \
+  -J-Xms1024M -J-Xmx4096M -J-server \
+  "zincScripted/test:run"

--- a/bin/run-ci.sh
+++ b/bin/run-ci.sh
@@ -13,6 +13,4 @@ sbt -Dfile.encoding=UTF-8 \
   "$PROJECT_ROOT/test:compile" \
   crossTestBridges \
   "publishBridges" \
-  "$PROJECT_ROOT/test" \
-  "zincScripted/test:run" \
-  "zincScripted/test:run --to-jar"
+  "$PROJECT_ROOT/test"

--- a/bin/run-ci.sh
+++ b/bin/run-ci.sh
@@ -14,4 +14,5 @@ sbt -Dfile.encoding=UTF-8 \
   crossTestBridges \
   "publishBridges" \
   "$PROJECT_ROOT/test" \
-  "zincScripted/test:run"
+  "zincScripted/test:run" \
+  "zincScripted/test:run --to-jar"

--- a/build.sbt
+++ b/build.sbt
@@ -393,7 +393,7 @@ lazy val compilerInterface212 = (project in internalPath / "compiler-interface")
         exclude[ReversedMissingMethodProblem]("xsbti.compile.ScalaInstance.loaderLibraryOnly"),
         exclude[DirectMissingMethodProblem]("xsbti.api.AnalyzedClass.of"),
         exclude[DirectMissingMethodProblem]("xsbti.api.AnalyzedClass.create"),
-        exclude[ReversedMissingMethodProblem]("xsbti.AnalysisCallback.previousJar")
+        exclude[ReversedMissingMethodProblem]("xsbti.AnalysisCallback.classesInJar")
       )
     },
   )

--- a/build.sbt
+++ b/build.sbt
@@ -282,8 +282,6 @@ lazy val zincCore = (project in internalPath / "zinc-core")
         exclude[ReversedMissingMethodProblem]("sbt.internal.inc.IncrementalCommon.invalidateClassesInternally"),
         exclude[ReversedMissingMethodProblem]("sbt.internal.inc.IncrementalCommon.invalidateClassesExternally"),
         exclude[ReversedMissingMethodProblem]("sbt.internal.inc.IncrementalCommon.findAPIChange"),
-        exclude[IncompatibleMethTypeProblem]("sbt.internal.inc.Stamps.initial"),
-        exclude[IncompatibleMethTypeProblem]("sbt.internal.inc.InitialStamps.this"),
         exclude[IncompatibleMethTypeProblem]("sbt.internal.inc.Incremental.prune")
       )
     }
@@ -394,8 +392,7 @@ lazy val compilerInterface212 = (project in internalPath / "compiler-interface")
         exclude[ReversedMissingMethodProblem]("xsbti.compile.ExternalHooks#Lookup.hashClasspath"),
         exclude[ReversedMissingMethodProblem]("xsbti.compile.ScalaInstance.loaderLibraryOnly"),
         exclude[DirectMissingMethodProblem]("xsbti.api.AnalyzedClass.of"),
-        exclude[DirectMissingMethodProblem]("xsbti.api.AnalyzedClass.create"),
-        exclude[ReversedMissingMethodProblem]("xsbti.compile.analysis.ReadStamps.reset")
+        exclude[DirectMissingMethodProblem]("xsbti.api.AnalyzedClass.create")
       )
     },
   )

--- a/build.sbt
+++ b/build.sbt
@@ -392,7 +392,8 @@ lazy val compilerInterface212 = (project in internalPath / "compiler-interface")
         exclude[ReversedMissingMethodProblem]("xsbti.compile.ExternalHooks#Lookup.hashClasspath"),
         exclude[ReversedMissingMethodProblem]("xsbti.compile.ScalaInstance.loaderLibraryOnly"),
         exclude[DirectMissingMethodProblem]("xsbti.api.AnalyzedClass.of"),
-        exclude[DirectMissingMethodProblem]("xsbti.api.AnalyzedClass.create")
+        exclude[DirectMissingMethodProblem]("xsbti.api.AnalyzedClass.create"),
+        exclude[ReversedMissingMethodProblem]("xsbti.AnalysisCallback.previousJar")
       )
     },
   )

--- a/build.sbt
+++ b/build.sbt
@@ -164,13 +164,7 @@ lazy val zinc = (project in file("zinc"))
   .configure(addBaseSettingsAndTestDeps)
   .settings(
     name := "zinc",
-    mimaSettings,
-    mimaBinaryIssueFilters ++= Seq(
-      exclude[DirectMissingMethodProblem]("sbt.internal.inc.MixedAnalyzingCompiler.searchClasspathAndLookup"),
-      exclude[IncompatibleResultTypeProblem]("sbt.internal.inc.MixedAnalyzingCompiler.javac"),
-      exclude[IncompatibleMethTypeProblem]("sbt.internal.inc.MixedAnalyzingCompiler.this"),
-
-    )
+    mimaSettings
   )
 
 lazy val zincTesting = (project in internalPath / "zinc-testing")

--- a/build.sbt
+++ b/build.sbt
@@ -164,7 +164,12 @@ lazy val zinc = (project in file("zinc"))
   .configure(addBaseSettingsAndTestDeps)
   .settings(
     name := "zinc",
-    mimaSettings
+    mimaSettings,
+    mimaBinaryIssueFilters ++= Seq(
+      exclude[DirectMissingMethodProblem]("sbt.internal.inc.IncrementalCompilerImpl.compileIncrementally"),
+      exclude[DirectMissingMethodProblem]("sbt.internal.inc.IncrementalCompilerImpl.inputs"),
+      exclude[DirectMissingMethodProblem]("sbt.internal.inc.IncrementalCompilerImpl.compile")
+    )
   )
 
 lazy val zincTesting = (project in internalPath / "zinc-testing")
@@ -393,7 +398,9 @@ lazy val compilerInterface212 = (project in internalPath / "compiler-interface")
         exclude[ReversedMissingMethodProblem]("xsbti.compile.ScalaInstance.loaderLibraryOnly"),
         exclude[DirectMissingMethodProblem]("xsbti.api.AnalyzedClass.of"),
         exclude[DirectMissingMethodProblem]("xsbti.api.AnalyzedClass.create"),
-        exclude[ReversedMissingMethodProblem]("xsbti.AnalysisCallback.classesInJar")
+        exclude[ReversedMissingMethodProblem]("xsbti.AnalysisCallback.classesInJar"),
+        exclude[ReversedMissingMethodProblem]("xsbti.compile.IncrementalCompiler.compile"),
+        exclude[DirectMissingMethodProblem]("xsbti.compile.IncrementalCompiler.compile")
       )
     },
   )

--- a/build.sbt
+++ b/build.sbt
@@ -165,6 +165,12 @@ lazy val zinc = (project in file("zinc"))
   .settings(
     name := "zinc",
     mimaSettings,
+    mimaBinaryIssueFilters ++= Seq(
+      exclude[DirectMissingMethodProblem]("sbt.internal.inc.MixedAnalyzingCompiler.searchClasspathAndLookup"),
+      exclude[IncompatibleResultTypeProblem]("sbt.internal.inc.MixedAnalyzingCompiler.javac"),
+      exclude[IncompatibleMethTypeProblem]("sbt.internal.inc.MixedAnalyzingCompiler.this"),
+
+    )
   )
 
 lazy val zincTesting = (project in internalPath / "zinc-testing")
@@ -281,7 +287,10 @@ lazy val zincCore = (project in internalPath / "zinc-core")
         exclude[ReversedMissingMethodProblem]("sbt.internal.inc.IncrementalCommon.findClassDependencies"),
         exclude[ReversedMissingMethodProblem]("sbt.internal.inc.IncrementalCommon.invalidateClassesInternally"),
         exclude[ReversedMissingMethodProblem]("sbt.internal.inc.IncrementalCommon.invalidateClassesExternally"),
-        exclude[ReversedMissingMethodProblem]("sbt.internal.inc.IncrementalCommon.findAPIChange")
+        exclude[ReversedMissingMethodProblem]("sbt.internal.inc.IncrementalCommon.findAPIChange"),
+        exclude[IncompatibleMethTypeProblem]("sbt.internal.inc.Stamps.initial"),
+        exclude[IncompatibleMethTypeProblem]("sbt.internal.inc.InitialStamps.this"),
+        exclude[IncompatibleMethTypeProblem]("sbt.internal.inc.Incremental.prune")
       )
     }
   )
@@ -391,7 +400,8 @@ lazy val compilerInterface212 = (project in internalPath / "compiler-interface")
         exclude[ReversedMissingMethodProblem]("xsbti.compile.ExternalHooks#Lookup.hashClasspath"),
         exclude[ReversedMissingMethodProblem]("xsbti.compile.ScalaInstance.loaderLibraryOnly"),
         exclude[DirectMissingMethodProblem]("xsbti.api.AnalyzedClass.of"),
-        exclude[DirectMissingMethodProblem]("xsbti.api.AnalyzedClass.create")
+        exclude[DirectMissingMethodProblem]("xsbti.api.AnalyzedClass.create"),
+        exclude[ReversedMissingMethodProblem]("xsbti.compile.analysis.ReadStamps.reset")
       )
     },
   )
@@ -745,7 +755,10 @@ lazy val zincClassfile212 = zincClassfileTemplate
   .settings(
     scalaVersion := scala212,
     crossScalaVersions := Seq(scala212),
-    target := (target in zincClassfileTemplate).value.getParentFile / "target-2.12"
+    target := (target in zincClassfileTemplate).value.getParentFile / "target-2.12",
+    mimaBinaryIssueFilters ++= Seq(
+      exclude[DirectMissingMethodProblem]("sbt.internal.inc.classfile.Analyze.apply")
+    )
   )
 
 // re-implementation of scripted engine

--- a/build.sbt
+++ b/build.sbt
@@ -836,6 +836,7 @@ lazy val otherRootSettings = Seq(
   Scripted.scriptedPrescripted := { (_: File) => () },
   Scripted.scriptedUnpublished := scriptedUnpublishedTask.evaluated,
   Scripted.scriptedSource := (sourceDirectory in zinc).value / "sbt-test",
+  Scripted.scriptedCompileToJar := false,
   publishAll := {
     val _ = (publishLocal).all(ScopeFilter(inAnyProject)).value
   }
@@ -850,6 +851,7 @@ def scriptedTask: Def.Initialize[InputTask[Unit]] = Def.inputTask {
     scriptedSource.value,
     result,
     scriptedBufferLog.value,
+    scriptedCompileToJar.value,
     scriptedPrescripted.value
   )
 }
@@ -862,6 +864,7 @@ def scriptedUnpublishedTask: Def.Initialize[InputTask[Unit]] = Def.inputTask {
     scriptedSource.value,
     result,
     scriptedBufferLog.value,
+    scriptedCompileToJar.value,
     scriptedPrescripted.value
   )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -168,7 +168,11 @@ lazy val zinc = (project in file("zinc"))
     mimaBinaryIssueFilters ++= Seq(
       exclude[DirectMissingMethodProblem]("sbt.internal.inc.IncrementalCompilerImpl.compileIncrementally"),
       exclude[DirectMissingMethodProblem]("sbt.internal.inc.IncrementalCompilerImpl.inputs"),
-      exclude[DirectMissingMethodProblem]("sbt.internal.inc.IncrementalCompilerImpl.compile")
+      exclude[DirectMissingMethodProblem]("sbt.internal.inc.IncrementalCompilerImpl.compile"),
+      exclude[DirectMissingMethodProblem]("sbt.internal.inc.MixedAnalyzingCompiler.config"),
+      exclude[DirectMissingMethodProblem]("sbt.internal.inc.MixedAnalyzingCompiler.makeConfig"),
+      exclude[DirectMissingMethodProblem]("sbt.internal.inc.MixedAnalyzingCompiler.this"),
+      exclude[DirectMissingMethodProblem]("sbt.internal.inc.CompileConfiguration.this")
     )
   )
 
@@ -287,7 +291,10 @@ lazy val zincCore = (project in internalPath / "zinc-core")
         exclude[ReversedMissingMethodProblem]("sbt.internal.inc.IncrementalCommon.invalidateClassesInternally"),
         exclude[ReversedMissingMethodProblem]("sbt.internal.inc.IncrementalCommon.invalidateClassesExternally"),
         exclude[ReversedMissingMethodProblem]("sbt.internal.inc.IncrementalCommon.findAPIChange"),
-        exclude[IncompatibleMethTypeProblem]("sbt.internal.inc.Incremental.prune")
+        exclude[IncompatibleMethTypeProblem]("sbt.internal.inc.Incremental.prune"),
+        exclude[DirectMissingMethodProblem]("sbt.internal.inc.IncrementalCompile.apply"),
+        exclude[DirectMissingMethodProblem]("sbt.internal.inc.AnalysisCallback#Builder.this"),
+        exclude[DirectMissingMethodProblem]("sbt.internal.inc.AnalysisCallback.this")
       )
     }
   )

--- a/build.sbt
+++ b/build.sbt
@@ -398,7 +398,7 @@ lazy val compilerInterface212 = (project in internalPath / "compiler-interface")
         exclude[ReversedMissingMethodProblem]("xsbti.compile.ScalaInstance.loaderLibraryOnly"),
         exclude[DirectMissingMethodProblem]("xsbti.api.AnalyzedClass.of"),
         exclude[DirectMissingMethodProblem]("xsbti.api.AnalyzedClass.create"),
-        exclude[ReversedMissingMethodProblem]("xsbti.AnalysisCallback.classesInJar"),
+        exclude[ReversedMissingMethodProblem]("xsbti.AnalysisCallback.classesInOutputJar"),
         exclude[ReversedMissingMethodProblem]("xsbti.compile.IncrementalCompiler.compile"),
         exclude[DirectMissingMethodProblem]("xsbti.compile.IncrementalCompiler.compile")
       )

--- a/internal/compiler-bridge/src/main/scala/xsbt/API.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/API.scala
@@ -20,7 +20,6 @@ final class API(val global: CallbackGlobal) extends Compat with GlobalHelpers wi
 
   import scala.collection.mutable
   private val nonLocalClassSymbolsInCurrentUnits = new mutable.HashSet[Symbol]()
-  private val JarUtils = new JarUtils(outputDirs)
 
   def newPhase(prev: Phase) = new ApiPhase(prev)
   class ApiPhase(prev: Phase) extends GlobalPhase(prev) {

--- a/internal/compiler-bridge/src/main/scala/xsbt/API.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/API.scala
@@ -120,7 +120,7 @@ final class API(val global: CallbackGlobal) extends Compat with GlobalHelpers wi
           val classFileName = s"${names.binaryName}.class"
           val outputDir = global.settings.outputDirs.outputDirFor(sourceFile).file
           val classFile = if (STJ.enabled) {
-            new java.io.File(STJ.init(outputDir, classFileName))
+            new java.io.File(STJ.jaredClass(outputDir, classFileName))
           } else {
             new java.io.File(outputDir, classFileName)
           }

--- a/internal/compiler-bridge/src/main/scala/xsbt/API.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/API.scala
@@ -120,7 +120,7 @@ final class API(val global: CallbackGlobal) extends Compat with GlobalHelpers wi
           val classFileName = s"${names.binaryName}.class"
           val outputDir = global.settings.outputDirs.outputDirFor(sourceFile).file
           val classFile = if (JarUtils.isCompilingToJar) {
-            new java.io.File(JarUtils.JaredClass(outputDir, classFileName))
+            new java.io.File(JarUtils.ClassInJar(outputDir, classFileName))
           } else {
             new java.io.File(outputDir, classFileName)
           }

--- a/internal/compiler-bridge/src/main/scala/xsbt/API.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/API.scala
@@ -20,7 +20,7 @@ final class API(val global: CallbackGlobal) extends Compat with GlobalHelpers wi
 
   import scala.collection.mutable
   private val nonLocalClassSymbolsInCurrentUnits = new mutable.HashSet[Symbol]()
-  private val STJ = new STJ(outputDirs)
+  private val JarUtils = new JarUtils(outputDirs)
 
   def newPhase(prev: Phase) = new ApiPhase(prev)
   class ApiPhase(prev: Phase) extends GlobalPhase(prev) {
@@ -119,8 +119,8 @@ final class API(val global: CallbackGlobal) extends Compat with GlobalHelpers wi
         if (!symbol.isLocalClass) {
           val classFileName = s"${names.binaryName}.class"
           val outputDir = global.settings.outputDirs.outputDirFor(sourceFile).file
-          val classFile = if (STJ.enabled) {
-            new java.io.File(STJ.JaredClass(outputDir, classFileName))
+          val classFile = if (JarUtils.isCompilingToJar) {
+            new java.io.File(JarUtils.JaredClass(outputDir, classFileName))
           } else {
             new java.io.File(outputDir, classFileName)
           }

--- a/internal/compiler-bridge/src/main/scala/xsbt/API.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/API.scala
@@ -120,7 +120,7 @@ final class API(val global: CallbackGlobal) extends Compat with GlobalHelpers wi
           val classFileName = s"${names.binaryName}.class"
           val outputDir = global.settings.outputDirs.outputDirFor(sourceFile).file
           val classFile = if (STJ.enabled) {
-            new java.io.File(STJ.jaredClass(outputDir, classFileName))
+            new java.io.File(STJ.JaredClass(outputDir, classFileName))
           } else {
             new java.io.File(outputDir, classFileName)
           }

--- a/internal/compiler-bridge/src/main/scala/xsbt/Analyzer.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/Analyzer.scala
@@ -10,6 +10,7 @@ package xsbt
 import java.io.File
 
 import scala.tools.nsc.Phase
+import scala.collection.JavaConverters._
 
 object Analyzer {
   def name = "xsbt-analyzer"
@@ -27,8 +28,8 @@ final class Analyzer(val global: CallbackGlobal) extends LocateClassFile {
     private lazy val existingClassesInJar: Set[JarUtils.ClassInJar] = {
       JarUtils.outputJar match {
         case Some(jar) =>
-          val classes = JarUtils.listFiles(jar)
-          classes.map(JarUtils.ClassInJar(jar, _))
+          val classes = global.callback.classesInJar().asScala
+          classes.map(JarUtils.ClassInJar(jar, _)).toSet
         case None => Set.empty
       }
     }

--- a/internal/compiler-bridge/src/main/scala/xsbt/Analyzer.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/Analyzer.scala
@@ -75,7 +75,7 @@ final class Analyzer(val global: CallbackGlobal) extends LocateClassFile {
 
     private def locateClassInJar(sym: Symbol, separatorRequired: Boolean): Option[File] = {
       val classFile =
-        fileForClass(new java.io.File("."), sym, separatorRequired).toString
+        fileForClass(new File("."), sym, separatorRequired).toString
           .drop(2) // stripPrefix ./ or .\
       val jaredClass = STJ.JaredClass(classFile)
       if (existingJaredClasses.contains(jaredClass)) {

--- a/internal/compiler-bridge/src/main/scala/xsbt/Analyzer.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/Analyzer.scala
@@ -17,7 +17,6 @@ object Analyzer {
 
 final class Analyzer(val global: CallbackGlobal) extends LocateClassFile {
   import global._
-  private val JarUtils = new JarUtils(outputDirs)
 
   def newPhase(prev: Phase): Phase = new AnalyzerPhase(prev)
   private class AnalyzerPhase(prev: Phase) extends GlobalPhase(prev) {

--- a/internal/compiler-bridge/src/main/scala/xsbt/Analyzer.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/Analyzer.scala
@@ -29,7 +29,7 @@ final class Analyzer(val global: CallbackGlobal) extends LocateClassFile {
       STJ.outputJar
         .map { jar =>
           val classes = STJ.listFiles(jar)
-          classes.map(STJ.init(jar, _))
+          classes.map(STJ.jaredClass(jar, _))
         }
         .getOrElse(Set.empty)
     }
@@ -77,7 +77,7 @@ final class Analyzer(val global: CallbackGlobal) extends LocateClassFile {
       val classFile =
         fileForClass(new java.io.File("."), sym, separatorRequired).toString
           .drop(2) // stripPrefix ./ or .\
-      val jaredClass = STJ.init(classFile)
+      val jaredClass = STJ.jaredClass(classFile)
       if (existingJaredClasses.contains(jaredClass)) {
         Some(new File(jaredClass))
       } else {

--- a/internal/compiler-bridge/src/main/scala/xsbt/Analyzer.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/Analyzer.scala
@@ -25,12 +25,12 @@ final class Analyzer(val global: CallbackGlobal) extends LocateClassFile {
     def name = Analyzer.name
 
     private lazy val existingClassesInJar: Set[JarUtils.ClassInJar] = {
-      JarUtils.outputJar
-        .map { jar =>
+      JarUtils.outputJar match {
+        case Some(jar) =>
           val classes = JarUtils.listFiles(jar)
           classes.map(JarUtils.ClassInJar(jar, _))
-        }
-        .getOrElse(Set.empty)
+        case None => Set.empty
+      }
     }
 
     def apply(unit: CompilationUnit): Unit = {

--- a/internal/compiler-bridge/src/main/scala/xsbt/Analyzer.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/Analyzer.scala
@@ -25,11 +25,11 @@ final class Analyzer(val global: CallbackGlobal) extends LocateClassFile {
       "Finds concrete instances of provided superclasses, and application entry points."
     def name = Analyzer.name
 
-    private lazy val existingJaredClasses: Set[JarUtils.JaredClass] = {
+    private lazy val existingClassesInJar: Set[JarUtils.ClassInJar] = {
       JarUtils.outputJar
         .map { jar =>
           val classes = JarUtils.listFiles(jar)
-          classes.map(JarUtils.JaredClass(jar, _))
+          classes.map(JarUtils.ClassInJar(jar, _))
         }
         .getOrElse(Set.empty)
     }
@@ -77,9 +77,9 @@ final class Analyzer(val global: CallbackGlobal) extends LocateClassFile {
       val classFile =
         fileForClass(new File("."), sym, separatorRequired).toString
           .drop(2) // stripPrefix ./ or .\
-      val jaredClass = JarUtils.JaredClass(classFile)
-      if (existingJaredClasses.contains(jaredClass)) {
-        Some(new File(jaredClass))
+      val classInJar = JarUtils.ClassInJar(classFile)
+      if (existingClassesInJar.contains(classInJar)) {
+        Some(new File(classInJar))
       } else {
         None
       }

--- a/internal/compiler-bridge/src/main/scala/xsbt/Analyzer.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/Analyzer.scala
@@ -29,7 +29,7 @@ final class Analyzer(val global: CallbackGlobal) extends LocateClassFile {
       STJ.outputJar
         .map { jar =>
           val classes = STJ.listFiles(jar)
-          classes.map(STJ.jaredClass(jar, _))
+          classes.map(STJ.JaredClass(jar, _))
         }
         .getOrElse(Set.empty)
     }
@@ -77,7 +77,7 @@ final class Analyzer(val global: CallbackGlobal) extends LocateClassFile {
       val classFile =
         fileForClass(new java.io.File("."), sym, separatorRequired).toString
           .drop(2) // stripPrefix ./ or .\
-      val jaredClass = STJ.jaredClass(classFile)
+      val jaredClass = STJ.JaredClass(classFile)
       if (existingJaredClasses.contains(jaredClass)) {
         Some(new File(jaredClass))
       } else {

--- a/internal/compiler-bridge/src/main/scala/xsbt/Analyzer.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/Analyzer.scala
@@ -17,7 +17,7 @@ object Analyzer {
 
 final class Analyzer(val global: CallbackGlobal) extends LocateClassFile {
   import global._
-  private val STJ = new STJ(outputDirs)
+  private val JarUtils = new JarUtils(outputDirs)
 
   def newPhase(prev: Phase): Phase = new AnalyzerPhase(prev)
   private class AnalyzerPhase(prev: Phase) extends GlobalPhase(prev) {
@@ -25,11 +25,11 @@ final class Analyzer(val global: CallbackGlobal) extends LocateClassFile {
       "Finds concrete instances of provided superclasses, and application entry points."
     def name = Analyzer.name
 
-    private lazy val existingJaredClasses: Set[STJ.JaredClass] = {
-      STJ.outputJar
+    private lazy val existingJaredClasses: Set[JarUtils.JaredClass] = {
+      JarUtils.outputJar
         .map { jar =>
-          val classes = STJ.listFiles(jar)
-          classes.map(STJ.JaredClass(jar, _))
+          val classes = JarUtils.listFiles(jar)
+          classes.map(JarUtils.JaredClass(jar, _))
         }
         .getOrElse(Set.empty)
     }
@@ -40,7 +40,7 @@ final class Analyzer(val global: CallbackGlobal) extends LocateClassFile {
         for (iclass <- unit.icode) {
           val sym = iclass.symbol
           def addGenerated(separatorRequired: Boolean): Unit = {
-            val locatedClass = if (STJ.enabled) {
+            val locatedClass = if (JarUtils.isCompilingToJar) {
               locateClassInJar(sym, separatorRequired)
             } else {
               locatePlainClassFile(sym, separatorRequired)
@@ -77,7 +77,7 @@ final class Analyzer(val global: CallbackGlobal) extends LocateClassFile {
       val classFile =
         fileForClass(new File("."), sym, separatorRequired).toString
           .drop(2) // stripPrefix ./ or .\
-      val jaredClass = STJ.JaredClass(classFile)
+      val jaredClass = JarUtils.JaredClass(classFile)
       if (existingJaredClasses.contains(jaredClass)) {
         Some(new File(jaredClass))
       } else {

--- a/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
@@ -40,6 +40,8 @@ sealed abstract class CallbackGlobal(settings: Settings,
     }
   }
 
+  lazy val JarUtils = new JarUtils(outputDirs)
+
   /**
    * Defines the sbt phase in which the dependency analysis is performed.
    * The reason why this is exposed in the callback global is because it's used
@@ -133,8 +135,6 @@ sealed class ZincCompiler(settings: Settings, dreporter: DelegatingReporter, out
     }
     this.computePhaseDescriptors
   }
-
-  private final val JarUtils = new JarUtils(outputDirs)
 
   private final val classesInJarFromPrevCompilation =
     perRunCaches.recordCache(new JarUtils.PrevJarCache(settings.classpath.value))

--- a/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
@@ -136,7 +136,7 @@ sealed class ZincCompiler(settings: Settings, dreporter: DelegatingReporter, out
 
   private final val JarUtils = new JarUtils(outputDirs)
 
-  private final val jaredClassesFromPrevCompilation =
+  private final val classesInJarFromPrevCompilation =
     perRunCaches.recordCache(new JarUtils.PrevJarCache(settings.classpath.value))
 
   private final val fqnsToAssociatedFiles = perRunCaches.newMap[String, (AbstractFile, Boolean)]()
@@ -146,9 +146,9 @@ sealed class ZincCompiler(settings: Settings, dreporter: DelegatingReporter, out
     def getOutputClass(name: String): Option[AbstractFile] = {
       val relPathToClass = name.replace('.', '/') + ".class"
       if (JarUtils.isCompilingToJar) {
-        val jaredClass = JarUtils.JaredClass(relPathToClass)
-        if (jaredClassesFromPrevCompilation.contains(jaredClass)) {
-          Some(new PlainFile(jaredClass))
+        val classInJar = JarUtils.ClassInJar(relPathToClass)
+        if (classesInJarFromPrevCompilation.contains(classInJar)) {
+          Some(new PlainFile(classInJar))
         } else None
       } else {
         // This could be improved if a hint where to look is given.

--- a/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
@@ -136,8 +136,11 @@ sealed class ZincCompiler(settings: Settings, dreporter: DelegatingReporter, out
     this.computePhaseDescriptors
   }
 
-  private final val classesInJarFromPrevCompilation =
-    perRunCaches.recordCache(new JarUtils.PrevJarCache(settings.classpath.value))
+  private final lazy val classesInJarFromPrevCompilation = {
+    val prevJarOptional = callback.previousJar()
+    val prevJar = if (prevJarOptional.isPresent) Some(prevJarOptional.get) else None
+    perRunCaches.recordCache(new JarUtils.PrevJarCache(prevJar))
+  }
 
   private final val fqnsToAssociatedFiles = perRunCaches.newMap[String, (AbstractFile, Boolean)]()
 

--- a/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
@@ -136,12 +136,6 @@ sealed class ZincCompiler(settings: Settings, dreporter: DelegatingReporter, out
     this.computePhaseDescriptors
   }
 
-  private final lazy val classesInJarFromPrevCompilation = {
-    val prevJarOptional = callback.previousJar()
-    val prevJar = if (prevJarOptional.isPresent) Some(prevJarOptional.get) else None
-    perRunCaches.recordCache(new JarUtils.PrevJarCache(prevJar))
-  }
-
   private final val fqnsToAssociatedFiles = perRunCaches.newMap[String, (AbstractFile, Boolean)]()
 
   /** Returns the associated file of a fully qualified name and whether it's on the classpath. */
@@ -150,7 +144,7 @@ sealed class ZincCompiler(settings: Settings, dreporter: DelegatingReporter, out
       val relPathToClass = name.replace('.', '/') + ".class"
       if (JarUtils.isCompilingToJar) {
         val classInJar = JarUtils.ClassInJar(relPathToClass)
-        if (classesInJarFromPrevCompilation.contains(classInJar)) {
+        if (callback.classesInJar().contains(relPathToClass)) {
           Some(new PlainFile(classInJar))
         } else None
       } else {

--- a/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
@@ -146,7 +146,7 @@ sealed class ZincCompiler(settings: Settings, dreporter: DelegatingReporter, out
     def getOutputClass(name: String): Option[AbstractFile] = {
       val relPathToClass = name.replace('.', '/') + ".class"
       if (STJ.enabled) {
-        val jaredClass = STJ.jaredClass(relPathToClass)
+        val jaredClass = STJ.JaredClass(relPathToClass)
         if (jaredClassesFromPrevCompilation.contains(jaredClass)) {
           Some(new PlainFile(jaredClass))
         } else None

--- a/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
@@ -146,7 +146,7 @@ sealed class ZincCompiler(settings: Settings, dreporter: DelegatingReporter, out
     def getOutputClass(name: String): Option[AbstractFile] = {
       val relPathToClass = name.replace('.', '/') + ".class"
       if (STJ.enabled) {
-        val jaredClass = STJ.init(relPathToClass)
+        val jaredClass = STJ.jaredClass(relPathToClass)
         if (jaredClassesFromPrevCompilation.contains(jaredClass)) {
           Some(new PlainFile(jaredClass))
         } else None

--- a/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
@@ -134,10 +134,10 @@ sealed class ZincCompiler(settings: Settings, dreporter: DelegatingReporter, out
     this.computePhaseDescriptors
   }
 
-  private final val STJ = new STJ(outputDirs)
+  private final val JarUtils = new JarUtils(outputDirs)
 
   private final val jaredClassesFromPrevCompilation =
-    perRunCaches.recordCache(new STJ.PrevJarCache(settings.classpath.value))
+    perRunCaches.recordCache(new JarUtils.PrevJarCache(settings.classpath.value))
 
   private final val fqnsToAssociatedFiles = perRunCaches.newMap[String, (AbstractFile, Boolean)]()
 
@@ -145,8 +145,8 @@ sealed class ZincCompiler(settings: Settings, dreporter: DelegatingReporter, out
   def findAssociatedFile(fqn: String): Option[(AbstractFile, Boolean)] = {
     def getOutputClass(name: String): Option[AbstractFile] = {
       val relPathToClass = name.replace('.', '/') + ".class"
-      if (STJ.enabled) {
-        val jaredClass = STJ.JaredClass(relPathToClass)
+      if (JarUtils.isCompilingToJar) {
+        val jaredClass = JarUtils.JaredClass(relPathToClass)
         if (jaredClassesFromPrevCompilation.contains(jaredClass)) {
           Some(new PlainFile(jaredClass))
         } else None

--- a/internal/compiler-bridge/src/main/scala/xsbt/JarUtils.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/JarUtils.scala
@@ -65,19 +65,10 @@ final class JarUtils(outputDirs: Iterable[File]) {
 
   /**
    * Class that holds cached list of paths located within previous jar for quick lookup.
-   * See [[sbt.internal.inc.JarUtils#withPreviousJar]] for details on what previous jar is.
-   * The previous jar is located using the classpath (if it exists it is a first entry
-   * and has a special prefix.
-   *
-   * @param rawClasspath the classpath in a single string (entries separated with [[File.pathSeparator]])
+   * @see sbt.internal.inc.JarUtils#withPreviousJar for details on what previous jar is
    */
-  class PrevJarCache(rawClasspath: String) extends scala.collection.generic.Clearable {
+  class PrevJarCache(prevJar: Option[File]) extends scala.collection.generic.Clearable {
     private var cache: Set[ClassInJar] = _
-
-    private lazy val prevJar = {
-      val classpath = rawClasspath.split(File.pathSeparator)
-      findPrevJar(classpath)
-    }
 
     def contains(classInJar: ClassInJar): Boolean = {
       if (cache == null) {
@@ -97,14 +88,5 @@ final class JarUtils(outputDirs: Iterable[File]) {
         }
     }
   }
-
-  private def findPrevJar(classpath: Seq[String]): Option[File] = {
-    classpath.headOption.map(new File(_)).filter { path =>
-      val fileName = path.getName
-      fileName.startsWith(prevJarPrefix) && fileName.endsWith(".jar")
-    }
-  }
-
-  private val prevJarPrefix: String = "prev-jar"
 
 }

--- a/internal/compiler-bridge/src/main/scala/xsbt/JarUtils.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/JarUtils.scala
@@ -11,21 +11,21 @@ import java.util.zip.ZipFile
  * duplicates some of the code, as it is difficult to share it.
  */
 final class JarUtils(outputDirs: Iterable[File]) {
-  type JaredClass = String
+  type ClassInJar = String
   type RelClass = String
 
   /**
    * Creates an identifier for a class located inside a jar.
-   * Mimics the behavior of [[sbt.internal.inc.JarUtils.JaredClass]].
+   * Mimics the behavior of [[sbt.internal.inc.JarUtils.ClassInJar]].
    */
-  def JaredClass(jar: File, cls: RelClass): JaredClass = {
+  def ClassInJar(jar: File, cls: RelClass): ClassInJar = {
     val relClass = if (File.separatorChar == '/') cls else cls.replace('/', File.separatorChar)
     s"$jar!$relClass"
   }
 
   /** Creates an identifier for a class located inside the current output jar. */
-  def JaredClass(cls: RelClass): JaredClass = {
-    JaredClass(outputJar.get, cls)
+  def ClassInJar(cls: RelClass): ClassInJar = {
+    ClassInJar(outputJar.get, cls)
   }
 
   /**
@@ -72,28 +72,28 @@ final class JarUtils(outputDirs: Iterable[File]) {
    * @param rawClasspath the classpath in a single string (entries separated with [[File.pathSeparator]])
    */
   class PrevJarCache(rawClasspath: String) extends scala.collection.generic.Clearable {
-    private var cache: Set[JaredClass] = _
+    private var cache: Set[ClassInJar] = _
 
     private lazy val prevJar = {
       val classpath = rawClasspath.split(File.pathSeparator)
       findPrevJar(classpath)
     }
 
-    def contains(jaredClass: JaredClass): Boolean = {
+    def contains(classInJar: ClassInJar): Boolean = {
       if (cache == null) {
         cache = loadEntriesFromPrevJar()
       }
-      cache.contains(jaredClass)
+      cache.contains(classInJar)
     }
 
     def clear(): Unit = cache = null
 
-    private def loadEntriesFromPrevJar(): Set[JaredClass] = {
+    private def loadEntriesFromPrevJar(): Set[ClassInJar] = {
       prevJar
         .filter(_.exists())
-        .fold(Set.empty[JaredClass]) { prevJar =>
+        .fold(Set.empty[ClassInJar]) { prevJar =>
           val classes = listFiles(prevJar)
-          classes.map(JaredClass)
+          classes.map(ClassInJar)
         }
     }
   }

--- a/internal/compiler-bridge/src/main/scala/xsbt/JarUtils.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/JarUtils.scala
@@ -4,21 +4,19 @@ import java.io.File
 import java.util.zip.ZipFile
 
 /**
- * STJ stands for Straight to Jar compilation.
- *
  * This is a utility class that provides a set of functions that
- * are used to implement this feature.
+ * are used to implement straight to jar compilation.
  *
- * [[sbt.internal.inc.STJ]] is an object that has similar purpose and
+ * [[sbt.internal.inc.JarUtils]] is an object that has similar purpose and
  * duplicates some of the code, as it is difficult to share it.
  */
-final class STJ(outputDirs: Iterable[File]) {
+final class JarUtils(outputDirs: Iterable[File]) {
   type JaredClass = String
   type RelClass = String
 
   /**
    * Creates an identifier for a class located inside a jar.
-   * Mimics the behavior of [[sbt.internal.inc.STJ.JaredClass]].
+   * Mimics the behavior of [[sbt.internal.inc.JarUtils.JaredClass]].
    */
   def JaredClass(jar: File, cls: RelClass): JaredClass = {
     val relClass = if (File.separatorChar == '/') cls else cls.replace('/', File.separatorChar)
@@ -63,11 +61,11 @@ final class STJ(outputDirs: Iterable[File]) {
    * Informs if the Straight to Jar compilation feature is enabled,
    * i.e. if the output is set to a jar file.
    */
-  val enabled: Boolean = outputJar.isDefined
+  val isCompilingToJar: Boolean = outputJar.isDefined
 
   /**
    * Class that holds cached list of paths located within previous jar for quick lookup.
-   * See [[sbt.internal.inc.STJ#withPreviousJar]] for details on what previous jar is.
+   * See [[sbt.internal.inc.JarUtils#withPreviousJar]] for details on what previous jar is.
    * The previous jar is located using the classpath (if it exists it is a first entry
    * and has a special prefix.
    *

--- a/internal/compiler-bridge/src/main/scala/xsbt/LocateClassFile.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/LocateClassFile.scala
@@ -43,4 +43,7 @@ abstract class LocateClassFile extends Compat with ClassName {
 
   protected def fileForClass(outputDirectory: File, s: Symbol, separatorRequired: Boolean): File =
     new File(outputDirectory, flatclassName(s, File.separatorChar, separatorRequired) + ".class")
+
+  protected def pathToClassFile(s: Symbol, separatorRequired: Boolean): String =
+    flatclassName(s, File.separatorChar, separatorRequired) + ".class"
 }

--- a/internal/compiler-bridge/src/main/scala/xsbt/STJ.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/STJ.scala
@@ -1,22 +1,47 @@
 package xsbt
+
 import java.io.File
-import java.nio.file.Paths
 import java.util.zip.ZipFile
 
-class STJ(outputDirs: Iterable[File]) {
+/** STJ stands for Straight to Jar compilation.
+ *
+ *  This is a utility class that provides a set of functions that
+ *  are used to implement this feature.
+ *
+ *  [[sbt.internal.inc.STJ]] is an object that has similar purpose and
+ *  duplicates some of the code, as it is difficult to share it.
+ */
+final class STJ(outputDirs: Iterable[File]) {
   type JaredClass = String
   type RelClass = String
 
-  def init(jar: File, cls: RelClass): JaredClass = {
+  /** Creates an identifier for a class located inside a jar.
+    * For plain class files it is enough to simply use the path.
+    * A class in jar `JaredClass` is identified as a path to jar
+    * and path to the class within that jar. Those two values
+    * are held in one string separated by `!`. Slashes in both
+    * paths are consistent with `File.separatorChar` as the actual
+    * string is usually kept in `File` object.
+    *
+    * As an example given a jar file "C:\develop\zinc\target\output.jar"
+    * and relative path to the class "sbt/internal/inc/Compile.class"
+    * The resulting identifier would be:
+    * "C:\develop\zinc\target\output.jar!sbt\internal\inc\Compile.class"
+    *
+    *  @param jar jar file that contains the class
+    *  @param cls relative path to the class within the jar
+    *  @return identifier/path to a class in jar.
+    */
+  def jaredClass(jar: File, cls: RelClass): JaredClass = {
     // This identifier will be stored as a java.io.File. Its constructor will normalize slashes
     // which means that the identifier to be consistent should at all points have consistent
     // slashes for safe comparisons, especially in sets or maps.
-    val relClass = if (File.separatorChar == '/') cls else cls.replace(File.separatorChar, '/')
+    val relClass = if (File.separatorChar == '/') cls else cls.replace('/', File.separatorChar)
     s"$jar!$relClass"
   }
 
-  def init(cls: RelClass): JaredClass = {
-    init(outputJar.get, cls)
+  def jaredClass(cls: RelClass): JaredClass = {
+    jaredClass(outputJar.get, cls)
   }
 
   def listFiles(jar: File): Set[RelClass] = {
@@ -62,7 +87,7 @@ class STJ(outputDirs: Iterable[File]) {
         .filter(_.exists())
         .fold(Set.empty[JaredClass]) { prevJar =>
           val classes = listFiles(prevJar)
-          classes.map(init)
+          classes.map(jaredClass)
         }
     }
   }

--- a/internal/compiler-bridge/src/main/scala/xsbt/STJ.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/STJ.scala
@@ -16,22 +16,22 @@ final class STJ(outputDirs: Iterable[File]) {
   type RelClass = String
 
   /** Creates an identifier for a class located inside a jar.
-    * For plain class files it is enough to simply use the path.
-    * A class in jar `JaredClass` is identified as a path to jar
-    * and path to the class within that jar. Those two values
-    * are held in one string separated by `!`. Slashes in both
-    * paths are consistent with `File.separatorChar` as the actual
-    * string is usually kept in `File` object.
-    *
-    * As an example given a jar file "C:\develop\zinc\target\output.jar"
-    * and relative path to the class "sbt/internal/inc/Compile.class"
-    * The resulting identifier would be:
-    * "C:\develop\zinc\target\output.jar!sbt\internal\inc\Compile.class"
-    *
-    *  @param jar jar file that contains the class
-    *  @param cls relative path to the class within the jar
-    *  @return identifier/path to a class in jar.
-    */
+   * For plain class files it is enough to simply use the path.
+   * A class in jar `JaredClass` is identified as a path to jar
+   * and path to the class within that jar. Those two values
+   * are held in one string separated by `!`. Slashes in both
+   * paths are consistent with `File.separatorChar` as the actual
+   * string is usually kept in `File` object.
+   *
+   * As an example given a jar file "C:\develop\zinc\target\output.jar"
+   * and relative path to the class "sbt/internal/inc/Compile.class"
+   * The resulting identifier would be:
+   * "C:\develop\zinc\target\output.jar!sbt\internal\inc\Compile.class"
+   *
+   *  @param jar jar file that contains the class
+   *  @param cls relative path to the class within the jar
+   *  @return identifier/path to a class in jar.
+   */
   def jaredClass(jar: File, cls: RelClass): JaredClass = {
     // This identifier will be stored as a java.io.File. Its constructor will normalize slashes
     // which means that the identifier to be consistent should at all points have consistent

--- a/internal/compiler-bridge/src/main/scala/xsbt/STJ.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/STJ.scala
@@ -1,0 +1,79 @@
+package xsbt
+import java.io.File
+import java.nio.file.Paths
+import java.util.zip.ZipFile
+
+class STJ(outputDirs: Iterable[File]) {
+  type JaredClass = String
+  type RelClass = String
+
+  def init(jar: File, cls: RelClass): JaredClass = {
+    // This identifier will be stored as a java.io.File. Its constructor will normalize slashes
+    // which means that the identifier to be consistent should at all points have consistent
+    // slashes for safe comparisons, especially in sets or maps.
+    val relClass = if (File.separatorChar == '/') cls else cls.replace(File.separatorChar, '/')
+    s"$jar!$relClass"
+  }
+
+  def init(cls: RelClass): JaredClass = {
+    init(outputJar.get, cls)
+  }
+
+  def listFiles(jar: File): Set[RelClass] = {
+    import scala.collection.JavaConverters._
+    // ZipFile is slightly slower than IndexBasedZipFsOps but it is quite difficult to use reuse
+    // IndexBasedZipFsOps in compiler bridge.
+    val zip = new ZipFile(jar)
+    try {
+      zip.entries().asScala.filterNot(_.isDirectory).map(_.getName).toSet
+    } finally {
+      zip.close()
+    }
+  }
+
+  val outputJar: Option[File] = {
+    outputDirs match {
+      case Seq(file) if file.getName.endsWith(".jar") => Some(file)
+      case _                                          => None
+    }
+  }
+
+  val enabled: Boolean = outputJar.isDefined
+
+  class PrevJarCache(rawClasspath: String) extends scala.collection.generic.Clearable {
+    private var cache: Set[JaredClass] = _
+
+    private lazy val prevJar = {
+      val classpath = rawClasspath.split(File.pathSeparator)
+      findPrevJar(classpath)
+    }
+
+    def contains(jaredClass: JaredClass): Boolean = {
+      if (cache == null) {
+        cache = loadEntriesFromPrevJar()
+      }
+      cache.contains(jaredClass)
+    }
+
+    def clear(): Unit = cache = null
+
+    private def loadEntriesFromPrevJar(): Set[JaredClass] = {
+      prevJar
+        .filter(_.exists())
+        .fold(Set.empty[JaredClass]) { prevJar =>
+          val classes = listFiles(prevJar)
+          classes.map(init)
+        }
+    }
+  }
+
+  private def findPrevJar(classpath: Seq[String]): Option[File] = {
+    classpath.headOption.map(new File(_)).filter { path =>
+      val fileName = path.getName
+      fileName.startsWith(prevJarPrefix) && fileName.endsWith(".jar")
+    }
+  }
+
+  private val prevJarPrefix: String = "prev-jar"
+
+}

--- a/internal/compiler-bridge/src/main/scala/xsbt/STJ.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/STJ.scala
@@ -3,33 +3,39 @@ package xsbt
 import java.io.File
 import java.util.zip.ZipFile
 
-/** STJ stands for Straight to Jar compilation.
+/**
+ * STJ stands for Straight to Jar compilation.
  *
- *  This is a utility class that provides a set of functions that
- *  are used to implement this feature.
+ * This is a utility class that provides a set of functions that
+ * are used to implement this feature.
  *
- *  [[sbt.internal.inc.STJ]] is an object that has similar purpose and
- *  duplicates some of the code, as it is difficult to share it.
+ * [[sbt.internal.inc.STJ]] is an object that has similar purpose and
+ * duplicates some of the code, as it is difficult to share it.
  */
 final class STJ(outputDirs: Iterable[File]) {
   type JaredClass = String
   type RelClass = String
 
-  /** Creates an identifier for a class located inside a jar.
-   *  Mimics the behavior of sbt.internal.inc.STJ.JaredClass.
+  /**
+   * Creates an identifier for a class located inside a jar.
+   * Mimics the behavior of [[sbt.internal.inc.STJ.JaredClass]].
    */
   def JaredClass(jar: File, cls: RelClass): JaredClass = {
-    // This identifier will be stored as a java.io.File. Its constructor will normalize slashes
-    // which means that the identifier to be consistent should at all points have consistent
-    // slashes for safe comparisons, especially in sets or maps.
     val relClass = if (File.separatorChar == '/') cls else cls.replace('/', File.separatorChar)
     s"$jar!$relClass"
   }
 
+  /** Creates an identifier for a class located inside the current output jar. */
   def JaredClass(cls: RelClass): JaredClass = {
     JaredClass(outputJar.get, cls)
   }
 
+  /**
+   * Lists regular files (not directories) inside the given jar.
+   *
+   * @param jar the file to list jars from
+   * @return list of paths to files in jar
+   */
   def listFiles(jar: File): Set[RelClass] = {
     import scala.collection.JavaConverters._
     // ZipFile is slightly slower than IndexBasedZipFsOps but it is quite difficult to use reuse
@@ -42,6 +48,10 @@ final class STJ(outputDirs: Iterable[File]) {
     }
   }
 
+  /**
+   * The jar file that is used as output for classes. If the output is
+   * not set to a single .jar file, value of this field is [[None]].
+   */
   val outputJar: Option[File] = {
     outputDirs match {
       case Seq(file) if file.getName.endsWith(".jar") => Some(file)
@@ -49,8 +59,20 @@ final class STJ(outputDirs: Iterable[File]) {
     }
   }
 
+  /**
+   * Informs if the Straight to Jar compilation feature is enabled,
+   * i.e. if the output is set to a jar file.
+   */
   val enabled: Boolean = outputJar.isDefined
 
+  /**
+   * Class that holds cached list of paths located within previous jar for quick lookup.
+   * See [[sbt.internal.inc.STJ#withPreviousJar]] for details on what previous jar is.
+   * The previous jar is located using the classpath (if it exists it is a first entry
+   * and has a special prefix.
+   *
+   * @param rawClasspath the classpath in a single string (entries separated with [[File.pathSeparator]])
+   */
   class PrevJarCache(rawClasspath: String) extends scala.collection.generic.Clearable {
     private var cache: Set[JaredClass] = _
 

--- a/internal/compiler-bridge/src/main/scala/xsbt/STJ.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/STJ.scala
@@ -16,23 +16,9 @@ final class STJ(outputDirs: Iterable[File]) {
   type RelClass = String
 
   /** Creates an identifier for a class located inside a jar.
-   * For plain class files it is enough to simply use the path.
-   * A class in jar `JaredClass` is identified as a path to jar
-   * and path to the class within that jar. Those two values
-   * are held in one string separated by `!`. Slashes in both
-   * paths are consistent with `File.separatorChar` as the actual
-   * string is usually kept in `File` object.
-   *
-   * As an example given a jar file "C:\develop\zinc\target\output.jar"
-   * and relative path to the class "sbt/internal/inc/Compile.class"
-   * The resulting identifier would be:
-   * "C:\develop\zinc\target\output.jar!sbt\internal\inc\Compile.class"
-   *
-   *  @param jar jar file that contains the class
-   *  @param cls relative path to the class within the jar
-   *  @return identifier/path to a class in jar.
+   *  Mimics the behavior of sbt.internal.inc.STJ.JaredClass.
    */
-  def jaredClass(jar: File, cls: RelClass): JaredClass = {
+  def JaredClass(jar: File, cls: RelClass): JaredClass = {
     // This identifier will be stored as a java.io.File. Its constructor will normalize slashes
     // which means that the identifier to be consistent should at all points have consistent
     // slashes for safe comparisons, especially in sets or maps.
@@ -40,8 +26,8 @@ final class STJ(outputDirs: Iterable[File]) {
     s"$jar!$relClass"
   }
 
-  def jaredClass(cls: RelClass): JaredClass = {
-    jaredClass(outputJar.get, cls)
+  def JaredClass(cls: RelClass): JaredClass = {
+    JaredClass(outputJar.get, cls)
   }
 
   def listFiles(jar: File): Set[RelClass] = {
@@ -87,7 +73,7 @@ final class STJ(outputDirs: Iterable[File]) {
         .filter(_.exists())
         .fold(Set.empty[JaredClass]) { prevJar =>
           val classes = listFiles(prevJar)
-          classes.map(jaredClass)
+          classes.map(JaredClass)
         }
     }
   }

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/compile/CompileOptions.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/compile/CompileOptions.java
@@ -44,6 +44,11 @@ public final class CompileOptions implements java.io.Serializable {
     private java.util.function.Function<xsbti.Position, xsbti.Position> sourcePositionMapper;
     /** Controls the order in which Java and Scala sources are compiled. */
     private xsbti.compile.CompileOrder order;
+    /**
+     * Points to a temporary classes directory where the compiler can put compilation products
+     * of any kind. The lifetime of these compilation products is short and the temporary
+     * classes directory only needs to exist during one incremental compiler cycle.
+     */
     private java.util.Optional<java.io.File> temporaryClassesDirectory;
     protected CompileOptions() {
         super();

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/compile/CompileOptions.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/compile/CompileOptions.java
@@ -19,6 +19,12 @@ public final class CompileOptions implements java.io.Serializable {
     public static CompileOptions of(java.io.File[] _classpath, java.io.File[] _sources, java.io.File _classesDirectory, String[] _scalacOptions, String[] _javacOptions, int _maxErrors, java.util.function.Function<xsbti.Position, xsbti.Position> _sourcePositionMapper, xsbti.compile.CompileOrder _order) {
         return new CompileOptions(_classpath, _sources, _classesDirectory, _scalacOptions, _javacOptions, _maxErrors, _sourcePositionMapper, _order);
     }
+    public static CompileOptions create(java.io.File[] _classpath, java.io.File[] _sources, java.io.File _classesDirectory, String[] _scalacOptions, String[] _javacOptions, int _maxErrors, java.util.function.Function<xsbti.Position, xsbti.Position> _sourcePositionMapper, xsbti.compile.CompileOrder _order, java.util.Optional<java.io.File> _temporaryClassesDirectory) {
+        return new CompileOptions(_classpath, _sources, _classesDirectory, _scalacOptions, _javacOptions, _maxErrors, _sourcePositionMapper, _order, _temporaryClassesDirectory);
+    }
+    public static CompileOptions of(java.io.File[] _classpath, java.io.File[] _sources, java.io.File _classesDirectory, String[] _scalacOptions, String[] _javacOptions, int _maxErrors, java.util.function.Function<xsbti.Position, xsbti.Position> _sourcePositionMapper, xsbti.compile.CompileOrder _order, java.util.Optional<java.io.File> _temporaryClassesDirectory) {
+        return new CompileOptions(_classpath, _sources, _classesDirectory, _scalacOptions, _javacOptions, _maxErrors, _sourcePositionMapper, _order, _temporaryClassesDirectory);
+    }
     /**
      * The classpath to use for compilation.
      * This will be modified according to the ClasspathOptions used to configure the ScalaCompiler.
@@ -38,6 +44,7 @@ public final class CompileOptions implements java.io.Serializable {
     private java.util.function.Function<xsbti.Position, xsbti.Position> sourcePositionMapper;
     /** Controls the order in which Java and Scala sources are compiled. */
     private xsbti.compile.CompileOrder order;
+    private java.util.Optional<java.io.File> temporaryClassesDirectory;
     protected CompileOptions() {
         super();
         classpath = new java.io.File[0];
@@ -48,6 +55,7 @@ public final class CompileOptions implements java.io.Serializable {
         maxErrors = 100;
         sourcePositionMapper = new java.util.function.Function<xsbti.Position, xsbti.Position>() { public xsbti.Position apply(xsbti.Position a) { return a; } };
         order = xsbti.compile.CompileOrder.Mixed;
+        temporaryClassesDirectory = java.util.Optional.empty();
     }
     protected CompileOptions(java.io.File[] _classpath, java.io.File[] _sources, java.io.File _classesDirectory, String[] _scalacOptions, String[] _javacOptions, int _maxErrors, java.util.function.Function<xsbti.Position, xsbti.Position> _sourcePositionMapper, xsbti.compile.CompileOrder _order) {
         super();
@@ -59,6 +67,19 @@ public final class CompileOptions implements java.io.Serializable {
         maxErrors = _maxErrors;
         sourcePositionMapper = _sourcePositionMapper;
         order = _order;
+        temporaryClassesDirectory = java.util.Optional.empty();
+    }
+    protected CompileOptions(java.io.File[] _classpath, java.io.File[] _sources, java.io.File _classesDirectory, String[] _scalacOptions, String[] _javacOptions, int _maxErrors, java.util.function.Function<xsbti.Position, xsbti.Position> _sourcePositionMapper, xsbti.compile.CompileOrder _order, java.util.Optional<java.io.File> _temporaryClassesDirectory) {
+        super();
+        classpath = _classpath;
+        sources = _sources;
+        classesDirectory = _classesDirectory;
+        scalacOptions = _scalacOptions;
+        javacOptions = _javacOptions;
+        maxErrors = _maxErrors;
+        sourcePositionMapper = _sourcePositionMapper;
+        order = _order;
+        temporaryClassesDirectory = _temporaryClassesDirectory;
     }
     public java.io.File[] classpath() {
         return this.classpath;
@@ -84,29 +105,35 @@ public final class CompileOptions implements java.io.Serializable {
     public xsbti.compile.CompileOrder order() {
         return this.order;
     }
+    public java.util.Optional<java.io.File> temporaryClassesDirectory() {
+        return this.temporaryClassesDirectory;
+    }
     public CompileOptions withClasspath(java.io.File[] classpath) {
-        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, maxErrors, sourcePositionMapper, order);
+        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, maxErrors, sourcePositionMapper, order, temporaryClassesDirectory);
     }
     public CompileOptions withSources(java.io.File[] sources) {
-        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, maxErrors, sourcePositionMapper, order);
+        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, maxErrors, sourcePositionMapper, order, temporaryClassesDirectory);
     }
     public CompileOptions withClassesDirectory(java.io.File classesDirectory) {
-        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, maxErrors, sourcePositionMapper, order);
+        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, maxErrors, sourcePositionMapper, order, temporaryClassesDirectory);
     }
     public CompileOptions withScalacOptions(String[] scalacOptions) {
-        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, maxErrors, sourcePositionMapper, order);
+        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, maxErrors, sourcePositionMapper, order, temporaryClassesDirectory);
     }
     public CompileOptions withJavacOptions(String[] javacOptions) {
-        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, maxErrors, sourcePositionMapper, order);
+        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, maxErrors, sourcePositionMapper, order, temporaryClassesDirectory);
     }
     public CompileOptions withMaxErrors(int maxErrors) {
-        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, maxErrors, sourcePositionMapper, order);
+        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, maxErrors, sourcePositionMapper, order, temporaryClassesDirectory);
     }
     public CompileOptions withSourcePositionMapper(java.util.function.Function<xsbti.Position, xsbti.Position> sourcePositionMapper) {
-        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, maxErrors, sourcePositionMapper, order);
+        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, maxErrors, sourcePositionMapper, order, temporaryClassesDirectory);
     }
     public CompileOptions withOrder(xsbti.compile.CompileOrder order) {
-        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, maxErrors, sourcePositionMapper, order);
+        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, maxErrors, sourcePositionMapper, order, temporaryClassesDirectory);
+    }
+    public CompileOptions withTemporaryClassesDirectory(java.util.Optional<java.io.File> temporaryClassesDirectory) {
+        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, maxErrors, sourcePositionMapper, order, temporaryClassesDirectory);
     }
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -115,13 +142,13 @@ public final class CompileOptions implements java.io.Serializable {
             return false;
         } else {
             CompileOptions o = (CompileOptions)obj;
-            return java.util.Arrays.deepEquals(this.classpath(), o.classpath()) && java.util.Arrays.deepEquals(this.sources(), o.sources()) && this.classesDirectory().equals(o.classesDirectory()) && java.util.Arrays.deepEquals(this.scalacOptions(), o.scalacOptions()) && java.util.Arrays.deepEquals(this.javacOptions(), o.javacOptions()) && (this.maxErrors() == o.maxErrors()) && this.sourcePositionMapper().equals(o.sourcePositionMapper()) && this.order().equals(o.order());
+            return java.util.Arrays.deepEquals(this.classpath(), o.classpath()) && java.util.Arrays.deepEquals(this.sources(), o.sources()) && this.classesDirectory().equals(o.classesDirectory()) && java.util.Arrays.deepEquals(this.scalacOptions(), o.scalacOptions()) && java.util.Arrays.deepEquals(this.javacOptions(), o.javacOptions()) && (this.maxErrors() == o.maxErrors()) && this.sourcePositionMapper().equals(o.sourcePositionMapper()) && this.order().equals(o.order()) && this.temporaryClassesDirectory().equals(o.temporaryClassesDirectory());
         }
     }
     public int hashCode() {
-        return 37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.compile.CompileOptions".hashCode()) + java.util.Arrays.deepHashCode(classpath())) + java.util.Arrays.deepHashCode(sources())) + classesDirectory().hashCode()) + java.util.Arrays.deepHashCode(scalacOptions())) + java.util.Arrays.deepHashCode(javacOptions())) + (new Integer(maxErrors())).hashCode()) + sourcePositionMapper().hashCode()) + order().hashCode());
+        return 37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.compile.CompileOptions".hashCode()) + java.util.Arrays.deepHashCode(classpath())) + java.util.Arrays.deepHashCode(sources())) + classesDirectory().hashCode()) + java.util.Arrays.deepHashCode(scalacOptions())) + java.util.Arrays.deepHashCode(javacOptions())) + (new Integer(maxErrors())).hashCode()) + sourcePositionMapper().hashCode()) + order().hashCode()) + temporaryClassesDirectory().hashCode());
     }
     public String toString() {
-        return "CompileOptions("  + "classpath: " + classpath() + ", " + "sources: " + sources() + ", " + "classesDirectory: " + classesDirectory() + ", " + "scalacOptions: " + scalacOptions() + ", " + "javacOptions: " + javacOptions() + ", " + "maxErrors: " + maxErrors() + ", " + "sourcePositionMapper: " + sourcePositionMapper() + ", " + "order: " + order() + ")";
+        return "CompileOptions("  + "classpath: " + classpath() + ", " + "sources: " + sources() + ", " + "classesDirectory: " + classesDirectory() + ", " + "scalacOptions: " + scalacOptions() + ", " + "javacOptions: " + javacOptions() + ", " + "maxErrors: " + maxErrors() + ", " + "sourcePositionMapper: " + sourcePositionMapper() + ", " + "order: " + order() + ", " + "temporaryClassesDirectory: " + temporaryClassesDirectory() + ")";
     }
 }

--- a/internal/compiler-interface/src/main/contraband/incremental.json
+++ b/internal/compiler-interface/src/main/contraband/incremental.json
@@ -312,6 +312,12 @@
           "default": "xsbti.compile.CompileOrder.Mixed",
           "doc": "Controls the order in which Java and Scala sources are compiled.",
           "since": "0.1.0"
+        },
+        {
+          "name": "temporaryClassesDirectory",
+          "type": "java.util.Optional<java.io.File>",
+          "default": "java.util.Optional.empty()",
+          "since": "1.3.0"
         }
       ]
     },

--- a/internal/compiler-interface/src/main/contraband/incremental.json
+++ b/internal/compiler-interface/src/main/contraband/incremental.json
@@ -317,6 +317,11 @@
           "name": "temporaryClassesDirectory",
           "type": "java.util.Optional<java.io.File>",
           "default": "java.util.Optional.empty()",
+          "doc": [
+            "Points to a temporary classes directory where the compiler can put compilation products",
+            "of any kind. The lifetime of these compilation products is short and the temporary",
+            "classes directory only needs to exist during one incremental compiler cycle."
+          ],
           "since": "1.3.0"
         }
       ]

--- a/internal/compiler-interface/src/main/java/xsbti/AnalysisCallback.java
+++ b/internal/compiler-interface/src/main/java/xsbti/AnalysisCallback.java
@@ -8,9 +8,9 @@
 package xsbti;
 
 import xsbti.api.DependencyContext;
+
 import java.io.File;
 import java.util.EnumSet;
-import java.util.Optional;
 
 public interface AnalysisCallback {
     /**
@@ -175,11 +175,9 @@ public interface AnalysisCallback {
     boolean enabled();
 
     /**
-     * Returns path to a jar generated in previous compilation if it exists
-     * and compilation to jar is enabled.
-     *
-     * @see sbt.internal.inc.JarUtils#withPreviousJar for more information.
+     * Returns paths to classes that are currently in jar.
+     * Format is "xsbti/AnalysisCallback.class".
      */
-    Optional<File> previousJar();
+    java.util.Set<String> classesInJar();
 
 }

--- a/internal/compiler-interface/src/main/java/xsbti/AnalysisCallback.java
+++ b/internal/compiler-interface/src/main/java/xsbti/AnalysisCallback.java
@@ -175,9 +175,27 @@ public interface AnalysisCallback {
     boolean enabled();
 
     /**
-     * Returns paths to classes that are currently in jar.
-     * Format is "xsbti/AnalysisCallback.class".
+     * Return class files in output jar at a given point in time.
+     *
+     * When straight-to-jar compilation is enabled, the following entrypoint
+     * in the analysis callback tells the compiler which classes can be found
+     * in the jar used as a compilation target (where all class files will be
+     * store). The entrypoint will return all the paths to class files in Zinc
+     * format, an example would be `xsbti/AnalysisCallback.class`.
+     *
+     * This entrypoint serves two main purposes:
+     *
+     * 1. Before the dependency phase is run, it returns the class files found
+     *    in the jar previous to the current compilation.
+     * 2. After dependency has run, when called again, it returns the class
+     *    files written by the compiler in genbcode.
+     *
+     * The second purpose is required because the compiler cannot communicate
+     * us via an internal programmatic API which files has written in genbcode
+     * and therefore we need to pay the price of opening the jar again to figure
+     * it out. If the compiler is to expose an entry point for this data, we
+     * can repurpose `classesInOutputJar` to only do 1).
      */
-    java.util.Set<String> classesInJar();
+    java.util.Set<String> classesInOutputJar();
 
 }

--- a/internal/compiler-interface/src/main/java/xsbti/AnalysisCallback.java
+++ b/internal/compiler-interface/src/main/java/xsbti/AnalysisCallback.java
@@ -10,6 +10,7 @@ package xsbti;
 import xsbti.api.DependencyContext;
 import java.io.File;
 import java.util.EnumSet;
+import java.util.Optional;
 
 public interface AnalysisCallback {
     /**
@@ -172,4 +173,13 @@ public interface AnalysisCallback {
      * phase defined by <code>xsbt-analyzer</code> should be added.
      */
     boolean enabled();
+
+    /**
+     * Returns path to a jar generated in previous compilation if it exists
+     * and compilation to jar is enabled.
+     *
+     * @see sbt.internal.inc.JarUtils#withPreviousJar for more information.
+     */
+    Optional<File> previousJar();
+
 }

--- a/internal/compiler-interface/src/main/java/xsbti/compile/IncrementalCompiler.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/IncrementalCompiler.java
@@ -79,6 +79,8 @@ public interface IncrementalCompiler {
      *                 the current compilation progress.
      * @param incrementalOptions An Instance of {@link IncOptions} that
      *                           configures the incremental compiler behaviour.
+     * @param temporaryClassesDirectory A directory where incremental compiler
+     *                                  will put temporary class files or jars.
      * @param extra An array of sbt tuples with extra options.
      * @param logger An instance of {@link Logger} that logs Zinc output.
      *
@@ -104,6 +106,7 @@ public interface IncrementalCompiler {
                           java.lang.Boolean skip,
                           Optional<CompileProgress> progress,
                           IncOptions incrementalOptions,
+                          Optional<File> temporaryClassesDirectory,
                           T2<String, String>[] extra,
                           Logger logger);
 }

--- a/internal/compiler-interface/src/main/java/xsbti/compile/IncrementalCompiler.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/IncrementalCompiler.java
@@ -80,7 +80,7 @@ public interface IncrementalCompiler {
      * @param incrementalOptions An Instance of {@link IncOptions} that
      *                           configures the incremental compiler behaviour.
      * @param temporaryClassesDirectory A directory where incremental compiler
-     *                                  will put temporary class files or jars.
+     *                                  can put temporary class files or jars.
      * @param extra An array of sbt tuples with extra options.
      * @param logger An instance of {@link Logger} that logs Zinc output.
      *

--- a/internal/compiler-interface/src/main/java/xsbti/compile/SingleOutput.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/SingleOutput.java
@@ -16,13 +16,15 @@ import java.util.Optional;
  */
 public interface SingleOutput extends Output {
     /**
-     * Return the directory where class files should be generated.
+     * Return the **directory or jar** where class files should be generated
+     * and written to. The method name is a misnamer since it can return a
+     * jar file when straight-to-jar compilation is enabled.
      * <p>
-     * Incremental compilation manages the class files in this directory, so
-     * don't play with this directory out of the Zinc API. Zinc already takes
-     * care of deleting classes before every compilation run.
+     * Incremental compilation manages the class files in this file, so don't
+     * play with this directory out of the Zinc API. Zinc already takes care
+     * of deleting classes before every compilation run.
      * <p>
-     * This directory must be exclusively used for one set of sources.
+     * This file or directory must be exclusively used for one set of sources.
      */
     public File getOutputDirectory();
 

--- a/internal/compiler-interface/src/main/java/xsbti/compile/analysis/ReadStamps.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/analysis/ReadStamps.java
@@ -72,4 +72,10 @@ public interface ReadStamps {
      * @see xsbti.compile.analysis.ReadStamps#product(File)
      */
     public Map<File, Stamp> getAllProductStamps();
+
+    /**
+     * Resets internal state of stamp reader that concerns data changing during the compilation.
+     * Namely it resets the cache for compilation products. Should be called before each compilation.
+     */
+    public void reset();
 }

--- a/internal/compiler-interface/src/main/java/xsbti/compile/analysis/ReadStamps.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/analysis/ReadStamps.java
@@ -73,9 +73,4 @@ public interface ReadStamps {
      */
     public Map<File, Stamp> getAllProductStamps();
 
-    /**
-     * Resets internal state of stamp reader that concerns data changing during the compilation.
-     * Namely it resets the cache for compilation products. Should be called before each compilation.
-     */
-    public void reset();
 }

--- a/internal/compiler-interface/src/test/scala/xsbti/TestCallback.scala
+++ b/internal/compiler-interface/src/test/scala/xsbti/TestCallback.scala
@@ -79,7 +79,7 @@ class TestCallback extends AnalysisCallback {
 
   override def apiPhaseCompleted(): Unit = {}
 
-  override def classesInJar(): util.Set[String] = java.util.Collections.emptySet()
+  override def classesInOutputJar(): util.Set[String] = java.util.Collections.emptySet()
 }
 
 object TestCallback {

--- a/internal/compiler-interface/src/test/scala/xsbti/TestCallback.scala
+++ b/internal/compiler-interface/src/test/scala/xsbti/TestCallback.scala
@@ -2,8 +2,9 @@ package xsbti
 
 import java.io.File
 import java.util
+import java.util.Optional
 
-import xsbti.api.{ ClassLike, DependencyContext }
+import xsbti.api.{ DependencyContext, ClassLike }
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -77,6 +78,9 @@ class TestCallback extends AnalysisCallback {
   override def dependencyPhaseCompleted(): Unit = {}
 
   override def apiPhaseCompleted(): Unit = {}
+
+  override def previousJar(): Optional[File] = Optional.empty[File]
+
 }
 
 object TestCallback {

--- a/internal/compiler-interface/src/test/scala/xsbti/TestCallback.scala
+++ b/internal/compiler-interface/src/test/scala/xsbti/TestCallback.scala
@@ -79,8 +79,7 @@ class TestCallback extends AnalysisCallback {
 
   override def apiPhaseCompleted(): Unit = {}
 
-  override def previousJar(): Optional[File] = Optional.empty[File]
-
+  override def classesInJar(): util.Set[String] = java.util.Collections.emptySet()
 }
 
 object TestCallback {

--- a/internal/zinc-classfile/src/main/java/sbt/internal/inc/zip/ZipCentralDir.java
+++ b/internal/zinc-classfile/src/main/java/sbt/internal/inc/zip/ZipCentralDir.java
@@ -60,8 +60,15 @@ import static sbt.internal.inc.zip.ZipUtils.*;
  * @author Xueming Shen
  */
 
-// Modified implementation of com.sun.nio.zipfs.ZipFileSystem that allows to:
-// read index (central directory), modify it and write at specified offset
+/**
+ * Modified implementation of [[com.sun.nio.zipfs.ZipFileSystem]] that allows to:
+ * read index (central directory), modify it and write at specified offset.
+ *
+ * The changes focus on making public whatever is required and remove what is not.
+ * It is possible to use unmodified ZipFileSystem to implement operations required
+ * for Straight to Jar but it does not work in place (has to recreate zips) and does
+ * not allow to disable compression that makes it not efficient enough.
+ */
 public class ZipCentralDir {
 
     private final byte[] cen; // CEN & ENDHDR

--- a/internal/zinc-classfile/src/main/java/sbt/internal/inc/zip/ZipCentralDir.java
+++ b/internal/zinc-classfile/src/main/java/sbt/internal/inc/zip/ZipCentralDir.java
@@ -1,0 +1,735 @@
+/*
+ * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   - Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   - Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ *   - Neither the name of Oracle nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This source code is provided to illustrate the usage of a given feature
+ * or technique and has been deliberately simplified. Additional steps
+ * required for a production-quality application, such as security checks,
+ * input validation and proper error handling, might not be present in
+ * this sample code.
+ */
+
+
+package sbt.internal.inc.zip;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.zip.ZipError;
+import java.util.zip.ZipException;
+
+import static java.nio.file.StandardOpenOption.READ;
+import static sbt.internal.inc.zip.ZipConstants.*;
+import static sbt.internal.inc.zip.ZipUtils.*;
+
+/**
+ * A FileSystem built on a zip file
+ *
+ * @author Xueming Shen
+ */
+
+// Modified implementation of com.sun.nio.zipfs.ZipFileSystem that allows to:
+// read index (central directory), modify it and write at specified offset
+public class ZipCentralDir {
+
+    private final byte[] cen; // CEN & ENDHDR
+    private END end;
+    private final SeekableByteChannel ch;
+    private LinkedHashMap<IndexNode, IndexNode> inodes;
+    private static byte[] ROOTPATH = new byte[0];
+    private final IndexNode LOOKUPKEY = IndexNode.keyOf(null);
+    private List<Entry> elist;
+    private static final boolean isWindows =
+            System.getProperty("os.name").startsWith("Windows");
+
+    public ZipCentralDir(Path zfpath) throws IOException {
+        this.ch = Files.newByteChannel(zfpath, READ);
+        this.cen = initCEN();
+        elist = readEntries();
+        ch.close();
+    }
+
+    public long getCentralDirStart() {
+        return end.cenoff;
+    }
+
+    public void setCentralDirStart(long value) {
+        end.cenoff = value;
+    }
+
+    public List<Entry> getHeaders() {
+        return elist;
+    }
+
+    public void setHeaders(List<Entry> value) {
+        elist = value;
+    }
+
+    public void dump(OutputStream os) throws IOException {
+        long written = 0;
+        for (Entry entry : elist) {
+            written += entry.writeCEN(os);
+        }
+        end.centot = elist.size();
+        end.cenlen = written;
+        end.write(os, written);
+    }
+
+    private List<Entry> readEntries() throws IOException {
+        List<Entry> elist = new ArrayList<>();
+        for (IndexNode inode : inodes.values()) {
+            if (inode.pos == -1) {
+                continue;               // pseudo directory node
+            }
+            Entry e = Entry.readCEN(this, inode.pos);
+            elist.add(e);
+        }
+        return elist;
+    }
+
+    // Reads zip file central directory. Returns the file position of first
+    // CEN header, otherwise returns -1 if an error occurred. If zip->msg != NULL
+    // then the error was a zip format error and zip->msg has the error text.
+    // Always pass in -1 for knownTotal; it's used for a recursive call.
+    private byte[] initCEN() throws IOException {
+        end = findEND();
+        // position of first LOC header (usually 0)
+        long locpos;
+        if (end.endpos == 0) {
+            inodes = new LinkedHashMap<>(10);
+            locpos = 0;
+            buildNodeTree();
+            return null;         // only END header present
+        }
+        if (end.cenlen > end.endpos)
+            zerror("invalid END header (bad central directory size)");
+        long cenpos = end.endpos - end.cenlen;     // position of CEN table
+
+        // Get position of first local file (LOC) header, taking into
+        // account that there may be a stub prefixed to the zip file.
+        locpos = cenpos - end.cenoff;
+        if (locpos < 0)
+            zerror("invalid END header (bad central directory offset)");
+
+        // read in the CEN and END
+        byte[] cen = new byte[(int)(end.cenlen + ENDHDR)];
+        if (readFullyAt(cen, 0, cen.length, cenpos) != end.cenlen + ENDHDR) {
+            zerror("read CEN tables failed");
+        }
+        // Iterate through the entries in the central directory
+        inodes = new LinkedHashMap<>(end.centot + 1);
+        int pos = 0;
+        int limit = cen.length - ENDHDR;
+        while (pos < limit) {
+            if (CENSIG(cen, pos) != CENSIG)
+                zerror("invalid CEN header (bad signature)");
+            int method = CENHOW(cen, pos);
+            int nlen   = CENNAM(cen, pos);
+            int elen   = CENEXT(cen, pos);
+            int clen   = CENCOM(cen, pos);
+            if ((CENFLG(cen, pos) & 1) != 0)
+                zerror("invalid CEN header (encrypted entry)");
+            if (method != METHOD_STORED && method != METHOD_DEFLATED)
+                zerror("invalid CEN header (unsupported compression method: " + method + ")");
+            if (pos + CENHDR + nlen > limit)
+                zerror("invalid CEN header (bad header size)");
+            byte[] name = Arrays.copyOfRange(cen, pos + CENHDR, pos + CENHDR + nlen);
+            IndexNode inode = new IndexNode(name, pos);
+            inodes.put(inode, inode);
+            // skip ext and comment
+            pos += (CENHDR + nlen + elen + clen);
+        }
+        if (pos + ENDHDR != cen.length) {
+            zerror("invalid CEN header (bad header size)");
+        }
+        buildNodeTree();
+        return cen;
+    }
+
+    private END findEND() throws IOException
+    {
+        byte[] buf = new byte[READBLOCKSZ];
+        long ziplen = ch.size();
+        long minHDR = (ziplen - END_MAXLEN) > 0 ? ziplen - END_MAXLEN : 0;
+        long minPos = minHDR - (buf.length - ENDHDR);
+
+        for (long pos = ziplen - buf.length; pos >= minPos; pos -= (buf.length - ENDHDR))
+        {
+            int off = 0;
+            if (pos < 0) {
+                // Pretend there are some NUL bytes before start of file
+                off = (int)-pos;
+                Arrays.fill(buf, 0, off, (byte)0);
+            }
+            int len = buf.length - off;
+            if (readFullyAt(buf, off, len, pos + off) != len)
+                zerror("zip END header not found");
+
+            // Now scan the block backwards for END header signature
+            for (int i = buf.length - ENDHDR; i >= 0; i--) {
+                if (buf[i+0] == (byte)'P'    &&
+                        buf[i+1] == (byte)'K'    &&
+                        buf[i+2] == (byte)'\005' &&
+                        buf[i+3] == (byte)'\006' &&
+                        (pos + i + ENDHDR + ENDCOM(buf, i) == ziplen)) {
+                    // Found END header
+                    buf = Arrays.copyOfRange(buf, i, i + ENDHDR);
+                    END end = new END();
+                    end.endsub = ENDSUB(buf);
+                    end.centot = ENDTOT(buf);
+                    end.cenlen = ENDSIZ(buf);
+                    end.cenoff = ENDOFF(buf);
+                    end.comlen = ENDCOM(buf);
+                    end.endpos = pos + i;
+                    if (end.cenlen == ZIP64_MINVAL ||
+                            end.cenoff == ZIP64_MINVAL ||
+                            end.centot == ZIP64_MINVAL32)
+                    {
+                        // need to find the zip64 end;
+                        byte[] loc64 = new byte[ZIP64_LOCHDR];
+                        if (readFullyAt(loc64, 0, loc64.length, end.endpos - ZIP64_LOCHDR)
+                                != loc64.length) {
+                            return end;
+                        }
+                        long end64pos = ZIP64_LOCOFF(loc64);
+                        byte[] end64buf = new byte[ZIP64_ENDHDR];
+                        if (readFullyAt(end64buf, 0, end64buf.length, end64pos)
+                                != end64buf.length) {
+                            return end;
+                        }
+                        // end64 found, re-calcualte everything.
+                        end.cenlen = ZIP64_ENDSIZ(end64buf);
+                        end.cenoff = ZIP64_ENDOFF(end64buf);
+                        end.centot = (int)ZIP64_ENDTOT(end64buf); // assume total < 2g
+                        end.endpos = end64pos;
+                    }
+                    return end;
+                }
+            }
+        }
+        zerror("zip END header not found");
+        return null; //make compiler happy
+    }
+
+    // Internal node that links a "name" to its pos in cen table.
+    // The node itself can be used as a "key" to lookup itself in
+    // the HashMap inodes.
+    static class IndexNode {
+        byte[] name;
+        int    hashcode;  // node is hashable/hashed by its name
+        int    pos = -1;  // position in cen table, -1 menas the
+        String nameAsString;
+        // entry does not exists in zip file
+        IndexNode(byte[] name, int pos) {
+            setName(name);
+            this.pos = pos;
+        }
+
+        static IndexNode keyOf(byte[] name) { // get a lookup key;
+            return new IndexNode(name, -1);
+        }
+
+        public final void setName(byte[] name) {
+            this.name = name;
+            this.hashcode = Arrays.hashCode(name);
+        }
+
+        public final String getName() {
+            if (nameAsString == null) {
+                this.nameAsString = new String(name);
+            }
+            return this.nameAsString;
+        }
+
+        final IndexNode as(byte[] name) {           // reuse the node, mostly
+            setName(name);                             // as a lookup "key"
+            return this;
+        }
+
+        public boolean equals(Object other) {
+            if (!(other instanceof IndexNode)) {
+                return false;
+            }
+            return Arrays.equals(name, ((IndexNode)other).name);
+        }
+
+        public int hashCode() {
+            return hashcode;
+        }
+
+        IndexNode() {}
+        IndexNode sibling;
+        IndexNode child;  // 1st child
+    }
+
+    private static void zerror(String msg) {
+        throw new ZipError(msg);
+    }
+
+    private void buildNodeTree() {
+        HashSet<IndexNode> dirs = new HashSet<>();
+        IndexNode root = new IndexNode(ROOTPATH, -1);
+        inodes.put(root, root);
+        dirs.add(root);
+        for (IndexNode node : inodes.keySet().toArray(new IndexNode[0])) {
+            addToTree(node, dirs);
+        }
+    }
+
+    // ZIP directory has two issues:
+    // (1) ZIP spec does not require the ZIP file to include
+    //     directory entry
+    // (2) all entries are not stored/organized in a "tree"
+    //     structure.
+    // A possible solution is to build the node tree ourself as
+    // implemented below.
+    private void addToTree(IndexNode inode, HashSet<IndexNode> dirs) {
+        if (dirs.contains(inode)) {
+            return;
+        }
+        IndexNode parent;
+        byte[] name = inode.name;
+        byte[] pname = getParent(name);
+        if (inodes.containsKey(LOOKUPKEY.as(pname))) {
+            parent = inodes.get(LOOKUPKEY);
+        } else {    // pseudo directory entry
+            parent = new IndexNode(pname, -1);
+            inodes.put(parent, parent);
+        }
+        addToTree(parent, dirs);
+        inode.sibling = parent.child;
+        parent.child = inode;
+        if (name[name.length -1] == '/')
+            dirs.add(inode);
+    }
+
+    private static byte[] getParent(byte[] path) {
+        int off = path.length - 1;
+        if (off > 0 && path[off] == '/')  // isDirectory
+            off--;
+        while (off > 0 && path[off] != '/') { off--; }
+        if (off <= 0)
+            return ROOTPATH;
+        return Arrays.copyOf(path, off + 1);
+    }
+
+    // Reads len bytes of data from the specified offset into buf.
+    // Returns the total number of bytes read.
+    // Each/every byte read from here (except the cen, which is mapped).
+    private long readFullyAt(byte[] buf, int off, long len, long pos) throws IOException
+    {
+        ByteBuffer bb = ByteBuffer.wrap(buf);
+        bb.position(off);
+        bb.limit((int)(off + len));
+        return readFullyAt(bb, pos);
+    }
+
+    private long readFullyAt(ByteBuffer bb, long pos) throws IOException
+    {
+        return ch.position(pos).read(bb);
+    }
+
+    // End of central directory record
+    static class END {
+        int  endsub;     // endsub
+        int  centot;     // 4 bytes
+        long cenlen;     // 4 bytes
+        long cenoff;     // 4 bytes
+        int  comlen;     // comment length
+        byte[] comment;
+
+        /* members of Zip64 end of central directory locator */
+        long endpos;
+
+        void write(OutputStream os, long offset) throws IOException {
+            boolean hasZip64 = false;
+            long xlen = cenlen;
+            long xoff = cenoff;
+            if (xlen >= ZIP64_MINVAL) {
+                xlen = ZIP64_MINVAL;
+                hasZip64 = true;
+            }
+            if (xoff >= ZIP64_MINVAL) {
+                xoff = ZIP64_MINVAL;
+                hasZip64 = true;
+            }
+            int count = centot;
+            if (count >= ZIP64_MINVAL32) {
+                count = ZIP64_MINVAL32;
+                hasZip64 = true;
+            }
+            if (hasZip64) {
+                long off64 = offset;
+                //zip64 end of central directory record
+                writeInt(os, ZIP64_ENDSIG);       // zip64 END record signature
+                writeLong(os, ZIP64_ENDHDR - 12); // size of zip64 end
+                writeShort(os, 45);               // version made by
+                writeShort(os, 45);               // version needed to extract
+                writeInt(os, 0);                  // number of this disk
+                writeInt(os, 0);                  // central directory start disk
+                writeLong(os, centot);            // number of directory entires on disk
+                writeLong(os, centot);            // number of directory entires
+                writeLong(os, cenlen);            // length of central directory
+                writeLong(os, cenoff);            // offset of central directory
+
+                //zip64 end of central directory locator
+                writeInt(os, ZIP64_LOCSIG);       // zip64 END locator signature
+                writeInt(os, 0);                  // zip64 END start disk
+                writeLong(os, off64);             // offset of zip64 END
+                writeInt(os, 1);                  // total number of disks (?)
+            }
+            writeInt(os, ENDSIG);                 // END record signature
+            writeShort(os, 0);                    // number of this disk
+            writeShort(os, 0);                    // central directory start disk
+            writeShort(os, count);                // number of directory entries on disk
+            writeShort(os, count);                // total number of directory entries
+            writeInt(os, xlen);                   // length of central directory
+            writeInt(os, xoff);                   // offset of central directory
+            if (comment != null) {            // zip file comment
+                writeShort(os, comment.length);
+                writeBytes(os, comment);
+            } else {
+                writeShort(os, 0);
+            }
+        }
+    }
+
+    public static class Entry extends IndexNode {
+
+        // entry attributes
+        int    version;
+        int    flag;
+        int    method = -1;    // compression method
+        long   mtime  = -1;    // last modification time (in DOS time)
+        long   atime  = -1;    // last access time
+        long   ctime  = -1;    // create time
+        long   crc    = -1;    // crc-32 of entry data
+        long   csize  = -1;    // compressed size of entry data
+        long   size   = -1;    // uncompressed size of entry data
+        byte[] extra;
+
+        // cen
+        int    versionMade;
+        int    disk;
+        int    attrs;
+        long   attrsEx;
+        long   locoff;
+        byte[] comment;
+
+        Entry() {}
+
+        public final long getLastModifiedTime() {
+            return mtime;
+        }
+
+        public final long getEntryOffset() {
+            return locoff;
+        }
+
+        public final  void setEntryOffset(long value) {
+            this.locoff = value;
+        }
+
+        int version() throws ZipException {
+            if (method == METHOD_DEFLATED)
+                return 20;
+            else if (method == METHOD_STORED)
+                return 10;
+            throw new ZipException("unsupported compression method");
+        }
+
+        ///////////////////// CEN //////////////////////
+        static Entry readCEN(ZipCentralDir zipfs, int pos)
+                throws IOException
+        {
+            return new Entry().cen(zipfs, pos);
+        }
+
+        private Entry cen(ZipCentralDir zipfs, int pos)
+                throws IOException
+        {
+            byte[] cen = zipfs.cen;
+            if (CENSIG(cen, pos) != CENSIG)
+                zerror("invalid CEN header (bad signature)");
+            versionMade = CENVEM(cen, pos);
+            version     = CENVER(cen, pos);
+            flag        = CENFLG(cen, pos);
+            method      = CENHOW(cen, pos);
+            mtime       = dosToJavaTime(CENTIM(cen, pos));
+            crc         = CENCRC(cen, pos);
+            csize       = CENSIZ(cen, pos);
+            size        = CENLEN(cen, pos);
+            int nlen    = CENNAM(cen, pos);
+            int elen    = CENEXT(cen, pos);
+            int clen    = CENCOM(cen, pos);
+            disk        = CENDSK(cen, pos);
+            attrs       = CENATT(cen, pos);
+            attrsEx     = CENATX(cen, pos);
+            locoff      = CENOFF(cen, pos);
+
+            pos += CENHDR;
+            setName(Arrays.copyOfRange(cen, pos, pos + nlen));
+
+            pos += nlen;
+            if (elen > 0) {
+                extra = Arrays.copyOfRange(cen, pos, pos + elen);
+                pos += elen;
+                readExtra(zipfs);
+            }
+            if (clen > 0) {
+                comment = Arrays.copyOfRange(cen, pos, pos + clen);
+            }
+            return this;
+        }
+
+        int writeCEN(OutputStream os) throws IOException
+        {
+            int version0 = version();
+            long csize0  = csize;
+            long size0   = size;
+            long locoff0 = locoff;
+            int elen64   = 0;                // extra for ZIP64
+            int elenNTFS = 0;                // extra for NTFS (a/c/mtime)
+            int elenEXTT = 0;                // extra for Extended Timestamp
+            boolean foundExtraTime = false;  // if time stamp NTFS, EXTT present
+
+            // confirm size/length
+            int nlen = (name != null) ? name.length : 0;
+            int elen = (extra != null) ? extra.length : 0;
+            int eoff = 0;
+            int clen = (comment != null) ? comment.length : 0;
+            if (csize >= ZIP64_MINVAL) {
+                csize0 = ZIP64_MINVAL;
+                elen64 += 8;                 // csize(8)
+            }
+            if (size >= ZIP64_MINVAL) {
+                size0 = ZIP64_MINVAL;        // size(8)
+                elen64 += 8;
+            }
+            if (locoff >= ZIP64_MINVAL) {
+                locoff0 = ZIP64_MINVAL;
+                elen64 += 8;                 // offset(8)
+            }
+            if (elen64 != 0) {
+                elen64 += 4;                 // header and data sz 4 bytes
+            }
+            while (eoff + 4 < elen) {
+                int tag = SH(extra, eoff);
+                int sz = SH(extra, eoff + 2);
+                if (tag == EXTID_EXTT || tag == EXTID_NTFS) {
+                    foundExtraTime = true;
+                }
+                eoff += (4 + sz);
+            }
+            if (!foundExtraTime) {
+                if (isWindows) {             // use NTFS
+                    elenNTFS = 36;           // total 36 bytes
+                } else {                     // Extended Timestamp otherwise
+                    elenEXTT = 9;            // only mtime in cen
+                }
+            }
+            writeInt(os, CENSIG);            // CEN header signature
+            if (elen64 != 0) {
+                writeShort(os, 45);          // ver 4.5 for zip64
+                writeShort(os, 45);
+            } else {
+                writeShort(os, version0);    // version made by
+                writeShort(os, version0);    // version needed to extract
+            }
+            writeShort(os, flag);            // general purpose bit flag
+            writeShort(os, method);          // compression method
+            // last modification time
+            writeInt(os, (int)javaToDosTime(mtime));
+            writeInt(os, crc);               // crc-32
+            writeInt(os, csize0);            // compressed size
+            writeInt(os, size0);             // uncompressed size
+            writeShort(os, name.length);
+            writeShort(os, elen + elen64 + elenNTFS + elenEXTT);
+
+            if (comment != null) {
+                writeShort(os, Math.min(clen, 0xffff));
+            } else {
+                writeShort(os, 0);
+            }
+            writeShort(os, 0);              // starting disk number
+            writeShort(os, 0);              // internal file attributes (unused)
+            writeInt(os, 0);                // external file attributes (unused)
+            writeInt(os, locoff0);          // relative offset of local header
+            writeBytes(os, name);
+            if (elen64 != 0) {
+                writeShort(os, EXTID_ZIP64);// Zip64 extra
+                writeShort(os, elen64 - 4); // size of "this" extra block
+                if (size0 == ZIP64_MINVAL)
+                    writeLong(os, size);
+                if (csize0 == ZIP64_MINVAL)
+                    writeLong(os, csize);
+                if (locoff0 == ZIP64_MINVAL)
+                    writeLong(os, locoff);
+            }
+            if (elenNTFS != 0) {
+                writeShort(os, EXTID_NTFS);
+                writeShort(os, elenNTFS - 4);
+                writeInt(os, 0);            // reserved
+                writeShort(os, 0x0001);     // NTFS attr tag
+                writeShort(os, 24);
+                writeLong(os, javaToWinTime(mtime));
+                writeLong(os, javaToWinTime(atime));
+                writeLong(os, javaToWinTime(ctime));
+            }
+            if (elenEXTT != 0) {
+                writeShort(os, EXTID_EXTT);
+                writeShort(os, elenEXTT - 4);
+                if (ctime == -1)
+                    os.write(0x3);          // mtime and atime
+                else
+                    os.write(0x7);          // mtime, atime and ctime
+                writeInt(os, javaToUnixTime(mtime));
+            }
+            if (extra != null)              // whatever not recognized
+                writeBytes(os, extra);
+            if (comment != null)            //TBD: 0, Math.min(commentBytes.length, 0xffff));
+                writeBytes(os, comment);
+            return CENHDR + nlen + elen + clen + elen64 + elenNTFS + elenEXTT;
+        }
+
+        ///////////////////// LOC //////////////////////
+        // read NTFS, UNIX and ZIP64 data from cen.extra
+        void readExtra(ZipCentralDir zipfs) throws IOException {
+            if (extra == null)
+                return;
+            int elen = extra.length;
+            int off = 0;
+            int newOff = 0;
+            while (off + 4 < elen) {
+                // extra spec: HeaderID+DataSize+Data
+                int pos = off;
+                int tag = SH(extra, pos);
+                int sz = SH(extra, pos + 2);
+                pos += 4;
+                if (pos + sz > elen)         // invalid data
+                    break;
+                switch (tag) {
+                    case EXTID_ZIP64 :
+                        if (size == ZIP64_MINVAL) {
+                            if (pos + 8 > elen)  // invalid zip64 extra
+                                break;           // fields, just skip
+                            size = LL(extra, pos);
+                            pos += 8;
+                        }
+                        if (csize == ZIP64_MINVAL) {
+                            if (pos + 8 > elen)
+                                break;
+                            csize = LL(extra, pos);
+                            pos += 8;
+                        }
+                        if (locoff == ZIP64_MINVAL) {
+                            if (pos + 8 > elen)
+                                break;
+                            locoff = LL(extra, pos);
+                            pos += 8;
+                        }
+                        break;
+                    case EXTID_NTFS:
+                        if (sz < 32)
+                            break;
+                        pos += 4;    // reserved 4 bytes
+                        if (SH(extra, pos) !=  0x0001)
+                            break;
+                        if (SH(extra, pos + 2) != 24)
+                            break;
+                        // override the loc field, datatime here is
+                        // more "accurate"
+                        mtime  = winToJavaTime(LL(extra, pos + 4));
+                        atime  = winToJavaTime(LL(extra, pos + 12));
+                        ctime  = winToJavaTime(LL(extra, pos + 20));
+                        break;
+                    case EXTID_EXTT:
+                        // spec says the Extened timestamp in cen only has mtime
+                        // need to read the loc to get the extra a/ctime
+                        byte[] buf = new byte[LOCHDR];
+                        if (zipfs.readFullyAt(buf, 0, buf.length , locoff)
+                                != buf.length)
+                            throw new ZipException("loc: reading failed");
+                        if (LOCSIG(buf) != LOCSIG)
+                            throw new ZipException("loc: wrong sig ->"
+                                    + Long.toString(LOCSIG(buf), 16));
+
+                        int locElen = LOCEXT(buf);
+                        if (locElen < 9)    // EXTT is at lease 9 bytes
+                            break;
+                        int locNlen = LOCNAM(buf);
+                        buf = new byte[locElen];
+                        if (zipfs.readFullyAt(buf, 0, buf.length , locoff + LOCHDR + locNlen)
+                                != buf.length)
+                            throw new ZipException("loc extra: reading failed");
+                        int locPos = 0;
+                        while (locPos + 4 < buf.length) {
+                            int locTag = SH(buf, locPos);
+                            int locSZ  = SH(buf, locPos + 2);
+                            locPos += 4;
+                            if (locTag  != EXTID_EXTT) {
+                                locPos += locSZ;
+                                continue;
+                            }
+                            int flag = CH(buf, locPos++);
+                            if ((flag & 0x1) != 0) {
+                                mtime = unixToJavaTime(LG(buf, locPos));
+                                locPos += 4;
+                            }
+                            if ((flag & 0x2) != 0) {
+                                atime = unixToJavaTime(LG(buf, locPos));
+                                locPos += 4;
+                            }
+                            if ((flag & 0x4) != 0) {
+                                ctime = unixToJavaTime(LG(buf, locPos));
+                                locPos += 4;
+                            }
+                            break;
+                        }
+                        break;
+                    default:    // unknown tag
+                        System.arraycopy(extra, off, extra, newOff, sz + 4);
+                        newOff += (sz + 4);
+                }
+                off += (sz + 4);
+            }
+            if (newOff != 0 && newOff != extra.length)
+                extra = Arrays.copyOf(extra, newOff);
+            else
+                extra = null;
+        }
+    }
+
+}

--- a/internal/zinc-classfile/src/main/java/sbt/internal/inc/zip/ZipConstants.java
+++ b/internal/zinc-classfile/src/main/java/sbt/internal/inc/zip/ZipConstants.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2009, 2012, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   - Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   - Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ *   - Neither the name of Oracle nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This source code is provided to illustrate the usage of a given feature
+ * or technique and has been deliberately simplified. Additional steps
+ * required for a production-quality application, such as security checks,
+ * input validation and proper error handling, might not be present in
+ * this sample code.
+ */
+
+
+package sbt.internal.inc.zip;
+
+
+/**
+ *
+ * @author Xueming Shen
+ */
+
+class ZipConstants {
+    /*
+     * Compression methods
+     */
+    static final int METHOD_STORED     = 0;
+    static final int METHOD_DEFLATED   = 8;
+
+    /*
+     * Header signatures
+     */
+    static long LOCSIG = 0x04034b50L;   // "PK\003\004"
+    static long CENSIG = 0x02014b50L;   // "PK\001\002"
+    static long ENDSIG = 0x06054b50L;   // "PK\005\006"
+
+    /*
+     * Header sizes in bytes (including signatures)
+     */
+    static final int LOCHDR = 30;       // LOC header size
+    static final int CENHDR = 46;       // CEN header size
+    static final int ENDHDR = 22;       // END header size
+
+    /*
+     * ZIP64 constants
+     */
+    static final long ZIP64_ENDSIG = 0x06064b50L;  // "PK\006\006"
+    static final long ZIP64_LOCSIG = 0x07064b50L;  // "PK\006\007"
+    static final int  ZIP64_ENDHDR = 56;           // ZIP64 end header size
+    static final int  ZIP64_LOCHDR = 20;           // ZIP64 end loc header size
+
+    static final int  ZIP64_MINVAL32 = 0xFFFF;
+    static final long ZIP64_MINVAL = 0xFFFFFFFFL;
+
+    /*
+     * Extra field header ID
+     */
+    static final int  EXTID_ZIP64 = 0x0001;      // ZIP64
+    static final int  EXTID_NTFS  = 0x000a;      // NTFS
+    static final int  EXTID_EXTT  = 0x5455;      // Info-ZIP Extended Timestamp
+
+    /*
+     * fields access methods
+     */
+    ///////////////////////////////////////////////////////
+    static final int CH(byte[] b, int n) {
+        return Byte.toUnsignedInt(b[n]);
+    }
+
+    static final int SH(byte[] b, int n) {
+        return Byte.toUnsignedInt(b[n]) | (Byte.toUnsignedInt(b[n + 1]) << 8);
+    }
+
+    static final long LG(byte[] b, int n) {
+        return ((SH(b, n)) | (SH(b, n + 2) << 16)) & 0xffffffffL;
+    }
+
+    static final long LL(byte[] b, int n) {
+        return (LG(b, n)) | (LG(b, n + 4) << 32);
+    }
+
+    static final long GETSIG(byte[] b) {
+        return LG(b, 0);
+    }
+
+    // local file (LOC) header fields
+    static final long LOCSIG(byte[] b) { return LG(b, 0); } // signature
+    static final int  LOCNAM(byte[] b) { return SH(b, 26);} // filename length
+    static final int  LOCEXT(byte[] b) { return SH(b, 28);} // extra field length
+
+    // end of central directory header (END) fields
+    static final int  ENDSUB(byte[] b) { return SH(b, 8); }  // number of entries on this disk
+    static final int  ENDTOT(byte[] b) { return SH(b, 10);}  // total number of entries
+    static final long ENDSIZ(byte[] b) { return LG(b, 12);}  // central directory size
+    static final long ENDOFF(byte[] b) { return LG(b, 16);}  // central directory offset
+    static final int  ENDCOM(byte[] b) { return SH(b, 20);}  // size of zip file comment
+    static final int  ENDCOM(byte[] b, int off) { return SH(b, off + 20);}
+
+    // zip64 end of central directory recoder fields
+    static final long ZIP64_ENDTOD(byte[] b) { return LL(b, 24);}  // total number of entries on disk
+    static final long ZIP64_ENDTOT(byte[] b) { return LL(b, 32);}  // total number of entries
+    static final long ZIP64_ENDSIZ(byte[] b) { return LL(b, 40);}  // central directory size
+    static final long ZIP64_ENDOFF(byte[] b) { return LL(b, 48);}  // central directory offset
+    static final long ZIP64_LOCOFF(byte[] b) { return LL(b, 8);}   // zip64 end offset
+
+    // central directory header (CEN) fields
+    static final long CENSIG(byte[] b, int pos) { return LG(b, pos + 0); }
+    static final int  CENVEM(byte[] b, int pos) { return SH(b, pos + 4); }
+    static final int  CENVER(byte[] b, int pos) { return SH(b, pos + 6); }
+    static final int  CENFLG(byte[] b, int pos) { return SH(b, pos + 8); }
+    static final int  CENHOW(byte[] b, int pos) { return SH(b, pos + 10);}
+    static final long CENTIM(byte[] b, int pos) { return LG(b, pos + 12);}
+    static final long CENCRC(byte[] b, int pos) { return LG(b, pos + 16);}
+    static final long CENSIZ(byte[] b, int pos) { return LG(b, pos + 20);}
+    static final long CENLEN(byte[] b, int pos) { return LG(b, pos + 24);}
+    static final int  CENNAM(byte[] b, int pos) { return SH(b, pos + 28);}
+    static final int  CENEXT(byte[] b, int pos) { return SH(b, pos + 30);}
+    static final int  CENCOM(byte[] b, int pos) { return SH(b, pos + 32);}
+    static final int  CENDSK(byte[] b, int pos) { return SH(b, pos + 34);}
+    static final int  CENATT(byte[] b, int pos) { return SH(b, pos + 36);}
+    static final long CENATX(byte[] b, int pos) { return LG(b, pos + 38);}
+    static final long CENOFF(byte[] b, int pos) { return LG(b, pos + 42);}
+
+    /* The END header is followed by a variable length comment of size < 64k. */
+    static final long END_MAXLEN = 0xFFFF + ENDHDR;
+    static final int READBLOCKSZ = 128;
+}

--- a/internal/zinc-classfile/src/main/java/sbt/internal/inc/zip/ZipUtils.java
+++ b/internal/zinc-classfile/src/main/java/sbt/internal/inc/zip/ZipUtils.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2009, 2011, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   - Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   - Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ *   - Neither the name of Oracle nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This source code is provided to illustrate the usage of a given feature
+ * or technique and has been deliberately simplified. Additional steps
+ * required for a production-quality application, such as security checks,
+ * input validation and proper error handling, might not be present in
+ * this sample code.
+ */
+
+
+package sbt.internal.inc.zip;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+/**
+ *
+ * @author Xueming Shen
+ */
+
+class ZipUtils {
+
+    /*
+     * Writes a 16-bit short to the output stream in little-endian byte order.
+     */
+    static void writeShort(OutputStream os, int v) throws IOException {
+        os.write(v & 0xff);
+        os.write((v >>> 8) & 0xff);
+    }
+
+    /*
+     * Writes a 32-bit int to the output stream in little-endian byte order.
+     */
+    static void writeInt(OutputStream os, long v) throws IOException {
+        os.write((int)(v & 0xff));
+        os.write((int)((v >>>  8) & 0xff));
+        os.write((int)((v >>> 16) & 0xff));
+        os.write((int)((v >>> 24) & 0xff));
+    }
+
+    /*
+     * Writes a 64-bit int to the output stream in little-endian byte order.
+     */
+    static void writeLong(OutputStream os, long v) throws IOException {
+        os.write((int)(v & 0xff));
+        os.write((int)((v >>>  8) & 0xff));
+        os.write((int)((v >>> 16) & 0xff));
+        os.write((int)((v >>> 24) & 0xff));
+        os.write((int)((v >>> 32) & 0xff));
+        os.write((int)((v >>> 40) & 0xff));
+        os.write((int)((v >>> 48) & 0xff));
+        os.write((int)((v >>> 56) & 0xff));
+    }
+
+    /*
+     * Writes an array of bytes to the output stream.
+     */
+    static void writeBytes(OutputStream os, byte[] b)
+            throws IOException
+    {
+        os.write(b, 0, b.length);
+    }
+
+    /*
+     * Converts DOS time to Java time (number of milliseconds since epoch).
+     */
+    static long dosToJavaTime(long dtime) {
+        Date d = new Date((int)(((dtime >> 25) & 0x7f) + 80),
+                (int)(((dtime >> 21) & 0x0f) - 1),
+                (int)((dtime >> 16) & 0x1f),
+                (int)((dtime >> 11) & 0x1f),
+                (int)((dtime >> 5) & 0x3f),
+                (int)((dtime << 1) & 0x3e));
+        return d.getTime();
+    }
+
+    /*
+     * Converts Java time to DOS time.
+     */
+    static long javaToDosTime(long time) {
+        Date d = new Date(time);
+        int year = d.getYear() + 1900;
+        if (year < 1980) {
+            return (1 << 21) | (1 << 16);
+        }
+        return (year - 1980) << 25 | (d.getMonth() + 1) << 21 |
+                d.getDate() << 16 | d.getHours() << 11 | d.getMinutes() << 5 |
+                d.getSeconds() >> 1;
+    }
+
+
+    // used to adjust values between Windows and java epoch
+    private static final long WINDOWS_EPOCH_IN_MICROSECONDS = -11644473600000000L;
+    static long winToJavaTime(long wtime) {
+        return TimeUnit.MILLISECONDS.convert(
+                wtime / 10 + WINDOWS_EPOCH_IN_MICROSECONDS, TimeUnit.MICROSECONDS);
+    }
+
+    static long javaToWinTime(long time) {
+        return (TimeUnit.MICROSECONDS.convert(time, TimeUnit.MILLISECONDS)
+                - WINDOWS_EPOCH_IN_MICROSECONDS) * 10;
+    }
+
+    static long unixToJavaTime(long utime) {
+        return TimeUnit.MILLISECONDS.convert(utime, TimeUnit.SECONDS);
+    }
+
+    static long javaToUnixTime(long time) {
+        return TimeUnit.SECONDS.convert(time, TimeUnit.MILLISECONDS);
+    }
+
+}

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/IndexBasedZipFsOps.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/IndexBasedZipFsOps.scala
@@ -1,0 +1,53 @@
+package sbt.internal.inc
+
+import java.io.OutputStream
+import java.nio.file.Path
+
+import sbt.internal.inc.zip.ZipCentralDir
+
+import scala.collection.JavaConverters._
+
+object IndexBasedZipFsOps extends IndexBasedZipOps {
+  override type CentralDir = ZipCentralDir
+  override type Header = ZipCentralDir.Entry
+
+  override protected def readCentralDir(path: Path): CentralDir = {
+    new ZipCentralDir(path)
+  }
+
+  override protected def getCentralDirStart(centralDir: CentralDir): Long = {
+    centralDir.getCentralDirStart
+  }
+
+  override protected def setCentralDirStart(centralDir: CentralDir, centralDirStart: Long): Unit = {
+    centralDir.setCentralDirStart(centralDirStart)
+  }
+
+  override protected def getHeaders(centralDir: CentralDir): Seq[Header] = {
+    centralDir.getHeaders.asScala
+  }
+  override protected def setHeaders(centralDir: CentralDir, headers: Seq[Header]): Unit = {
+    centralDir.setHeaders(new java.util.ArrayList[Header](headers.asJava))
+  }
+
+  override protected def getFileName(header: Header): String = {
+    header.getName
+  }
+
+  override protected def getFileOffset(header: Header): Long = {
+    header.getEntryOffset
+  }
+
+  override protected def setFileOffset(header: Header, offset: Long): Unit = {
+    header.setEntryOffset(offset)
+  }
+
+  override protected def getLastModifiedTime(header: Header): Long = {
+    header.getLastModifiedTime
+  }
+
+  override protected def writeCentralDir(centralDir: CentralDir,
+                                         outputStream: OutputStream): Unit = {
+    centralDir.dump(outputStream)
+  }
+}

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/IndexBasedZipFsOps.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/IndexBasedZipFsOps.scala
@@ -7,6 +7,10 @@ import sbt.internal.inc.zip.ZipCentralDir
 
 import scala.collection.JavaConverters._
 
+/**
+ * The concrete implementation of [[sbt.internal.inc.IndexBasedZipOps]]
+ * based on [[sbt.internal.inc.zip.ZipCentralDir]].
+ */
 object IndexBasedZipFsOps extends IndexBasedZipOps {
   override type CentralDir = ZipCentralDir
   override type Header = ZipCentralDir.Entry

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/IndexBasedZipOps.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/IndexBasedZipOps.scala
@@ -115,6 +115,12 @@ abstract class IndexBasedZipOps extends CreateZip {
     writeCentralDir(zipFile.toPath, centralDir)
   }
 
+  def listEntries(zipFile: File): Seq[String] = {
+    val centralDir = readCentralDir(zipFile)
+    val headers = getHeaders(centralDir)
+    headers.map(getFileName)
+  }
+
   /**
    * Represents the central directory (index) of a zip file. It must contain the start offset
    * (where it is located in the zip file) and list of headers

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/IndexBasedZipOps.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/IndexBasedZipOps.scala
@@ -32,13 +32,10 @@ abstract class IndexBasedZipOps extends CreateZip {
    * an argument is only used to initialize the cache and is later ignored.
    * This is enough as stamps are only read from the output jar.
    */
-  class CachedStampReader {
-    private var cachedNameToTimestamp: Map[String, Long] = _
+  class CachedStamps(zip: File) {
+    private val cachedNameToTimestamp: Map[String, Long] = initializeCache(zip)
 
-    def readStamp(zip: File, entry: String): Long = {
-      if (cachedNameToTimestamp == null) {
-        cachedNameToTimestamp = initializeCache(zip)
-      }
+    def getStamp(entry: String): Long = {
       cachedNameToTimestamp.getOrElse(entry, 0)
     }
 
@@ -281,14 +278,14 @@ sealed trait CreateZip {
   private def writeZip(files: Seq[(File, String)], output: ZipOutputStream): Unit = {
     val now = System.currentTimeMillis()
 
-    def makeFileEntry(file: File, name: String): ZipEntry = {
+    def makeFileEntry(name: String): ZipEntry = {
       val entry = new ZipEntry(name)
       entry.setTime(now)
       entry
     }
 
     def addFileEntry(file: File, name: String): Unit = {
-      output.putNextEntry(makeFileEntry(file, name))
+      output.putNextEntry(makeFileEntry(name))
       IO.transfer(file, output)
       output.closeEntry()
     }

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/IndexBasedZipOps.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/IndexBasedZipOps.scala
@@ -32,7 +32,7 @@ abstract class IndexBasedZipOps extends CreateZip {
    * an argument is only used to initialize the cache and is later ignored.
    * This is enough as stamps are only read from the output jar.
    */
-  class CachedStamps(zip: File) {
+  final class CachedStamps(zip: File) {
     private val cachedNameToTimestamp: Map[String, Long] = initializeCache(zip)
 
     def getStamp(entry: String): Long = {

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/IndexBasedZipOps.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/IndexBasedZipOps.scala
@@ -1,0 +1,235 @@
+package sbt.internal.inc
+
+import java.nio.channels.{ FileChannel, Channels, ReadableByteChannel }
+import java.io._
+import java.nio.file.{ Files, Path }
+import java.util.UUID
+import java.util.zip.{ Deflater, ZipOutputStream, ZipEntry }
+
+import sbt.io.{ IO, Using }
+
+abstract class IndexBasedZipOps extends CreateZip {
+
+  class CachedStampReader {
+    private var cachedNameToTimestamp: Map[String, Long] = _
+
+    def readStamp(jar: File, cls: String): Long = {
+      if (cachedNameToTimestamp == null) {
+        cachedNameToTimestamp = initializeCache(jar)
+      }
+      cachedNameToTimestamp.getOrElse(cls, 0)
+    }
+
+    private def initializeCache(jar: File): Map[String, Long] = {
+      if (jar.exists()) {
+        val centralDir = readCentralDir(jar.toPath)
+        val headers = getHeaders(centralDir)
+        headers.map(header => getFileName(header) -> getLastModifiedTime(header))(
+          collection.breakOut)
+      } else {
+        Map.empty
+      }
+    }
+  }
+
+  def removeEntries(jarFile: File, classes: Iterable[String]): Unit = {
+    removeEntries(jarFile.toPath, classes.toSet)
+  }
+
+  def mergeArchives(into: File, from: File): Unit = {
+    mergeArchives(into.toPath, from.toPath)
+  }
+
+  def includeInJar(jar: File, files: Seq[(File, String)]): Unit = {
+    if (jar.exists()) {
+      val tempZip = jar.toPath.resolveSibling(s"${UUID.randomUUID()}.jar").toFile
+      createZip(tempZip, files)
+      mergeArchives(jar, tempZip)
+    } else {
+      createZip(jar, files)
+    }
+  }
+
+  def readCentralDir(file: File): CentralDir = {
+    readCentralDir(file.toPath)
+  }
+
+  def writeCentralDir(file: File, centralDir: CentralDir): Unit = {
+    writeCentralDir(file.toPath, centralDir)
+  }
+
+  type CentralDir
+  type Header
+
+  private def writeCentralDir(path: Path, newCentralDir: CentralDir): Unit = {
+    val currentCentralDir = readCentralDir(path)
+    val currentCentralDirStart = truncateCentralDir(currentCentralDir, path)
+    finalizeZip(newCentralDir, path, currentCentralDirStart)
+  }
+
+  private def removeEntries(path: Path, toRemove: Set[String]): Unit = {
+    val centralDir = readCentralDir(path)
+    removeEntriesFromCentralDir(centralDir, toRemove)
+    val writeOffset = truncateCentralDir(centralDir, path)
+    finalizeZip(centralDir, path, writeOffset)
+  }
+
+  private def removeEntriesFromCentralDir(centralDir: CentralDir, toRemove: Set[String]): Unit = {
+    val headers = getHeaders(centralDir)
+    val clearedHeaders = headers.filterNot(header => toRemove.contains(getFileName(header)))
+    setHeaders(centralDir, clearedHeaders)
+  }
+
+  private def mergeArchives(target: Path, source: Path): Unit = {
+    val targetCentralDir = readCentralDir(target)
+    val sourceCentralDir = readCentralDir(source)
+
+    // "source" will start where "target" ends
+    val sourceStart = truncateCentralDir(targetCentralDir, target)
+    // "source" data (files) is as long as from its beginning till the start of central dir
+    val sourceLength = getCentralDirStart(sourceCentralDir)
+
+    transferAll(source, target, startPos = sourceStart, bytesToTransfer = sourceLength)
+
+    val mergedHeaders = mergeHeaders(targetCentralDir, sourceCentralDir, sourceStart)
+    setHeaders(targetCentralDir, mergedHeaders)
+
+    val centralDirStart = sourceStart + sourceLength
+    finalizeZip(targetCentralDir, target, centralDirStart)
+
+    Files.delete(source)
+  }
+
+  private def mergeHeaders(
+      targetCentralDir: CentralDir,
+      sourceCentralDir: CentralDir,
+      sourceStart: Long
+  ): Seq[Header] = {
+    val sourceHeaders = getHeaders(sourceCentralDir)
+    sourceHeaders.foreach { header =>
+      // potentially offsets should be updated for each header
+      // not only in central directory but a valid zip tool
+      // should not rely on that unless the file is corrupted
+      val currentOffset = getFileOffset(header)
+      val newOffset = currentOffset + sourceStart
+      setFileOffset(header, newOffset)
+    }
+
+    // override files from target with files from source
+    val sourceNames = sourceHeaders.map(getFileName).toSet
+    val targetHeaders =
+      getHeaders(targetCentralDir).filterNot(h => sourceNames.contains(getFileName(h)))
+
+    targetHeaders ++ sourceHeaders
+  }
+
+  private def truncateCentralDir(centralDir: CentralDir, path: Path): Long = {
+    val sizeAfterTruncate = getCentralDirStart(centralDir)
+    new FileOutputStream(path.toFile, true).getChannel
+      .truncate(sizeAfterTruncate)
+      .close()
+    sizeAfterTruncate
+  }
+
+  private def finalizeZip(
+      centralDir: CentralDir,
+      path: Path,
+      centralDirStart: Long
+  ): Unit = {
+    setCentralDirStart(centralDir, centralDirStart)
+    val fileOutputStream = new FileOutputStream(path.toFile, /*append =*/ true)
+    fileOutputStream.getChannel.position(centralDirStart)
+    val outputStream = new BufferedOutputStream(fileOutputStream)
+    writeCentralDir(centralDir, outputStream)
+    outputStream.close()
+  }
+
+  private def transferAll(
+      source: Path,
+      target: Path,
+      startPos: Long,
+      bytesToTransfer: Long
+  ): Unit = {
+    val sourceFile = openFileForReading(source)
+    val targetFile = openFileForWriting(target)
+    var remaining = bytesToTransfer
+    var offset = startPos
+    while (remaining > 0) {
+      val transferred =
+        targetFile.transferFrom(sourceFile, /*position =*/ offset, /*count = */ remaining)
+      offset += transferred
+      remaining -= transferred
+    }
+    sourceFile.close()
+    targetFile.close()
+  }
+
+  private def openFileForReading(path: Path): ReadableByteChannel = {
+    Channels.newChannel(new BufferedInputStream(Files.newInputStream(path)))
+  }
+
+  private def openFileForWriting(path: Path): FileChannel = {
+    new FileOutputStream(path.toFile, /*append = */ true).getChannel
+  }
+
+  protected def readCentralDir(path: Path): CentralDir
+
+  protected def getCentralDirStart(centralDir: CentralDir): Long
+  protected def setCentralDirStart(centralDir: CentralDir, centralDirStart: Long): Unit
+
+  protected def getHeaders(centralDir: CentralDir): Seq[Header]
+  protected def setHeaders(centralDir: CentralDir, headers: Seq[Header]): Unit
+
+  protected def getFileName(header: Header): String
+
+  protected def getFileOffset(header: Header): Long
+  protected def setFileOffset(header: Header, offset: Long): Unit
+  protected def getLastModifiedTime(header: Header): Long
+
+  protected def writeCentralDir(centralDir: CentralDir, outputStream: OutputStream): Unit
+
+}
+
+// Adapted from sbt.io.IO.zip - disabled compression and simplified
+sealed trait CreateZip {
+
+  def createZip(target: File, files: Seq[(File, String)]): Unit = {
+    IO.createDirectory(target.getParentFile)
+    withZipOutput(target) { output =>
+      writeZip(files, output)
+    }
+  }
+
+  private def withZipOutput(file: File)(f: ZipOutputStream => Unit): Unit = {
+    Using.fileOutputStream()(file) { fileOut =>
+      val zipOut = new ZipOutputStream(fileOut)
+      zipOut.setMethod(ZipOutputStream.DEFLATED)
+      zipOut.setLevel(Deflater.NO_COMPRESSION)
+      try { f(zipOut) } finally { zipOut.close() }
+    }
+  }
+
+  private def writeZip(files: Seq[(File, String)], output: ZipOutputStream): Unit = {
+    val now = System.currentTimeMillis()
+
+    def makeFileEntry(file: File, name: String): ZipEntry = {
+      val entry = new ZipEntry(name)
+      entry.setTime(now)
+      entry
+    }
+
+    def addFileEntry(file: File, name: String): Unit = {
+      output.putNextEntry(makeFileEntry(file, name))
+      IO.transfer(file, output)
+      output.closeEntry()
+    }
+
+    files.foreach { case (file, name) => addFileEntry(file, normalizeName(name)) }
+  }
+
+  private def normalizeName(name: String): String = {
+    val sep = File.separatorChar
+    if (sep == '/') name else name.replace(sep, '/')
+  }
+
+}

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/JarUtils.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/JarUtils.scala
@@ -262,16 +262,7 @@ object JarUtils {
 
   /** Lists class file entries in jar e.g. sbt/internal/inc/JarUtils.class */
   def listClassFiles(jar: File): Seq[String] = {
-//    IndexBasedZipFsOps.listEntries(jar).filter(_.endsWith(".class"))
-    withZipFile(jar) { zip =>
-      zip
-        .entries()
-        .asScala
-        .filterNot(_.isDirectory)
-        .map(_.getName)
-        .filter(_.endsWith(".class"))
-        .toList
-    }
+    IndexBasedZipFsOps.listEntries(jar).filter(_.endsWith(".class"))
   }
 
   object OutputJarContent {

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/JarUtils.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/JarUtils.scala
@@ -5,11 +5,8 @@ import java.util.zip.ZipFile
 import java.io.File
 import java.util.UUID
 
-import scala.collection.JavaConverters._
 import sbt.io.syntax.URL
-import xsbti.AnalysisCallback
 import xsbti.compile.{ Output, SingleOutput }
-import sbt.util.InterfaceUtil.toOption
 
 /**
  * This is a utility class that provides a set of functions that
@@ -211,9 +208,18 @@ object JarUtils {
     }
   }
 
+  private var tempDir: File = _
+  def setupTempClassesDir(temporaryClassesDirectory: Option[File]): Unit = {
+    temporaryClassesDirectory match {
+      case Some(dir) =>
+        IO.createDirectory(dir)
+        tempDir = dir
+      case None =>
+        tempDir = new File(IO.temporaryDirectory, "zinc_temp_classes_dir")
+    }
+  }
+
   private def createPrevJarPath(): File = {
-    val tempDir =
-      sys.props.get("zinc.compile-to-jar.tmp-dir").map(new File(_)).getOrElse(IO.temporaryDirectory)
     val prevJarName = s"$prevJarPrefix-${UUID.randomUUID()}.jar"
     tempDir.toPath.resolve(prevJarName).toFile
   }

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/JarUtils.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/JarUtils.scala
@@ -10,15 +10,14 @@ import scala.collection.JavaConverters._
 import sbt.io.syntax.URL
 import xsbti.compile.{ Output, SingleOutput }
 
-/** STJ stands for Straight to Jar compilation.
+/**
+ * This is a utility class that provides a set of functions that
+ * are used to implement straight to jar compilation.
  *
- *  This is a utility object that provides a set of functions
- *  that are used to implement this feature.
- *
- *  [[xsbt.STJ]] is a class that has similar purpose and
+ *  [[xsbt.JarUtils]] is a class that has similar purpose and
  *  duplicates some of the code, as it is difficult to share it.
  */
-object STJ {
+object JarUtils {
 
   /** Represents a path to a class file located inside a jar, relative to this jar */
   type RelClass = String
@@ -181,7 +180,7 @@ object STJ {
    * is simply reverted (moved to output jar path).
    *
    * If the previous output does not exist or the output is not a jar
-   * at all (STJ feature is disabled) this function runs a normal
+   * at all (JarUtils feature is disabled) this function runs a normal
    * compilation.
    *
    * @param output output for scalac compilation
@@ -203,7 +202,7 @@ object STJ {
         }
 
         if (outputJar.exists()) {
-          STJ.mergeJars(into = prevJar, from = outputJar)
+          JarUtils.mergeJars(into = prevJar, from = outputJar)
         }
         IO.move(prevJar, outputJar)
         result
@@ -234,7 +233,7 @@ object STJ {
    * Determines if Straight to Jar compilations is enabled
    * by inspecting if compilation output is a jar file
    */
-  def isEnabled(output: Output): Boolean = {
+  def isCompilingToJar(output: Output): Boolean = {
     getOutputJar(output).isDefined
   }
 

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/STJ.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/STJ.scala
@@ -1,0 +1,178 @@
+package sbt.internal.inc
+
+import sbt.io.IO
+import java.util.zip.ZipFile
+import java.io.File
+import java.util.UUID
+
+import scala.collection.JavaConverters._
+
+import sbt.io.syntax.URL
+import xsbti.compile.{ Output, SingleOutput }
+
+object STJ extends PathFunctions with ForTestCode {
+
+  val scalacOptions = Set("-YdisableFlatCpCaching")
+  val javacOptions = Set("-XDuseOptimizedZip=false")
+
+  def stashIndex(jar: File): IndexBasedZipFsOps.CentralDir = {
+    IndexBasedZipFsOps.readCentralDir(jar)
+  }
+
+  def unstashIndex(jar: File, index: IndexBasedZipFsOps.CentralDir): Unit = {
+    IndexBasedZipFsOps.writeCentralDir(jar, index)
+  }
+
+  def includeInJar(jar: File, files: Seq[(File, RelClass)]): Unit = {
+    IndexBasedZipFsOps.includeInJar(jar, files)
+  }
+
+  // puts all files in `from` (overriding the original files in case of conflicts)
+  // into `to`, removing `from`. In other words it merges `from` into `into`.
+  def mergeJars(into: File, from: File): Unit = {
+    IndexBasedZipFsOps.mergeArchives(into, from)
+  }
+
+  def createCachedStampReader(): File => Long = {
+    val reader = new IndexBasedZipFsOps.CachedStampReader
+    file: File =>
+      if (isJar(file)) {
+        val (jar, cls) = toJarAndRelClass(file.toString)
+        reader.readStamp(jar, cls)
+      } else {
+        IO.getModifiedTimeOrZero(file)
+      }
+  }
+
+  def removeFromJar(jarFile: File, classes: Iterable[RelClass]): Unit = {
+    if (jarFile.exists()) {
+      IndexBasedZipFsOps.removeEntries(jarFile, classes)
+    }
+  }
+
+  def withPreviousJar[A](output: Output)(compile: /*extra classpath: */ Seq[File] => A): A = {
+    getOutputJar(output)
+      .filter(_.exists())
+      .map { outputJar =>
+        val prevJar = createPrevJarPath()
+        IO.move(outputJar, prevJar)
+
+        val result = try {
+          compile(Seq(prevJar))
+        } catch {
+          case e: Exception =>
+            IO.move(prevJar, outputJar)
+            throw e
+        }
+
+        if (outputJar.exists()) {
+          STJ.mergeJars(into = prevJar, from = outputJar)
+        }
+        IO.move(prevJar, outputJar)
+        result
+      }
+      .getOrElse {
+        compile(Nil)
+      }
+  }
+
+  private def createPrevJarPath(): File = {
+    val tempDir =
+      sys.props.get("zinc.compile-to-jar.tmp-dir").map(new File(_)).getOrElse(IO.temporaryDirectory)
+    val prevJarName = s"$prevJarPrefix-${UUID.randomUUID()}.jar"
+    tempDir.toPath.resolve(prevJarName).toFile
+  }
+
+  val prevJarPrefix: String = "prev-jar"
+}
+
+sealed trait ForTestCode { this: PathFunctions =>
+
+  def listFiles(jar: File): Seq[String] = {
+    if (jar.exists()) {
+      withZipFile(jar) { zip =>
+        zip.entries().asScala.filterNot(_.isDirectory).map(_.getName).toList
+      }
+    } else Seq.empty
+  }
+
+  def readModifiedTimeFromJar(jc: JaredClass): Long = {
+    val (jar, cls) = toJarAndRelClass(jc)
+    if (jar.exists()) {
+      withZipFile(jar) { zip =>
+        Option(zip.getEntry(cls)).map(_.getLastModifiedTime.toMillis).getOrElse(0)
+      }
+    } else 0
+  }
+
+  def existsInJar(s: JaredClass): Boolean = {
+    val (jar, cls) = toJarAndRelClass(s)
+    jar.exists() && {
+      withZipFile(jar)(zip => zip.getEntry(cls) != null)
+    }
+  }
+
+  private def withZipFile[A](zip: File)(f: ZipFile => A): A = {
+    val file = new ZipFile(zip)
+    try f(file)
+    finally file.close()
+  }
+}
+
+sealed trait PathFunctions {
+
+  type JaredClass = String
+  type RelClass = String
+
+  def init(jar: File, cls: RelClass): JaredClass = {
+    val relClass = if (File.separatorChar == '/') cls else cls.replace(File.separatorChar, '/')
+    s"$jar!$relClass"
+  }
+
+  // Converts URL to JaredClass but reuses the jar file extracted at the call site to avoid recalculation.
+  def fromJarAndUrl(jar: File, url: URL): JaredClass = {
+    val Array(_, cls) = url.getPath.split("!/")
+    init(jar, cls)
+  }
+
+  def getRelClass(jc: JaredClass): RelClass = {
+    toJarAndRelClass(jc)._2
+  }
+
+  def getJarFile(jc: JaredClass): File = {
+    toJarAndRelClass(jc)._1
+  }
+
+  def toJarAndRelClass(jc: JaredClass): (File, RelClass) = {
+    val Array(jar, cls) = jc.split("!")
+    // JaredClass stores this part with File.separatorChar, however actual paths in zips always use '/'
+    val relClass = cls.replace('\\', '/')
+    (new File(jar), relClass)
+  }
+
+  def isJar(file: File): Boolean = {
+    file.toString.split("!") match {
+      case Array(jar, _) => jar.endsWith(".jar")
+      case _             => false
+    }
+  }
+
+  def isEnabled(output: Output): Boolean = {
+    getOutputJar(output).isDefined
+  }
+
+  def getOutputJar(output: Output): Option[File] = {
+    output match {
+      case s: SingleOutput =>
+        Some(s.getOutputDirectory).filter(_.getName.endsWith(".jar"))
+      case _ => None
+    }
+  }
+
+  def javacOutputTempDir(outputJar: File): File = {
+    val outJarName = outputJar.getName
+    val outDirName = outJarName + "-javac-output"
+    outputJar.toPath.resolveSibling(outDirName).toFile
+  }
+
+}

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/STJ.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/STJ.scala
@@ -18,7 +18,53 @@ import xsbti.compile.{ Output, SingleOutput }
  *  [[xsbt.STJ]] is a class that has similar purpose and
  *  duplicates some of the code, as it is difficult to share it.
  */
-object STJ extends PathFunctions with ForTestCode {
+object STJ {
+
+  type RelClass = String
+
+  /** `JaredClass` is an identifier for a class located inside a jar.
+   * For plain class files it is enough to simply use the actual file
+   * system path. A class in jar is identified as a path to a jar
+   * and path to the class within that jar. Those two values
+   * are held in one string separated by `!`. Slashes in both
+   * paths are consistent with `File.separatorChar` as the actual
+   * string is usually kept in `File` object.
+   *
+   * As an example given a jar file "C:\develop\zinc\target\output.jar"
+   * and relative path to the class "sbt/internal/inc/Compile.class"
+   * The resulting identifier would be:
+   * "C:\develop\zinc\target\output.jar!sbt\internal\inc\Compile.class"
+   */
+  class JaredClass(override val toString: String) extends AnyVal {
+
+    def relClass: RelClass = toJarAndRelClass._2
+
+    def toJarAndRelClass: (File, RelClass) = {
+      val Array(jar, cls) = toString.split("!")
+      // JaredClass stores RelClass part with File.separatorChar, however actual paths in zips always use '/'
+      val relClass = cls.replace('\\', '/')
+      (new File(jar), relClass)
+    }
+
+    def toFile: File = new File(toString)
+
+  }
+
+  object JaredClass {
+
+    def apply(jar: File, cls: RelClass): JaredClass = {
+      val relClass = if (File.separatorChar == '/') cls else cls.replace('/', File.separatorChar)
+      new JaredClass(s"$jar!$relClass")
+    }
+
+    // Converts URL to JaredClass but reuses the jar file extracted at the call site to avoid recomputing.
+    def fromURL(url: URL, jar: File): JaredClass = {
+      val Array(_, cls) = url.getPath.split("!/")
+      apply(jar, cls)
+    }
+
+    def fromFile(f: File): JaredClass = new JaredClass(f.toString)
+  }
 
   val scalacOptions = Set("-YdisableFlatCpCaching")
   val javacOptions = Set("-XDuseOptimizedZip=false")
@@ -45,7 +91,7 @@ object STJ extends PathFunctions with ForTestCode {
     val reader = new IndexBasedZipFsOps.CachedStampReader
     file: File =>
       if (isJar(file)) {
-        val (jar, cls) = toJarAndRelClass(file.toString)
+        val (jar, cls) = JaredClass.fromFile(file).toJarAndRelClass
         reader.readStamp(jar, cls)
       } else {
         IO.getModifiedTimeOrZero(file)
@@ -92,88 +138,6 @@ object STJ extends PathFunctions with ForTestCode {
   }
 
   val prevJarPrefix: String = "prev-jar"
-}
-
-sealed trait ForTestCode { this: PathFunctions =>
-
-  def listFiles(jar: File): Seq[String] = {
-    if (jar.exists()) {
-      withZipFile(jar) { zip =>
-        zip.entries().asScala.filterNot(_.isDirectory).map(_.getName).toList
-      }
-    } else Seq.empty
-  }
-
-  def readModifiedTimeFromJar(jc: JaredClass): Long = {
-    val (jar, cls) = toJarAndRelClass(jc)
-    if (jar.exists()) {
-      withZipFile(jar) { zip =>
-        Option(zip.getEntry(cls)).map(_.getLastModifiedTime.toMillis).getOrElse(0)
-      }
-    } else 0
-  }
-
-  def existsInJar(s: JaredClass): Boolean = {
-    val (jar, cls) = toJarAndRelClass(s)
-    jar.exists() && {
-      withZipFile(jar)(zip => zip.getEntry(cls) != null)
-    }
-  }
-
-  private def withZipFile[A](zip: File)(f: ZipFile => A): A = {
-    val file = new ZipFile(zip)
-    try f(file)
-    finally file.close()
-  }
-}
-
-sealed trait PathFunctions {
-
-  type JaredClass = String
-  type RelClass = String
-
-  /** Creates an identifier for a class located inside a jar.
-   * For plain class files it is enough to simply use the path.
-   * A class in jar `JaredClass` is identified as a path to jar
-   * and path to the class within that jar. Those two values
-   * are held in one string separated by `!`. Slashes in both
-   * paths are consistent with `File.separatorChar` as the actual
-   * string is usually kept in `File` object.
-   *
-   * As an example given a jar file "C:\develop\zinc\target\output.jar"
-   * and relative path to the class "sbt/internal/inc/Compile.class"
-   * The resulting identifier would be:
-   * "C:\develop\zinc\target\output.jar!sbt\internal\inc\Compile.class"
-   *
-   *  @param jar jar file that contains the class
-   *  @param cls relative path to the class within the jar
-   *  @return identifier/path to a class in jar.
-   */
-  def jaredClass(jar: File, cls: RelClass): JaredClass = {
-    val relClass = if (File.separatorChar == '/') cls else cls.replace('/', File.separatorChar)
-    s"$jar!$relClass"
-  }
-
-  // Converts URL to JaredClass but reuses the jar file extracted at the call site to avoid recalculation.
-  def fromJarAndUrl(jar: File, url: URL): JaredClass = {
-    val Array(_, cls) = url.getPath.split("!/")
-    jaredClass(jar, cls)
-  }
-
-  def getRelClass(jc: JaredClass): RelClass = {
-    toJarAndRelClass(jc)._2
-  }
-
-  def getJarFile(jc: JaredClass): File = {
-    toJarAndRelClass(jc)._1
-  }
-
-  def toJarAndRelClass(jc: JaredClass): (File, RelClass) = {
-    val Array(jar, cls) = jc.split("!")
-    // JaredClass stores this part with File.separatorChar, however actual paths in zips always use '/'
-    val relClass = cls.replace('\\', '/')
-    (new File(jar), relClass)
-  }
 
   def isJar(file: File): Boolean = {
     file.toString.split("!") match {
@@ -194,10 +158,40 @@ sealed trait PathFunctions {
     }
   }
 
-  def javacOutputTempDir(outputJar: File): File = {
+  def javacTempOutput(outputJar: File): File = {
     val outJarName = outputJar.getName
     val outDirName = outJarName + "-javac-output"
     outputJar.toPath.resolveSibling(outDirName).toFile
   }
 
+  // for test code only
+  def listFiles(jar: File): Seq[String] = {
+    if (jar.exists()) {
+      withZipFile(jar) { zip =>
+        zip.entries().asScala.filterNot(_.isDirectory).map(_.getName).toList
+      }
+    } else Seq.empty
+  }
+
+  def readModifiedTimeFromJar(jc: JaredClass): Long = {
+    val (jar, cls) = jc.toJarAndRelClass
+    if (jar.exists()) {
+      withZipFile(jar) { zip =>
+        Option(zip.getEntry(cls)).map(_.getLastModifiedTime.toMillis).getOrElse(0)
+      }
+    } else 0
+  }
+
+  def existsInJar(jc: JaredClass): Boolean = {
+    val (jar, cls) = jc.toJarAndRelClass
+    jar.exists() && {
+      withZipFile(jar)(zip => zip.getEntry(cls) != null)
+    }
+  }
+
+  private def withZipFile[A](zip: File)(f: ZipFile => A): A = {
+    val file = new ZipFile(zip)
+    try f(file)
+    finally file.close()
+  }
 }

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Analyze.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Analyze.scala
@@ -195,7 +195,7 @@ private[sbt] object Analyze {
       outputDir <- Some(output).collect { case s: SingleOutput => s.getOutputDirectory }
       relativeClass <- IO.relativize(outputDir, realClassFile)
     } yield {
-      new File(STJ.init(outputJar, relativeClass))
+      new File(STJ.jaredClass(outputJar, relativeClass))
     }
     jaredClass.getOrElse(realClassFile)
   }

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Analyze.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Analyze.scala
@@ -203,7 +203,7 @@ private[sbt] object Analyze {
       outputDir <- Some(output).collect { case s: SingleOutput => s.getOutputDirectory }
       relativeClass <- IO.relativize(outputDir, realClassFile)
     } yield {
-      STJ.JaredClass(outputJar, relativeClass).toFile
+      JarUtils.JaredClass(outputJar, relativeClass).toFile
     }
     jaredClass.getOrElse(realClassFile)
   }
@@ -223,7 +223,7 @@ private[sbt] object Analyze {
       //
       // .contains does not compile with 2.10
       if (finalJarOutput.exists(_ == file)) {
-        STJ.JaredClass.fromURL(url, file).toFile
+        JarUtils.JaredClass.fromURL(url, file).toFile
       } else {
         file
       }

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Analyze.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Analyze.scala
@@ -198,14 +198,14 @@ private[sbt] object Analyze {
   private def resolveFinalClassFile(realClassFile: File,
                                     output: Output,
                                     finalJarOutput: Option[File]): File = {
-    val jaredClass = for {
+    val classInJar = for {
       outputJar <- finalJarOutput
       outputDir <- Some(output).collect { case s: SingleOutput => s.getOutputDirectory }
       relativeClass <- IO.relativize(outputDir, realClassFile)
     } yield {
-      JarUtils.JaredClass(outputJar, relativeClass).toFile
+      JarUtils.ClassInJar(outputJar, relativeClass).toFile
     }
-    jaredClass.getOrElse(realClassFile)
+    classInJar.getOrElse(realClassFile)
   }
 
   private[this] def urlAsFile(url: URL, log: Logger, finalJarOutput: Option[File]): Option[File] =
@@ -223,7 +223,7 @@ private[sbt] object Analyze {
       //
       // .contains does not compile with 2.10
       if (finalJarOutput.exists(_ == file)) {
-        JarUtils.JaredClass.fromURL(url, file).toFile
+        JarUtils.ClassInJar.fromURL(url, file).toFile
       } else {
         file
       }

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Analyze.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Analyze.scala
@@ -275,7 +275,8 @@ private[sbt] object Analyze {
   private def findSource(sourceNameMap: Map[String, Iterable[File]],
                          pkg: List[String],
                          sourceFileName: String): List[File] =
-    refine((sourceNameMap get sourceFileName).toList.flatten.map { x => (x, x.getParentFile)
+    refine((sourceNameMap get sourceFileName).toList.flatten.map { x =>
+      (x, x.getParentFile)
     }, pkg.reverse)
 
   @tailrec private def refine(sources: List[(File, File)], pkgRev: List[String]): List[File] = {

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Analyze.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Analyze.scala
@@ -195,7 +195,7 @@ private[sbt] object Analyze {
       outputDir <- Some(output).collect { case s: SingleOutput => s.getOutputDirectory }
       relativeClass <- IO.relativize(outputDir, realClassFile)
     } yield {
-      new File(STJ.jaredClass(outputJar, relativeClass))
+      STJ.JaredClass(outputJar, relativeClass).toFile
     }
     jaredClass.getOrElse(realClassFile)
   }
@@ -212,7 +212,7 @@ private[sbt] object Analyze {
     IO.urlAsFile(url).map { file =>
       // .contains does not compile with 2.10
       if (finalJarOutput.exists(_ == file)) {
-        new File(STJ.fromJarAndUrl(file, url))
+        STJ.JaredClass.fromURL(url, file).toFile
       } else {
         file
       }

--- a/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/JavaCompilerForUnitTesting.scala
+++ b/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/JavaCompilerForUnitTesting.scala
@@ -12,6 +12,7 @@ import sbt.internal.util.ConsoleLogger
 import xsbti.api.DependencyContext._
 import xsbti.{ AnalysisCallback, TestCallback }
 import xsbti.TestCallback.ExtractedClassDependencies
+import xsbti.compile.SingleOutput
 
 import scala.collection.JavaConverters._
 
@@ -61,9 +62,12 @@ object JavaCompilerForUnitTesting {
       // - extract api representation out of Class (and saved it via a side effect)
       // - extract all base classes.
       // we extract just parents as this is enough for testing
-      Analyze(classFiles, srcFiles, logger)(analysisCallback,
-                                            classloader,
-                                            readAPI(analysisCallback, _, _))
+
+      val output = new SingleOutput { def getOutputDirectory: File = classesDir }
+      Analyze(classFiles, srcFiles, logger, output, finalJarOutput = None)(
+        analysisCallback,
+        classloader,
+        readAPI(analysisCallback, _, _))
       (srcFiles, analysisCallback)
     }
   }

--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaders.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaders.scala
@@ -58,6 +58,14 @@ final class SelfFirstLoader(classpath: Seq[URL], parent: ClassLoader)
 /** Doesn't load any classes itself, but instead verifies that all classes loaded through `parent` either come from `root` or `classpath`.*/
 final class ClasspathFilter(parent: ClassLoader, root: ClassLoader, classpath: Set[File])
     extends ClassLoader(parent) {
+
+  def close(): Unit = {
+    parent match {
+      case ucl: URLClassLoader => ucl.close()
+      case _                   => ()
+    }
+  }
+
   override def toString =
     s"""|ClasspathFilter(
         |  parent = $parent

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/LocalJava.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/LocalJava.scala
@@ -178,7 +178,12 @@ final class LocalJavaCompiler(compiler: javax.tools.JavaCompiler) extends XJavaC
     compileSuccess
   }
 
-  // rewrite of getStandardFileManager method that also sets the desired option
+  /**
+   * Rewrite of [[javax.tools.JavaCompiler.getStandardFileManager]] method that also sets
+   * useOptimizedZip=false flag. With forked javac adding this option to arguments just works.
+   * Here, as `FileManager` is created before `CompilationTask` options do not get passed
+   * properly. Also there is no access to `com.sun.tools.javac` classes, hence the reflection...
+   */
   private def fileManagerWithoutOptimizedZips(
       diagnostics: DiagnosticsReporter): StandardJavaFileManager = {
     val classLoader = compiler.getClass.getClassLoader

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/LocalJava.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/LocalJava.scala
@@ -12,6 +12,9 @@ package inc
 package javac
 
 import java.io.{ File, OutputStream, PrintWriter, Writer }
+import java.nio.charset.Charset
+import java.util.Locale
+
 import javax.tools.JavaFileManager.Location
 import javax.tools.JavaFileObject.Kind
 import javax.tools.{
@@ -19,7 +22,9 @@ import javax.tools.{
   ForwardingJavaFileManager,
   ForwardingJavaFileObject,
   JavaFileManager,
-  JavaFileObject
+  JavaFileObject,
+  StandardJavaFileManager,
+  DiagnosticListener
 }
 
 import sbt.internal.util.LoggerWriter
@@ -126,8 +131,6 @@ final class LocalJavaCompiler(compiler: javax.tools.JavaCompiler) extends XJavaC
     val logWriter = new PrintWriter(logger)
     log.debug("Attempting to call " + compiler + " directly...")
     val diagnostics = new DiagnosticsReporter(reporter)
-    val fileManager = compiler.getStandardFileManager(diagnostics, null, null)
-    val jfiles = fileManager.getJavaFileObjectsFromFiles(sources.toList.asJava)
 
     /* Local Java compiler doesn't accept `-J<flag>` options, strip them. */
     val (invalidOptions, cleanedOptions) = options partition (_ startsWith "-J")
@@ -136,6 +139,15 @@ final class LocalJavaCompiler(compiler: javax.tools.JavaCompiler) extends XJavaC
       log.warn(invalidOptions.mkString("\t", ", ", ""))
     }
 
+    val fileManager = {
+      if (cleanedOptions.contains("-XDuseOptimizedZip=false")) {
+        fileManagerWithoutOptimizedZips(diagnostics)
+      } else {
+        compiler.getStandardFileManager(diagnostics, null, null)
+      }
+    }
+
+    val jfiles = fileManager.getJavaFileObjectsFromFiles(sources.toList.asJava)
     val customizedFileManager = {
       val maybeClassFileManager = incToolOptions.classFileManager()
       if (incToolOptions.useCustomizedFileManager && maybeClassFileManager.isPresent)
@@ -160,9 +172,36 @@ final class LocalJavaCompiler(compiler: javax.tools.JavaCompiler) extends XJavaC
        * to javac's behaviour, we report fail compilation from diagnostics. */
       compileSuccess = success && !diagnostics.hasErrors
     } finally {
+      customizedFileManager.close()
       logger.flushLines(if (compileSuccess) Level.Warn else Level.Error)
     }
     compileSuccess
+  }
+
+  // rewrite of getStandardFileManager method that also sets the desired option
+  private def fileManagerWithoutOptimizedZips(
+      diagnostics: DiagnosticsReporter): StandardJavaFileManager = {
+    val classLoader = compiler.getClass.getClassLoader
+    val contextClass = Class.forName("com.sun.tools.javac.util.Context", true, classLoader)
+    val optionsClass = Class.forName("com.sun.tools.javac.util.Options", true, classLoader)
+    val javacFileManagerClass =
+      Class.forName("com.sun.tools.javac.file.JavacFileManager", true, classLoader)
+
+    val `Options.instance` = optionsClass.getMethod("instance", contextClass)
+    val `context.put` = contextClass.getMethod("put", classOf[Class[_]], classOf[Object])
+    val `options.put` = optionsClass.getMethod("put", classOf[String], classOf[String])
+    val `new JavacFileManager` =
+      javacFileManagerClass.getConstructor(contextClass, classOf[Boolean], classOf[Charset])
+
+    val context = contextClass.newInstance().asInstanceOf[AnyRef]
+    `context.put`.invoke(context, classOf[Locale], null)
+    `context.put`.invoke(context, classOf[DiagnosticListener[_]], diagnostics)
+    val options = `Options.instance`.invoke(null, context)
+    `options.put`.invoke(options, "useOptimizedZip", "false")
+
+    `new JavacFileManager`
+      .newInstance(context, Boolean.box(true), null)
+      .asInstanceOf[StandardJavaFileManager]
   }
 }
 

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/ClassFileManager.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/ClassFileManager.scala
@@ -82,7 +82,7 @@ object ClassFileManager {
     new DeleteClassFileManagerForJar(outputJar)
 
   def deleteImmediately(output: Output): XClassFileManager = {
-    val outputJar = STJ.getOutputJar(output)
+    val outputJar = JarUtils.getOutputJar(output)
     outputJar.fold(deleteImmediately)(deleteImmediatelyFromJar)
   }
 
@@ -101,7 +101,7 @@ object ClassFileManager {
   }
 
   def transactional(output: Output, tempDir: File, logger: sbt.util.Logger): XClassFileManager = {
-    val outputJar = STJ.getOutputJar(output)
+    val outputJar = JarUtils.getOutputJar(output)
     outputJar.fold(transactional(tempDir, logger))(transactionalForJar)
   }
 
@@ -156,8 +156,8 @@ object ClassFileManager {
 
   private final class DeleteClassFileManagerForJar(outputJar: File) extends XClassFileManager {
     override def delete(classes: Array[File]): Unit = {
-      val relClasses = classes.map(c => STJ.JaredClass.fromFile(c).relClass)
-      STJ.removeFromJar(outputJar, relClasses)
+      val relClasses = classes.map(c => JarUtils.JaredClass.fromFile(c).relClass)
+      JarUtils.removeFromJar(outputJar, relClasses)
     }
     override def generated(classes: Array[File]): Unit = ()
     override def complete(success: Boolean): Unit = ()
@@ -176,18 +176,18 @@ object ClassFileManager {
    */
   private final class TransactionalClassFileManagerForJar(outputJar: File)
       extends XClassFileManager {
-    private val backedUpIndex = Some(outputJar).filter(_.exists()).map(STJ.stashIndex)
+    private val backedUpIndex = Some(outputJar).filter(_.exists()).map(JarUtils.stashIndex)
 
     override def delete(jaredClasses: Array[File]): Unit = {
-      val classes = jaredClasses.map(c => STJ.JaredClass.fromFile(c).relClass)
-      STJ.removeFromJar(outputJar, classes)
+      val classes = jaredClasses.map(c => JarUtils.JaredClass.fromFile(c).relClass)
+      JarUtils.removeFromJar(outputJar, classes)
     }
 
     override def generated(classes: Array[File]): Unit = ()
 
     override def complete(success: Boolean): Unit = {
       if (!success) {
-        backedUpIndex.foreach(index => STJ.unstashIndex(outputJar, index))
+        backedUpIndex.foreach(index => JarUtils.unstashIndex(outputJar, index))
       }
     }
   }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/ClassFileManager.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/ClassFileManager.scala
@@ -163,6 +163,17 @@ object ClassFileManager {
     override def complete(success: Boolean): Unit = ()
   }
 
+  /**
+   * Version of [[sbt.internal.inc.ClassFileManager.TransactionalClassFileManager]]
+   * that works when sources are compiled directly to a jar file.
+   *
+   * Before compilation the index is read from the output jar if it exists
+   * and after failed compilation it is reverted. This implementation relies
+   * on the fact that nothing is actually removed from jar during incremental
+   * compilation. Files are only removed from index or new files are appended
+   * and potential overwrite is also handled by replacing index entry. For this
+   * reason the old index with offsets to old files will still be valid.
+   */
   private final class TransactionalClassFileManagerForJar(outputJar: File)
       extends XClassFileManager {
     private val backedUpIndex = Some(outputJar).filter(_.exists()).map(STJ.stashIndex)

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/ClassFileManager.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/ClassFileManager.scala
@@ -45,20 +45,26 @@ object ClassFileManager {
 
   def getDefaultClassFileManager(
       classFileManagerType: Optional[ClassFileManagerType],
-      output: Output
+      output: Output,
+      outputJarContent: JarUtils.OutputJarContent
   ): XClassFileManager = {
     if (classFileManagerType.isPresent) {
       classFileManagerType.get match {
-        case _: DeleteImmediatelyManagerType => deleteImmediately(output)
+        case _: DeleteImmediatelyManagerType => deleteImmediately(output, outputJarContent)
         case m: TransactionalManagerType =>
-          transactional(output, m.backupDirectory, m.logger)
+          transactional(output, outputJarContent, m.backupDirectory, m.logger)
       }
-    } else deleteImmediately(output)
+    } else deleteImmediately(output, outputJarContent)
   }
 
-  def getClassFileManager(options: IncOptions, output: Output): XClassFileManager = {
+  def getClassFileManager(
+      options: IncOptions,
+      output: Output,
+      outputJarContent: JarUtils.OutputJarContent
+  ): XClassFileManager = {
     import sbt.internal.inc.JavaInterfaceUtil.{ EnrichOptional, EnrichOption }
-    val internal = getDefaultClassFileManager(options.classfileManagerType, output)
+    val internal =
+      getDefaultClassFileManager(options.classfileManagerType, output, outputJarContent)
     val external = Option(options.externalHooks())
       .flatMap(ext => ext.getExternalClassFileManager.toOption)
     xsbti.compile.WrappedClassFileManager.of(internal, external.toOptional)
@@ -78,12 +84,14 @@ object ClassFileManager {
    */
   def deleteImmediately: XClassFileManager = new DeleteClassFileManager
 
-  def deleteImmediatelyFromJar(outputJar: File): XClassFileManager =
-    new DeleteClassFileManagerForJar(outputJar)
+  def deleteImmediatelyFromJar(outputJar: File,
+                               outputJarContent: JarUtils.OutputJarContent): XClassFileManager =
+    new DeleteClassFileManagerForJar(outputJar, outputJarContent)
 
-  def deleteImmediately(output: Output): XClassFileManager = {
+  def deleteImmediately(output: Output,
+                        outputJarContent: JarUtils.OutputJarContent): XClassFileManager = {
     val outputJar = JarUtils.getOutputJar(output)
-    outputJar.fold(deleteImmediately)(deleteImmediatelyFromJar)
+    outputJar.fold(deleteImmediately)(deleteImmediatelyFromJar(_, outputJarContent))
   }
 
   /**
@@ -96,13 +104,19 @@ object ClassFileManager {
   def transactional(tempDir0: File, logger: sbt.util.Logger): XClassFileManager =
     new TransactionalClassFileManager(tempDir0, logger)
 
-  def transactionalForJar(outputJar: File): XClassFileManager = {
-    new TransactionalClassFileManagerForJar(outputJar)
+  def transactionalForJar(outputJar: File,
+                          outputJarContent: JarUtils.OutputJarContent): XClassFileManager = {
+    new TransactionalClassFileManagerForJar(outputJar, outputJarContent)
   }
 
-  def transactional(output: Output, tempDir: File, logger: sbt.util.Logger): XClassFileManager = {
+  def transactional(
+      output: Output,
+      outputJarContent: JarUtils.OutputJarContent,
+      tempDir: File,
+      logger: sbt.util.Logger
+  ): XClassFileManager = {
     val outputJar = JarUtils.getOutputJar(output)
-    outputJar.fold(transactional(tempDir, logger))(transactionalForJar)
+    outputJar.fold(transactional(tempDir, logger))(transactionalForJar(_, outputJarContent))
   }
 
   private final class TransactionalClassFileManager(tempDir0: File, logger: sbt.util.Logger)
@@ -154,10 +168,13 @@ object ClassFileManager {
     }
   }
 
-  private final class DeleteClassFileManagerForJar(outputJar: File) extends XClassFileManager {
+  private final class DeleteClassFileManagerForJar(
+      outputJar: File,
+      outputJarContent: JarUtils.OutputJarContent
+  ) extends XClassFileManager {
     override def delete(classes: Array[File]): Unit = {
       val relClasses = classes.map(c => JarUtils.ClassInJar.fromFile(c).toClassFilePath)
-      JarUtils.OutputJarContent.removeClasses(relClasses.toSet)
+      outputJarContent.removeClasses(relClasses.toSet)
       JarUtils.removeFromJar(outputJar, relClasses)
     }
     override def generated(classes: Array[File]): Unit = ()
@@ -175,14 +192,16 @@ object ClassFileManager {
    * and potential overwrite is also handled by replacing index entry. For this
    * reason the old index with offsets to old files will still be valid.
    */
-  private final class TransactionalClassFileManagerForJar(outputJar: File)
-      extends XClassFileManager {
+  private final class TransactionalClassFileManagerForJar(
+      outputJar: File,
+      outputJarContent: JarUtils.OutputJarContent
+  ) extends XClassFileManager {
     private val backedUpIndex = Some(outputJar).filter(_.exists()).map(JarUtils.stashIndex)
 
     override def delete(classesInJar: Array[File]): Unit = {
       val classes = classesInJar.map(c => JarUtils.ClassInJar.fromFile(c).toClassFilePath)
       JarUtils.removeFromJar(outputJar, classes)
-      JarUtils.OutputJarContent.removeClasses(classes.toSet)
+      outputJarContent.removeClasses(classes.toSet)
     }
 
     override def generated(classes: Array[File]): Unit = ()

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/ClassFileManager.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/ClassFileManager.scala
@@ -157,6 +157,7 @@ object ClassFileManager {
   private final class DeleteClassFileManagerForJar(outputJar: File) extends XClassFileManager {
     override def delete(classes: Array[File]): Unit = {
       val relClasses = classes.map(c => JarUtils.ClassInJar.fromFile(c).relClass)
+      JarUtils.OutputJarContent.removeClasses(relClasses.toSet)
       JarUtils.removeFromJar(outputJar, relClasses)
     }
     override def generated(classes: Array[File]): Unit = ()
@@ -181,6 +182,7 @@ object ClassFileManager {
     override def delete(classesInJar: Array[File]): Unit = {
       val classes = classesInJar.map(c => JarUtils.ClassInJar.fromFile(c).relClass)
       JarUtils.removeFromJar(outputJar, classes)
+      JarUtils.OutputJarContent.removeClasses(classes.toSet)
     }
 
     override def generated(classes: Array[File]): Unit = ()

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/ClassFileManager.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/ClassFileManager.scala
@@ -156,7 +156,7 @@ object ClassFileManager {
 
   private final class DeleteClassFileManagerForJar(outputJar: File) extends XClassFileManager {
     override def delete(classes: Array[File]): Unit = {
-      val relClasses = classes.map(c => JarUtils.ClassInJar.fromFile(c).relClass)
+      val relClasses = classes.map(c => JarUtils.ClassInJar.fromFile(c).toClassFilePath)
       JarUtils.OutputJarContent.removeClasses(relClasses.toSet)
       JarUtils.removeFromJar(outputJar, relClasses)
     }
@@ -180,7 +180,7 @@ object ClassFileManager {
     private val backedUpIndex = Some(outputJar).filter(_.exists()).map(JarUtils.stashIndex)
 
     override def delete(classesInJar: Array[File]): Unit = {
-      val classes = classesInJar.map(c => JarUtils.ClassInJar.fromFile(c).relClass)
+      val classes = classesInJar.map(c => JarUtils.ClassInJar.fromFile(c).toClassFilePath)
       JarUtils.removeFromJar(outputJar, classes)
       JarUtils.OutputJarContent.removeClasses(classes.toSet)
     }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/ClassFileManager.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/ClassFileManager.scala
@@ -156,7 +156,7 @@ object ClassFileManager {
 
   private final class DeleteClassFileManagerForJar(outputJar: File) extends XClassFileManager {
     override def delete(classes: Array[File]): Unit = {
-      val relClasses = classes.map(c => STJ.getRelClass(c.toString))
+      val relClasses = classes.map(c => STJ.JaredClass.fromFile(c).relClass)
       STJ.removeFromJar(outputJar, relClasses)
     }
     override def generated(classes: Array[File]): Unit = ()
@@ -168,7 +168,7 @@ object ClassFileManager {
     private val backedUpIndex = Some(outputJar).filter(_.exists()).map(STJ.stashIndex)
 
     override def delete(jaredClasses: Array[File]): Unit = {
-      val classes = jaredClasses.map(s => STJ.getRelClass(s.toString))
+      val classes = jaredClasses.map(c => STJ.JaredClass.fromFile(c).relClass)
       STJ.removeFromJar(outputJar, classes)
     }
 

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/ClassFileManager.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/ClassFileManager.scala
@@ -156,7 +156,7 @@ object ClassFileManager {
 
   private final class DeleteClassFileManagerForJar(outputJar: File) extends XClassFileManager {
     override def delete(classes: Array[File]): Unit = {
-      val relClasses = classes.map(c => JarUtils.JaredClass.fromFile(c).relClass)
+      val relClasses = classes.map(c => JarUtils.ClassInJar.fromFile(c).relClass)
       JarUtils.removeFromJar(outputJar, relClasses)
     }
     override def generated(classes: Array[File]): Unit = ()
@@ -178,8 +178,8 @@ object ClassFileManager {
       extends XClassFileManager {
     private val backedUpIndex = Some(outputJar).filter(_.exists()).map(JarUtils.stashIndex)
 
-    override def delete(jaredClasses: Array[File]): Unit = {
-      val classes = jaredClasses.map(c => JarUtils.JaredClass.fromFile(c).relClass)
+    override def delete(classesInJar: Array[File]): Unit = {
+      val classes = classesInJar.map(c => JarUtils.ClassInJar.fromFile(c).relClass)
       JarUtils.removeFromJar(outputJar, classes)
     }
 

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Compile.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Compile.scala
@@ -10,7 +10,7 @@ package internal
 package inc
 
 import sbt.internal.inc.Analysis.{ LocalProduct, NonLocalProduct }
-import xsbt.api.{ APIUtil, HashAPI, NameHashing }
+import xsbt.api.{ APIUtil, NameHashing, HashAPI }
 import xsbti.api._
 import xsbti.compile.{
   ClassFileManager => XClassFileManager,
@@ -23,14 +23,12 @@ import xsbti.{ Position, Problem, Severity, UseScope }
 import sbt.util.Logger
 import sbt.util.InterfaceUtil.jo2o
 import java.io.File
-import java.net.URL
 import java.util
+import java.util.Optional
+import sbt.internal.inc.JavaInterfaceUtil.EnrichOption
 
-import sbt.io.IO
 import xsbti.api.DependencyContext
 import xsbti.compile.analysis.ReadStamps
-
-import scala.util.Try
 
 /**
  * Helper methods for running incremental compilation.  All this is responsible for is
@@ -176,6 +174,12 @@ private final class AnalysisCallback(
   private[this] val binaryClassName = new HashMap[File, String]
   // source files containing a macro def.
   private[this] val macroClasses = Set[String]()
+  private[this] val prevJar = {
+    JarUtils
+      .getOutputJar(output)
+      .filter(_.exists())
+      .map(_ => JarUtils.createPrevJarPath())
+  }
 
   private def add[A, B](map: Map[A, Set[B]], a: A, b: B): Unit = {
     map.getOrElseUpdate(a, new HashSet[B]) += b
@@ -409,4 +413,7 @@ private final class AnalysisCallback(
   override def dependencyPhaseCompleted(): Unit = {}
 
   override def apiPhaseCompleted(): Unit = {}
+
+  override def previousJar(): Optional[File] = prevJar.toOptional
+
 }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Compile.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Compile.scala
@@ -366,7 +366,7 @@ private final class AnalysisCallback(
 
   def addProductsAndDeps(base: Analysis): Analysis = {
     val currentProductsStamps =
-      STJ.getOutputJar(output).fold(stampReader.product _)(Stamper.forLastModifiedInJar)
+      JarUtils.getOutputJar(output).fold(stampReader.product _)(Stamper.forLastModifiedInJar)
     (base /: srcs) {
       case (a, src) =>
         val stamp = stampReader.source(src)

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -67,7 +67,8 @@ object Incremental {
     val previous = previous0 match { case a: Analysis => a }
     val runProfiler = profiler.profileRun
     val incremental: IncrementalCommon = new IncrementalNameHashing(log, options, runProfiler)
-    val initialChanges = incremental.detectInitialChanges(sources, previous, current, lookup)
+    val initialChanges =
+      incremental.detectInitialChanges(sources, previous, current, lookup, output)
     val binaryChanges = new DependencyChanges {
       val modifiedBinaries = initialChanges.binaryDeps.toArray
       val modifiedClasses = initialChanges.external.allModified.toArray

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
@@ -14,7 +14,12 @@ import java.io.File
 import sbt.util.Logger
 import xsbt.api.APIUtil
 import xsbti.api.AnalyzedClass
-import xsbti.compile.{ DependencyChanges, IncOptions, ClassFileManager => XClassFileManager }
+import xsbti.compile.{
+  DependencyChanges,
+  IncOptions,
+  Output,
+  ClassFileManager => XClassFileManager
+}
 import xsbti.compile.analysis.{ ReadStamps, Stamp => XStamp }
 
 import scala.annotation.tailrec
@@ -234,7 +239,8 @@ private[inc] abstract class IncrementalCommon(
       sources: Set[File],
       previousAnalysis: Analysis,
       stamps: ReadStamps,
-      lookup: Lookup
+      lookup: Lookup,
+      output: Output
   )(implicit equivS: Equiv[XStamp]): InitialChanges = {
     import IncrementalCommon.{ isBinaryModified, findExternalAnalyzedClass }
     val previous = previousAnalysis.stamps
@@ -251,8 +257,12 @@ private[inc] abstract class IncrementalCommon(
       }
     }
 
-    val removedProducts = lookup.removedProducts(previousAnalysis).getOrElse {
-      previous.allProducts.filter(p => !equivS.equiv(previous.product(p), stamps.product(p))).toSet
+    val removedProducts: Set[File] = lookup.removedProducts(previousAnalysis).getOrElse {
+      val currentProductsStamps =
+        STJ.getOutputJar(output).fold(stamps.product _)(Stamper.forLastModifiedInJar)
+      previous.allProducts
+        .filter(p => !equivS.equiv(previous.product(p), currentProductsStamps(p)))
+        .toSet
     }
 
     val changedBinaries: Set[File] = lookup.changedBinaries(previousAnalysis).getOrElse {

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
@@ -259,7 +259,7 @@ private[inc] abstract class IncrementalCommon(
 
     val removedProducts: Set[File] = lookup.removedProducts(previousAnalysis).getOrElse {
       val currentProductsStamps =
-        STJ.getOutputJar(output).fold(stamps.product _)(Stamper.forLastModifiedInJar)
+        JarUtils.getOutputJar(output).fold(stamps.product _)(Stamper.forLastModifiedInJar)
       previous.allProducts
         .filter(p => !equivS.equiv(previous.product(p), currentProductsStamps(p)))
         .toSet

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/MiniSetupUtil.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/MiniSetupUtil.scala
@@ -110,7 +110,7 @@ object MiniSetupUtil {
     new Equiv[MiniOptions] {
       def equiv(a: MiniOptions, b: MiniOptions) = {
         equivScalacOpts.equiv(a.scalacOptions, b.scalacOptions) &&
-        (a.javacOptions sameElements b.javacOptions)
+        equivJavacOptions.equiv(a.javacOptions, b.javacOptions)
       }
     }
   }
@@ -128,6 +128,13 @@ object MiniSetupUtil {
   }
 
   def equivScalacOptions(ignoredRegexes: Array[String]): Equiv[Array[String]] = {
+    equivCompilerOptions(ignoredRegexes)
+  }
+
+  // ignoring -d as it is overridden anyway
+  val equivJavacOptions: Equiv[Array[String]] = equivCompilerOptions(Array("-d .*"))
+
+  def equivCompilerOptions(ignoredRegexes: Array[String]): Equiv[Array[String]] = {
     def groupWithParams(opts: Array[String]): Set[String] = {
       def isParam(s: String) = !s.startsWith("-")
       def recur(opts: List[String], res: Set[String]): Set[String] = opts match {

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
@@ -142,6 +142,16 @@ object Stamper {
   }
 
   val forHash: File => XStamp = (toStamp: File) => tryStamp(Hash.ofFile(toStamp))
+
+  /**
+   * Creates a function that reads a timestamp from file.
+   * Notably it also handles files containing [[sbt.internal.inc.STJ.JaredClass]].
+   * For purpose of reading timestamps from jar, the jar is read only once and
+   * all stamps are cached. This means that for the jar use case it is crutial
+   * to create not create this function for each file/entry as it will be terribly
+   * slow. On the flip side it must be recreated each time the jar that is accessed
+   * changes to get the up to date stamps.
+   */
   def forLastModified: File => XStamp = {
     val reader = STJ.createCachedStampReader()
     toStamp: File =>

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
@@ -146,8 +146,7 @@ object Stamper {
     tryStamp(new LastModified(IO.getModifiedTimeOrZero(toStamp)))
   def forLastModifiedInJar(jar: File): File => XStamp = {
     val stamps = JarUtils.readStamps(jar)
-    file: File =>
-      new LastModified(stamps(file))
+    (file: File) => new LastModified(stamps(file))
   }
 }
 

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
@@ -145,7 +145,7 @@ object Stamper {
   val forLastModified: File => XStamp = (toStamp: File) =>
     tryStamp(new LastModified(IO.getModifiedTimeOrZero(toStamp)))
   def forLastModifiedInJar(jar: File): File => XStamp = {
-    val stamps = STJ.readStamps(jar)
+    val stamps = JarUtils.readStamps(jar)
     file: File =>
       new LastModified(stamps(file))
   }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
@@ -146,7 +146,8 @@ object Stamper {
     tryStamp(new LastModified(IO.getModifiedTimeOrZero(toStamp)))
   def forLastModifiedInJar(jar: File): File => XStamp = {
     val stamps = JarUtils.readStamps(jar)
-    (file: File) => new LastModified(stamps(file))
+    (file: File) =>
+      new LastModified(stamps(file))
   }
 }
 

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/FileAnalysisStore.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/FileAnalysisStore.scala
@@ -11,7 +11,7 @@ package inc
 
 import java.io._
 import java.util.Optional
-import java.util.zip.{ ZipEntry, ZipInputStream }
+import java.util.zip.{ ZipEntry, ZipInputStream, Deflater, ZipOutputStream }
 
 import com.google.protobuf.{ CodedInputStream, CodedOutputStream }
 import sbt.internal.inc.binary.BinaryAnalysisFormat
@@ -45,6 +45,8 @@ object FileAnalysisStore {
 
     private final val format = new BinaryAnalysisFormat(readWriteMappers)
     private final val TmpEnding = ".tmp"
+    private final val useCompression =
+      sys.props.get("zinc.binary-file-store.use-compression").map(_ == "true").getOrElse(true)
 
     /**
      * Get `CompileAnalysis` and `MiniSetup` instances for current `Analysis`.
@@ -82,6 +84,11 @@ object FileAnalysisStore {
 
       val outputStream = new FileOutputStream(tmpAnalysisFile)
       Using.zipOutputStream(outputStream) { outputStream =>
+        if (!useCompression) {
+          outputStream.setMethod(ZipOutputStream.DEFLATED)
+          outputStream.setLevel(Deflater.NO_COMPRESSION)
+        }
+
         val protobufWriter = CodedOutputStream.newInstance(outputStream)
         outputStream.putNextEntry(new ZipEntry(analysisFileName))
         format.write(protobufWriter, analysis, setup)

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/FileAnalysisStore.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/FileAnalysisStore.scala
@@ -11,7 +11,7 @@ package inc
 
 import java.io._
 import java.util.Optional
-import java.util.zip.{ ZipEntry, ZipInputStream, Deflater, ZipOutputStream }
+import java.util.zip.{ ZipEntry, ZipInputStream }
 
 import com.google.protobuf.{ CodedInputStream, CodedOutputStream }
 import sbt.internal.inc.binary.BinaryAnalysisFormat
@@ -45,8 +45,6 @@ object FileAnalysisStore {
 
     private final val format = new BinaryAnalysisFormat(readWriteMappers)
     private final val TmpEnding = ".tmp"
-    private final val useCompression =
-      sys.props.get("zinc.binary-file-store.use-compression").map(_ == "true").getOrElse(true)
 
     /**
      * Get `CompileAnalysis` and `MiniSetup` instances for current `Analysis`.
@@ -84,11 +82,6 @@ object FileAnalysisStore {
 
       val outputStream = new FileOutputStream(tmpAnalysisFile)
       Using.zipOutputStream(outputStream) { outputStream =>
-        if (!useCompression) {
-          outputStream.setMethod(ZipOutputStream.DEFLATED)
-          outputStream.setLevel(Deflater.NO_COMPRESSION)
-        }
-
         val protobufWriter = CodedOutputStream.newInstance(outputStream)
         outputStream.putNextEntry(new ZipEntry(analysisFileName))
         format.write(protobufWriter, analysis, setup)

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/cached/ExportableCache.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/cached/ExportableCache.scala
@@ -52,9 +52,10 @@ class ExportableCache(val cacheLocation: Path, cleanOutputMode: CleanOutputMode 
                                               importedFiles: Set[File]): Analysis = {
     val oldStamps = analysis.stamps
 
+    val stamper = Stamper.forLastModified
     val updatedProducts = oldStamps.products.map {
       case (file, _) if importedFiles.contains(file) =>
-        (file, Stamper.forLastModified(file))
+        (file, stamper(file))
       case other => other
     }
 

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/cached/ExportableCache.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/cached/ExportableCache.scala
@@ -52,10 +52,9 @@ class ExportableCache(val cacheLocation: Path, cleanOutputMode: CleanOutputMode 
                                               importedFiles: Set[File]): Analysis = {
     val oldStamps = analysis.stamps
 
-    val stamper = Stamper.forLastModified
     val updatedProducts = oldStamps.products.map {
       case (file, _) if importedFiles.contains(file) =>
-        (file, stamper(file))
+        (file, Stamper.forLastModified(file))
       case other => other
     }
 

--- a/internal/zinc-scripted/src/test/scala/sbt/inc/MainScriptedRunner.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/inc/MainScriptedRunner.scala
@@ -19,7 +19,11 @@ final class MainScriptedRunner {
     IO.withTemporaryDirectory { tempDir =>
       // Create a global temporary directory to store the bridge et al
       val handlers = new MainScriptedHandlers(tempDir, compileToJar)
-      ScriptedRunnerImpl.run(resourceBaseDirectory, bufferLog, tests, handlers, 4)
+      ScriptedRunnerImpl.run(resourceBaseDirectory,
+                             bufferLog,
+                             tests,
+                             handlers,
+                             if (compileToJar) 1 else 4)
     }
   }
 }

--- a/internal/zinc-scripted/src/test/scala/sbt/inc/MainScriptedRunner.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/inc/MainScriptedRunner.scala
@@ -19,11 +19,7 @@ final class MainScriptedRunner {
     IO.withTemporaryDirectory { tempDir =>
       // Create a global temporary directory to store the bridge et al
       val handlers = new MainScriptedHandlers(tempDir, compileToJar)
-      ScriptedRunnerImpl.run(resourceBaseDirectory,
-                             bufferLog,
-                             tests,
-                             handlers,
-                             if (compileToJar) 1 else 4)
+      ScriptedRunnerImpl.run(resourceBaseDirectory, bufferLog, tests, handlers, 4)
     }
   }
 }

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -371,7 +371,7 @@ case class ProjectStructure(
 
   def checkNoGeneratedClassFiles(): Unit = {
     val allPlainClassFiles = generatedClassFiles.get.map(_.toString)
-    val allClassesInJar = outputJar.toSeq.flatMap(JarUtils.listFiles).filter(_.endsWith(".class"))
+    val allClassesInJar = outputJar.toSeq.filter(_.exists()).flatMap(JarUtils.listClassFiles)
     if (allPlainClassFiles.nonEmpty || allClassesInJar.nonEmpty) {
       val allClassFiles = allPlainClassFiles ++ allClassesInJar
       sys.error(s"Classes existed:\n\t${allClassFiles.mkString("\n\t")}")

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -370,11 +370,12 @@ case class ProjectStructure(
   }
 
   def checkNoGeneratedClassFiles(): Unit = {
-    val allClassFiles = generatedClassFiles.get
+    val allPlainClassFiles = generatedClassFiles.get.map(_.toString)
     val allClassesInJar = outputJar.toSeq.flatMap(JarUtils.listFiles).filter(_.endsWith(".class"))
-    if (allClassFiles.nonEmpty || allClassesInJar.nonEmpty)
-      sys.error(
-        s"Classes existed:\n\t${allClassFiles.mkString("\n\t")} \n\t${allClassesInJar.mkString("\n\t")}")
+    if (allPlainClassFiles.nonEmpty || allClassesInJar.nonEmpty) {
+      val allClassFiles = allPlainClassFiles ++ allClassesInJar
+      sys.error(s"Classes existed:\n\t${allClassFiles.mkString("\n\t")}")
+    }
   }
 
   def checkDependencies(i: IncInstance, className: String, expected: List[String]): Unit = {

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -346,14 +346,19 @@ case class ProjectStructure(
 
   def checkProducts(i: IncInstance, src: String, expected: List[String]): Unit = {
     val analysis = compile(i)
+
+    def isWindows: Boolean = sys.props("os.name").toLowerCase.startsWith("win")
     def relativeClassDir(f: File): File = f.relativeTo(classesDir) getOrElse f
+    def normalizePath(path: String): String = {
+      if (isWindows) path.replace('\\', '/') else path
+    }
     def products(srcFile: String): Set[String] = {
       val productFiles = analysis.relations.products(baseDirectory / srcFile)
       productFiles.map { file =>
         if (JarUtils.isClassInJar(file)) {
           JarUtils.ClassInJar.fromFile(file).relClass
         } else {
-          relativeClassDir(file).getPath.replace('\\', '/')
+          normalizePath(relativeClassDir(file).getPath)
         }
       }
     }

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -351,7 +351,7 @@ case class ProjectStructure(
       val productFiles = analysis.relations.products(baseDirectory / srcFile)
       productFiles.map { file =>
         if (STJ.isJar(file)) {
-          STJ.getRelClass(file.toString)
+          STJ.JaredClass.fromFile(file).relClass
         } else {
           relativeClassDir(file).getPath.replace('\\', '/')
         }
@@ -443,6 +443,7 @@ case class ProjectStructure(
     outputJar
       .map { currentJar =>
         IO.copy(Seq(currentJar -> targetJar))
+        ()
       }
       .getOrElse {
         val manifest = new Manifest
@@ -454,6 +455,7 @@ case class ProjectStructure(
             }
           }
         IO.jar(sources, targetJar, manifest)
+        ()
       }
   }
 

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -226,7 +226,7 @@ case class ProjectStructure(
     scalaVersion: String
 ) extends BridgeProviderSpecification {
 
-  val useStraightToJar = false
+  val useStraightToJar = true
 
   val compiler = new IncrementalCompilerImpl
   val maxErrors = 100

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -356,7 +356,7 @@ case class ProjectStructure(
       val productFiles = analysis.relations.products(baseDirectory / srcFile)
       productFiles.map { file =>
         if (JarUtils.isClassInJar(file)) {
-          JarUtils.ClassInJar.fromFile(file).relClass
+          JarUtils.ClassInJar.fromFile(file).toClassFilePath
         } else {
           normalizePath(relativeClassDir(file).getPath)
         }

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -226,7 +226,7 @@ case class ProjectStructure(
     scalaVersion: String
 ) extends BridgeProviderSpecification {
 
-  val useStraightToJar = true
+  val useStraightToJar = false
 
   val compiler = new IncrementalCompilerImpl
   val maxErrors = 100
@@ -350,7 +350,7 @@ case class ProjectStructure(
     def products(srcFile: String): Set[String] = {
       val productFiles = analysis.relations.products(baseDirectory / srcFile)
       productFiles.map { file =>
-        if (STJ.isJar(file)) {
+        if (STJ.isJaredClass(file)) {
           STJ.JaredClass.fromFile(file).relClass
         } else {
           relativeClassDir(file).getPath.replace('\\', '/')

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -446,12 +446,11 @@ case class ProjectStructure(
   def packageBin(i: IncInstance): Unit = {
     compile(i)
     val targetJar = targetDir / s"$name.jar"
-    outputJar
-      .map { currentJar =>
+    outputJar match {
+      case Some(currentJar) =>
         IO.copy(Seq(currentJar -> targetJar))
         ()
-      }
-      .getOrElse {
+      case None =>
         val manifest = new Manifest
         val sources =
           (classesDir ** -DirectoryFilter).get flatMap { x =>
@@ -461,8 +460,7 @@ case class ProjectStructure(
             }
           }
         IO.jar(sources, targetJar, manifest)
-        ()
-      }
+    }
   }
 
   def unrecognizedArguments(commandName: String, args: List[String]): Unit =

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -350,8 +350,8 @@ case class ProjectStructure(
     def products(srcFile: String): Set[String] = {
       val productFiles = analysis.relations.products(baseDirectory / srcFile)
       productFiles.map { file =>
-        if (JarUtils.isJaredClass(file)) {
-          JarUtils.JaredClass.fromFile(file).relClass
+        if (JarUtils.isClassInJar(file)) {
+          JarUtils.ClassInJar.fromFile(file).relClass
         } else {
           relativeClassDir(file).getPath.replace('\\', '/')
         }
@@ -366,10 +366,10 @@ case class ProjectStructure(
 
   def checkNoGeneratedClassFiles(): Unit = {
     val allClassFiles = generatedClassFiles.get
-    val allJaredClassFiles = outputJar.toSeq.flatMap(JarUtils.listFiles).filter(_.endsWith(".class"))
-    if (allClassFiles.nonEmpty || allJaredClassFiles.nonEmpty)
+    val allClassesInJar = outputJar.toSeq.flatMap(JarUtils.listFiles).filter(_.endsWith(".class"))
+    if (allClassFiles.nonEmpty || allClassesInJar.nonEmpty)
       sys.error(
-        s"Classes existed:\n\t${allClassFiles.mkString("\n\t")} \n\t${allJaredClassFiles.mkString("\n\t")}")
+        s"Classes existed:\n\t${allClassFiles.mkString("\n\t")} \n\t${allClassesInJar.mkString("\n\t")}")
   }
 
   def checkDependencies(i: IncInstance, className: String, expected: List[String]): Unit = {

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -350,8 +350,8 @@ case class ProjectStructure(
     def products(srcFile: String): Set[String] = {
       val productFiles = analysis.relations.products(baseDirectory / srcFile)
       productFiles.map { file =>
-        if (STJ.isJaredClass(file)) {
-          STJ.JaredClass.fromFile(file).relClass
+        if (JarUtils.isJaredClass(file)) {
+          JarUtils.JaredClass.fromFile(file).relClass
         } else {
           relativeClassDir(file).getPath.replace('\\', '/')
         }
@@ -366,7 +366,7 @@ case class ProjectStructure(
 
   def checkNoGeneratedClassFiles(): Unit = {
     val allClassFiles = generatedClassFiles.get
-    val allJaredClassFiles = outputJar.toSeq.flatMap(STJ.listFiles).filter(_.endsWith(".class"))
+    val allJaredClassFiles = outputJar.toSeq.flatMap(JarUtils.listFiles).filter(_.endsWith(".class"))
     if (allClassFiles.nonEmpty || allJaredClassFiles.nonEmpty)
       sys.error(
         s"Classes existed:\n\t${allClassFiles.mkString("\n\t")} \n\t${allJaredClassFiles.mkString("\n\t")}")

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -435,7 +435,8 @@ case class ProjectStructure(
                              CompileOrder.Mixed,
                              cs,
                              setup,
-                             previousResult)
+                             previousResult,
+                             Optional.empty())
     val result = compiler.compile(in, scriptedLog)
     val analysis = result.analysis match { case a: Analysis => a }
     cachedStore.set(AnalysisContents.create(analysis, result.setup))

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncScriptedRunner.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncScriptedRunner.scala
@@ -9,10 +9,15 @@ import sbt.util.Logger
 import scala.collection.parallel.ParSeq
 
 class IncScriptedRunner {
-  def run(resourceBaseDirectory: File, bufferLog: Boolean, tests: Array[String]): Unit = {
+  def run(
+      resourceBaseDirectory: File,
+      bufferLog: Boolean,
+      compileToJar: Boolean,
+      tests: Array[String]
+  ): Unit = {
     IO.withTemporaryDirectory { tempDir =>
       // Create a global temporary directory to store the bridge et al
-      val handlers = new IncScriptedHandlers(tempDir)
+      val handlers = new IncScriptedHandlers(tempDir, compileToJar)
       ScriptedRunnerImpl.run(resourceBaseDirectory, bufferLog, tests, handlers, 4)
     }
   }

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncScriptedRunner.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncScriptedRunner.scala
@@ -18,7 +18,7 @@ class IncScriptedRunner {
     IO.withTemporaryDirectory { tempDir =>
       // Create a global temporary directory to store the bridge et al
       val handlers = new IncScriptedHandlers(tempDir, compileToJar)
-      ScriptedRunnerImpl.run(resourceBaseDirectory, bufferLog, tests, handlers, 4)
+      ScriptedRunnerImpl.run(resourceBaseDirectory, bufferLog, tests, handlers, 1)
     }
   }
 }

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncScriptedRunner.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncScriptedRunner.scala
@@ -18,7 +18,11 @@ class IncScriptedRunner {
     IO.withTemporaryDirectory { tempDir =>
       // Create a global temporary directory to store the bridge et al
       val handlers = new IncScriptedHandlers(tempDir, compileToJar)
-      ScriptedRunnerImpl.run(resourceBaseDirectory, bufferLog, tests, handlers, 1)
+      ScriptedRunnerImpl.run(resourceBaseDirectory,
+                             bufferLog,
+                             tests,
+                             handlers,
+                             if (compileToJar) 1 else 4)
     }
   }
 }

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncScriptedRunner.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncScriptedRunner.scala
@@ -18,11 +18,7 @@ class IncScriptedRunner {
     IO.withTemporaryDirectory { tempDir =>
       // Create a global temporary directory to store the bridge et al
       val handlers = new IncScriptedHandlers(tempDir, compileToJar)
-      ScriptedRunnerImpl.run(resourceBaseDirectory,
-                             bufferLog,
-                             tests,
-                             handlers,
-                             if (compileToJar) 1 else 4)
+      ScriptedRunnerImpl.run(resourceBaseDirectory, bufferLog, tests, handlers, 4)
     }
   }
 }

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/ScriptedHandlers.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/ScriptedHandlers.scala
@@ -16,7 +16,7 @@ class SleepingHandler(val handler: StatementHandler, delay: Long) extends Statem
   override def finish(state: State) = handler.finish(state)
 }
 
-class IncScriptedHandlers(globalCacheDir: File) extends HandlersProvider {
+class IncScriptedHandlers(globalCacheDir: File, compileToJar: Boolean) extends HandlersProvider {
   def getHandlers(config: ScriptConfig): Map[Char, StatementHandler] = Map(
     '$' -> new SleepingHandler(new ZincFileCommands(config.testDirectory()), 500),
     '#' -> CommentHandler,
@@ -26,7 +26,7 @@ class IncScriptedHandlers(globalCacheDir: File) extends HandlersProvider {
           case x: ManagedLogger => x
           case _                => sys.error("Expected ManagedLogger")
         }
-      new IncHandler(config.testDirectory(), globalCacheDir, logger)
+      new IncHandler(config.testDirectory(), globalCacheDir, logger, compileToJar)
     }
   )
 }

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/ZincFileCommands.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/ZincFileCommands.scala
@@ -54,7 +54,7 @@ class ZincFileCommands(baseDirectory: File) extends FileCommands(baseDirectory) 
       val relBasePath = "target/classes"
       IO.relativize(new File(relBasePath), new File(path)).map { relClass =>
         val jar = Paths.get(baseDirectory.toString, relBasePath, "output.jar").toFile
-        transformJared(STJ.jaredClass(jar, relClass))
+        transformJared(STJ.JaredClass(jar, relClass))
       }
     }
     val regularRes = transformPlain(fromString(path))

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/ZincFileCommands.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/ZincFileCommands.scala
@@ -54,7 +54,7 @@ class ZincFileCommands(baseDirectory: File) extends FileCommands(baseDirectory) 
       val relBasePath = "target/classes"
       IO.relativize(new File(relBasePath), new File(path)).map { relClass =>
         val jar = Paths.get(baseDirectory.toString, relBasePath, "output.jar").toFile
-        transformJared(STJ.init(jar, relClass))
+        transformJared(STJ.jaredClass(jar, relClass))
       }
     }
     val regularRes = transformPlain(fromString(path))

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/ZincFileCommands.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/ZincFileCommands.scala
@@ -11,7 +11,7 @@ class ZincFileCommands(baseDirectory: File) extends FileCommands(baseDirectory) 
     super.commandMap + {
       "pause" noArg {
         // Redefine pause not to use `System.console`, which is too restrictive
-        println(s"Pausing in $baseDirectory. Press enter to continue.")
+        println(s"Pausing in $baseDirectory (press enter to continue)")
         scala.io.StdIn.readLine()
         println("Restarting the execution.")
       }

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/ZincFileCommands.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/ZincFileCommands.scala
@@ -64,13 +64,13 @@ class ZincFileCommands(baseDirectory: File) extends FileCommands(baseDirectory) 
    */
   private def pathFold[A](path: String)(
       transformPlain: File => A,
-      transformJared: JarUtils.JaredClass => A
+      transformJared: JarUtils.ClassInJar => A
   )(combine: (A, A) => A): A = {
     val jaredRes = {
       val relBasePath = "target/classes"
       IO.relativize(new File(relBasePath), new File(path)).map { relClass =>
         val jar = Paths.get(baseDirectory.toString, relBasePath, "output.jar").toFile
-        transformJared(JarUtils.JaredClass(jar, relClass))
+        transformJared(JarUtils.ClassInJar(jar, relClass))
       }
     }
     val regularRes = transformPlain(fromString(path))

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/ZincFileCommands.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/ZincFileCommands.scala
@@ -39,11 +39,11 @@ class ZincFileCommands(baseDirectory: File) extends FileCommands(baseDirectory) 
   }
 
   private def exists(path: String): Boolean = {
-    pathFold(path)(_.exists(), STJ.exists)(_ || _)
+    pathFold(path)(_.exists(), JarUtils.exists)(_ || _)
   }
 
   private def getModifiedTimeOrZero(path: String): Long = {
-    pathFold(path)(IO.getModifiedTimeOrZero, STJ.readModifiedTime)(_ max _)
+    pathFold(path)(IO.getModifiedTimeOrZero, JarUtils.readModifiedTime)(_ max _)
   }
 
   /**
@@ -64,13 +64,13 @@ class ZincFileCommands(baseDirectory: File) extends FileCommands(baseDirectory) 
    */
   private def pathFold[A](path: String)(
       transformPlain: File => A,
-      transformJared: STJ.JaredClass => A
+      transformJared: JarUtils.JaredClass => A
   )(combine: (A, A) => A): A = {
     val jaredRes = {
       val relBasePath = "target/classes"
       IO.relativize(new File(relBasePath), new File(path)).map { relClass =>
         val jar = Paths.get(baseDirectory.toString, relBasePath, "output.jar").toFile
-        transformJared(STJ.JaredClass(jar, relClass))
+        transformJared(JarUtils.JaredClass(jar, relClass))
       }
     }
     val regularRes = transformPlain(fromString(path))

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/ZincFileCommands.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/ZincFileCommands.scala
@@ -1,8 +1,10 @@
 package sbt.internal.inc
 
 import java.io.File
+import java.nio.file.Paths
 
 import sbt.internal.scripted.FileCommands
+import sbt.io.IO
 
 class ZincFileCommands(baseDirectory: File) extends FileCommands(baseDirectory) {
   override def commandMap: Map[String, List[String] => Unit] = {
@@ -15,4 +17,48 @@ class ZincFileCommands(baseDirectory: File) extends FileCommands(baseDirectory) 
       }
     }
   }
+
+  override def absent(paths: List[String]): Unit = {
+    val present = paths.filter(exists)
+    if (present.nonEmpty)
+      scriptError("File(s) existed: " + present.mkString("[ ", " , ", " ]"))
+  }
+
+  override def newer(a: String, b: String): Unit = {
+    val isNewer = exists(a) && (!exists(b) || getModifiedTimeOrZero(a) > getModifiedTimeOrZero(b))
+    if (!isNewer) {
+      scriptError(s"$a is not newer than $b")
+    }
+  }
+
+  override def exists(paths: List[String]): Unit = {
+    val notPresent = paths.filterNot(exists)
+    if (notPresent.nonEmpty) {
+      scriptError("File(s) did not exist: " + notPresent.mkString("[ ", " , ", " ]"))
+    }
+  }
+
+  private def exists(path: String): Boolean = {
+    pathFold(path)(_.exists(), STJ.existsInJar)(_ || _)
+  }
+
+  private def getModifiedTimeOrZero(path: String): Long = {
+    pathFold(path)(IO.getModifiedTimeOrZero, STJ.readModifiedTimeFromJar)(_ max _)
+  }
+
+  private def pathFold[A](path: String)(
+      transformPlain: File => A,
+      transformJared: STJ.JaredClass => A
+  )(combine: (A, A) => A): A = {
+    val jaredRes = {
+      val relBasePath = "target/classes"
+      IO.relativize(new File(relBasePath), new File(path)).map { relClass =>
+        val jar = Paths.get(baseDirectory.toString, relBasePath, "output.jar").toFile
+        transformJared(STJ.init(jar, relClass))
+      }
+    }
+    val regularRes = transformPlain(fromString(path))
+    jaredRes.map(combine(_, regularRes)).getOrElse(regularRes)
+  }
+
 }

--- a/zinc/src/main/scala/sbt/internal/inc/CompileConfiguration.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/CompileConfiguration.scala
@@ -49,5 +49,6 @@ final class CompileConfiguration(
     val compiler: xsbti.compile.ScalaCompiler,
     val javac: xsbti.compile.JavaCompiler,
     val cache: GlobalsCache,
-    val incOptions: IncOptions
+    val incOptions: IncOptions,
+    val outputJarContent: JarUtils.OutputJarContent
 )

--- a/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
@@ -263,6 +263,8 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
         JarUtils.javacOptions
       } else Seq.empty
 
+      val outputJarContent = JarUtils.createOutputJarContent(output)
+
       val config = MixedAnalyzingCompiler.makeConfig(
         scalaCompiler,
         javaCompiler,
@@ -280,6 +282,7 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
         compileOrder,
         skip,
         incrementalOptions,
+        outputJarContent,
         extra
       )
       if (skip) CompileResult.of(prev, config.currentSetup, false)
@@ -319,9 +322,9 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
           previousAnalysis
         else if (!equivPairs.equiv(previous.extra, currentSetup.extra))
           Analysis.empty
-        else Incremental.prune(srcsSet, previousAnalysis, output)
+        else Incremental.prune(srcsSet, previousAnalysis, output, outputJarContent)
       case None =>
-        Incremental.prune(srcsSet, previousAnalysis, output)
+        Incremental.prune(srcsSet, previousAnalysis, output, outputJarContent)
     }
 
     // Run the incremental compilation
@@ -332,7 +335,8 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
       analysis,
       output,
       log,
-      incOptions
+      incOptions,
+      outputJarContent
     )
     compile.swap
   }

--- a/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
@@ -241,7 +241,7 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
         case None           => Analysis.empty
       }
 
-      val compileStraightToJar = STJ.isEnabled(output)
+      val compileStraightToJar = JarUtils.isCompilingToJar(output)
 
       // otherwise jars on classpath will not be closed, especially prev jar.
       if (compileStraightToJar) sys.props.put("scala.classpath.closeZip", "true")
@@ -249,12 +249,12 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
       val extraScalacOptions = {
         val scalaVersion = scalaCompiler.scalaInstance.version
         if (compileStraightToJar && scalaVersion.startsWith("2.12")) {
-          STJ.scalacOptions
+          JarUtils.scalacOptions
         } else Seq.empty
       }
 
       val extraJavacOptions = if (compileStraightToJar) {
-        STJ.javacOptions
+        JarUtils.javacOptions
       } else Seq.empty
 
       val config = MixedAnalyzingCompiler.makeConfig(

--- a/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
@@ -243,6 +243,7 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
 
       val compileStraightToJar = STJ.isEnabled(output)
 
+      // otherwise jars on classpath will not be closed, especially prev jar.
       if (compileStraightToJar) sys.props.put("scala.classpath.closeZip", "true")
 
       val extraScalacOptions = {

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -68,7 +68,7 @@ final class MixedAnalyzingCompiler(
     /** Compile Scala sources. */
     def compileScala(): Unit =
       if (scalaSrcs.nonEmpty) {
-        JarUtils.withPreviousJar(output, callback) { extraClasspath =>
+        JarUtils.withPreviousJar(output) { extraClasspath =>
           val sources = if (config.currentSetup.order == Mixed) incSrc else scalaSrcs
           val arguments = cArgs(Nil,
                                 toAbsolute(extraClasspath) ++ absClasspath,
@@ -154,6 +154,7 @@ final class MixedAnalyzingCompiler(
 
     if (compiledClasses.nonEmpty) {
       JarUtils.includeInJar(outputJar, compiledClasses)
+      JarUtils.OutputJarContent.addClasses(compiledClasses.map(_._2).toSet)
     }
     IO.delete(outputDir)
   }

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -301,10 +301,10 @@ object MixedAnalyzingCompiler {
   ): (Seq[File], String => Option[File]) = {
     import config._
     import currentSetup._
-    // If we are compiling straight to jar, javac does not have this option
+    // If we are compiling straight to jar, as javac does not support this,
     // it will be compiled to a temporary directory (with deterministic name)
     // and then added to the final jar. This temporary directory has to be
-    // available for Analyze to work phase to work.
+    // available for sbt.internal.inc.classfile.Analyze to work correctly.
     val tempJavacOutput = STJ.getOutputJar(currentSetup.output).map(STJ.javacTempOutput).toSeq
     val absClasspath = classpath.map(_.getAbsoluteFile)
     val cArgs =

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -68,7 +68,7 @@ final class MixedAnalyzingCompiler(
     /** Compile Scala sources. */
     def compileScala(): Unit =
       if (scalaSrcs.nonEmpty) {
-        STJ.withPreviousJar(output) { extraClasspath =>
+        JarUtils.withPreviousJar(output) { extraClasspath =>
           val sources = if (config.currentSetup.order == Mixed) incSrc else scalaSrcs
           val arguments = cArgs(Nil,
                                 toAbsolute(extraClasspath) ++ absClasspath,
@@ -101,9 +101,9 @@ final class MixedAnalyzingCompiler(
             )
           val joptions = config.currentSetup.options.javacOptions
 
-          STJ.getOutputJar(output) match {
+          JarUtils.getOutputJar(output) match {
             case Some(outputJar) =>
-              val outputDir = STJ.javacTempOutput(outputJar)
+              val outputDir = JarUtils.javacTempOutput(outputJar)
               IO.createDirectory(outputDir)
               javac.compile(javaSrcs,
                             joptions,
@@ -153,7 +153,7 @@ final class MixedAnalyzingCompiler(
     }
 
     if (compiledClasses.nonEmpty) {
-      STJ.includeInJar(outputJar, compiledClasses)
+      JarUtils.includeInJar(outputJar, compiledClasses)
     }
     IO.delete(outputDir)
   }
@@ -305,7 +305,7 @@ object MixedAnalyzingCompiler {
     // it will be compiled to a temporary directory (with deterministic name)
     // and then added to the final jar. This temporary directory has to be
     // available for sbt.internal.inc.classfile.Analyze to work correctly.
-    val tempJavacOutput = STJ.getOutputJar(currentSetup.output).map(STJ.javacTempOutput).toSeq
+    val tempJavacOutput = JarUtils.getOutputJar(currentSetup.output).map(JarUtils.javacTempOutput).toSeq
     val absClasspath = classpath.map(_.getAbsoluteFile)
     val cArgs =
       new CompilerArguments(compiler.scalaInstance, compiler.classpathOptions)

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -305,7 +305,8 @@ object MixedAnalyzingCompiler {
     // it will be compiled to a temporary directory (with deterministic name)
     // and then added to the final jar. This temporary directory has to be
     // available for sbt.internal.inc.classfile.Analyze to work correctly.
-    val tempJavacOutput = JarUtils.getOutputJar(currentSetup.output).map(JarUtils.javacTempOutput).toSeq
+    val tempJavacOutput =
+      JarUtils.getOutputJar(currentSetup.output).map(JarUtils.javacTempOutput).toSeq
     val absClasspath = classpath.map(_.getAbsoluteFile)
     val cArgs =
       new CompilerArguments(compiler.scalaInstance, compiler.classpathOptions)

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -28,7 +28,8 @@ final class MixedAnalyzingCompiler(
     val scalac: xsbti.compile.ScalaCompiler,
     val javac: AnalyzingJavaCompiler,
     val config: CompileConfiguration,
-    val log: Logger
+    val log: Logger,
+    outputJarContent: JarUtils.OutputJarContent
 ) {
 
   private[this] val absClasspath = toAbsolute(config.classpath)
@@ -152,7 +153,7 @@ final class MixedAnalyzingCompiler(
 
     if (compiledClasses.nonEmpty) {
       JarUtils.includeInJar(outputJar, compiledClasses)
-      JarUtils.OutputJarContent.addClasses(compiledClasses.map(_._2).toSet)
+      outputJarContent.addClasses(compiledClasses.map(_._2).toSet)
     }
     IO.delete(outputDir)
   }
@@ -221,6 +222,7 @@ object MixedAnalyzingCompiler {
       compileOrder: CompileOrder = Mixed,
       skip: Boolean = false,
       incrementalCompilerOptions: IncOptions,
+      outputJarContent: JarUtils.OutputJarContent,
       extra: List[(String, String)]
   ): CompileConfiguration = {
     val lookup = incrementalCompilerOptions.externalHooks().getExternalLookup
@@ -259,7 +261,8 @@ object MixedAnalyzingCompiler {
       reporter,
       skip,
       cache,
-      incrementalCompilerOptions
+      incrementalCompilerOptions,
+      outputJarContent
     )
   }
 
@@ -276,7 +279,8 @@ object MixedAnalyzingCompiler {
       reporter: Reporter,
       skip: Boolean,
       cache: GlobalsCache,
-      incrementalCompilerOptions: IncOptions
+      incrementalCompilerOptions: IncOptions,
+      outputJarContent: JarUtils.OutputJarContent
   ): CompileConfiguration = {
     new CompileConfiguration(
       sources,
@@ -290,7 +294,8 @@ object MixedAnalyzingCompiler {
       compiler,
       javac,
       cache,
-      incrementalCompilerOptions
+      incrementalCompilerOptions,
+      outputJarContent
     )
   }
 
@@ -338,7 +343,8 @@ object MixedAnalyzingCompiler {
         searchClasspath
       ),
       config,
-      log
+      log,
+      outputJarContent
     )
   }
 

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -103,7 +103,7 @@ final class MixedAnalyzingCompiler(
 
           STJ.getOutputJar(output) match {
             case Some(outputJar) =>
-              val outputDir = STJ.javacOutputTempDir(outputJar)
+              val outputDir = STJ.javacTempOutput(outputJar)
               IO.createDirectory(outputDir)
               javac.compile(javaSrcs,
                             joptions,
@@ -305,7 +305,7 @@ object MixedAnalyzingCompiler {
     // it will be compiled to a temporary directory (with deterministic name)
     // and then added to the final jar. This temporary directory has to be
     // available for Analyze to work phase to work.
-    val tempJavacOutput = STJ.getOutputJar(currentSetup.output).map(STJ.javacOutputTempDir).toSeq
+    val tempJavacOutput = STJ.getOutputJar(currentSetup.output).map(STJ.javacTempOutput).toSeq
     val absClasspath = classpath.map(_.getAbsoluteFile)
     val cArgs =
       new CompilerArguments(compiler.scalaInstance, compiler.classpathOptions)

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -70,10 +70,8 @@ final class MixedAnalyzingCompiler(
       if (scalaSrcs.nonEmpty) {
         JarUtils.withPreviousJar(output) { extraClasspath =>
           val sources = if (config.currentSetup.order == Mixed) incSrc else scalaSrcs
-          val arguments = cArgs(Nil,
-                                toAbsolute(extraClasspath) ++ absClasspath,
-                                None,
-                                config.currentSetup.options.scalacOptions)
+          val cp = toAbsolute(extraClasspath) ++ absClasspath
+          val arguments = cArgs(Nil, cp, None, config.currentSetup.options.scalacOptions)
           timed("Scala compilation", log) {
             config.compiler.compile(
               sources.toArray,

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -68,7 +68,7 @@ final class MixedAnalyzingCompiler(
     /** Compile Scala sources. */
     def compileScala(): Unit =
       if (scalaSrcs.nonEmpty) {
-        JarUtils.withPreviousJar(output) { extraClasspath =>
+        JarUtils.withPreviousJar(output, callback) { extraClasspath =>
           val sources = if (config.currentSetup.order == Mixed) incSrc else scalaSrcs
           val arguments = cArgs(Nil,
                                 toAbsolute(extraClasspath) ++ absClasspath,

--- a/zinc/src/main/scala/sbt/internal/inc/javac/AnalyzingJavaCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/javac/AnalyzingJavaCompiler.scala
@@ -46,12 +46,35 @@ final class AnalyzingJavaCompiler private[sbt] (
     val searchClasspath: Seq[File]
 ) extends JavaCompiler {
 
+  // for compatibility
+  def compile(
+      sources: Seq[File],
+      options: Seq[String],
+      output: Output,
+      callback: AnalysisCallback,
+      incToolOptions: IncToolOptions,
+      reporter: XReporter,
+      log: XLogger,
+      progressOpt: Option[CompileProgress]
+  ): Unit = {
+    compile(sources,
+            options,
+            output,
+            finalJarOutput = None,
+            callback,
+            incToolOptions,
+            reporter,
+            log,
+            progressOpt)
+  }
+
   /**
    * Compile some java code using the current configured compiler.
    *
    * @param sources  The sources to compile
    * @param options  The options for the Java compiler
    * @param output   The output configuration for this compiler
+   * @param finalJarOutput The output that will be used for straight to jar compilation.
    * @param callback  A callback to report discovered source/binary dependencies on.
    * @param incToolOptions The component that manages generated class files.
    * @param reporter  A reporter where semantic compiler failures can be reported.
@@ -63,6 +86,7 @@ final class AnalyzingJavaCompiler private[sbt] (
       sources: Seq[File],
       options: Seq[String],
       output: Output,
+      finalJarOutput: Option[File],
       callback: AnalysisCallback,
       incToolOptions: IncToolOptions,
       reporter: XReporter,
@@ -158,7 +182,7 @@ final class AnalyzingJavaCompiler private[sbt] (
       timed(javaAnalysisPhase, log) {
         for ((classesFinder, oldClasses, srcs) <- memo) {
           val newClasses = Set(classesFinder.get: _*) -- oldClasses
-          Analyze(newClasses.toSeq, srcs, log)(callback, loader, readAPI)
+          Analyze(newClasses.toSeq, srcs, log, output, finalJarOutput)(callback, loader, readAPI)
         }
       }
 

--- a/zinc/src/sbt-test/source-dependencies/anon-class-java-depends-on-scala/JJ.java
+++ b/zinc/src/sbt-test/source-dependencies/anon-class-java-depends-on-scala/JJ.java
@@ -1,11 +1,11 @@
 public class JJ {
-	public static void main(String[] args) {
-    // Declare anonymous class depending on Scala class
-		S s = new S() {
-      public void foo(String s) {
-        System.out.println(s);
-      }
-    };
-    s.foo("ahoy");
-	}
+    public static void main(String[] args) {
+        // Declare anonymous class depending on Scala class
+        S s = new S() {
+            public void foo(String s) {
+                System.out.println(s);
+            }
+        };
+        s.foo("ahoy");
+    }
 }

--- a/zinc/src/sbt-test/source-dependencies/default-arguments-separate-compilation/incOptions.properties
+++ b/zinc/src/sbt-test/source-dependencies/default-arguments-separate-compilation/incOptions.properties
@@ -1,2 +1,1 @@
-apiDebug = true
 relationsDebug = true

--- a/zinc/src/test/scala/sbt/inc/BaseCompilerSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/BaseCompilerSpec.scala
@@ -180,7 +180,8 @@ class BaseCompilerSpec extends BridgeProviderSpecification {
                              CompileOrder.Mixed,
                              cs,
                              setup,
-                             prev)
+                             prev,
+                             Optional.empty())
 
     def doCompile(newInputs: Inputs => Inputs = identity): CompileResult = {
       lastCompiledUnits = Set.empty

--- a/zinc/src/test/scala/sbt/inc/MultiProjectIncrementalSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/MultiProjectIncrementalSpec.scala
@@ -79,7 +79,8 @@ class MultiProjectIncrementalSpec extends BridgeProviderSpecification {
                                CompileOrder.Mixed,
                                cs,
                                setup,
-                               prev0)
+                               prev0,
+                               Optional.empty())
       // This registers `test.pkg.Ext1` as the class name on the binary stamp
       val result0 = compiler.compile(in, log)
       val contents = AnalysisContents.create(result0.analysis(), result0.setup())
@@ -100,7 +101,8 @@ class MultiProjectIncrementalSpec extends BridgeProviderSpecification {
                                 CompileOrder.Mixed,
                                 cs,
                                 setup,
-                                prev1)
+                                prev1,
+                                Optional.empty())
       // This registers `test.pkg.Ext2` as the class name on the binary stamp,
       // which means `test.pkg.Ext1` is no longer in the stamp.
       val result1 = compiler.compile(in1, log)
@@ -137,7 +139,8 @@ class MultiProjectIncrementalSpec extends BridgeProviderSpecification {
                                 CompileOrder.Mixed,
                                 cs,
                                 setup2,
-                                emptyPrev)
+                                emptyPrev,
+                                Optional.empty())
       val result2 = compiler.compile(in2, log)
       fileStore2.set(AnalysisContents.create(result2.analysis(), result2.setup()))
 
@@ -176,7 +179,8 @@ class MultiProjectIncrementalSpec extends BridgeProviderSpecification {
                                 CompileOrder.Mixed,
                                 cs,
                                 setup3,
-                                prev)
+                                prev,
+                                Optional.empty())
       val result3 = compiler.compile(in3, log)
       val a3 = result3.analysis match { case a: Analysis => a }
       fileStore.set(AnalysisContents.create(a3, result3.setup))

--- a/zinc/src/test/scala/sbt/inc/cached/CachedHashingSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/cached/CachedHashingSpec.scala
@@ -9,8 +9,9 @@ package sbt.inc.cached
 
 import java.nio.file.{ Path, Paths }
 import java.io.File
+
 import sbt.inc.{ BaseCompilerSpec, SourceFiles }
-import sbt.internal.inc.{ Analysis, CompileOutput, MixedAnalyzingCompiler }
+import sbt.internal.inc.{ CompileOutput, Analysis, MixedAnalyzingCompiler, JarUtils }
 import sbt.io.IO
 
 class CachedHashingSpec extends BaseCompilerSpec {
@@ -35,13 +36,14 @@ class CachedHashingSpec extends BaseCompilerSpec {
       val javac = compilers.javaTools.javac
       val scalac = compilers.scalac
       val giganticClasspath = file(sys.props("user.home"))./(".ivy2").**("*.jar").get.take(500)
+      val output = CompileOutput(options.classesDirectory)
 
       def genConfig = MixedAnalyzingCompiler.makeConfig(
         scalac,
         javac,
         options.sources,
         giganticClasspath,
-        CompileOutput(options.classesDirectory),
+        output,
         setup.cache,
         setup.progress.toOption,
         options.scalacOptions,
@@ -53,6 +55,7 @@ class CachedHashingSpec extends BaseCompilerSpec {
         options.order,
         setup.skip,
         setup.incrementalCompilerOptions,
+        JarUtils.createOutputJarContent(output),
         setup.extra.toList.map(_.toScalaTuple)
       )
 
@@ -77,13 +80,14 @@ class CachedHashingSpec extends BaseCompilerSpec {
       val javac = compilers.javaTools.javac
       val scalac = compilers.scalac
       val fakeLibraryJar = tempDir / "lib" / "foo.jar"
+      val output = CompileOutput(options.classesDirectory)
 
       def genConfig = MixedAnalyzingCompiler.makeConfig(
         scalac,
         javac,
         options.sources,
         List(fakeLibraryJar),
-        CompileOutput(options.classesDirectory),
+        output,
         setup.cache,
         setup.progress.toOption,
         options.scalacOptions,
@@ -95,6 +99,7 @@ class CachedHashingSpec extends BaseCompilerSpec {
         options.order,
         setup.skip,
         setup.incrementalCompilerOptions,
+        JarUtils.createOutputJarContent(output),
         setup.extra.toList.map(_.toScalaTuple)
       )
 


### PR DESCRIPTION
This PR represents my work on implementing straight to jar compilation in zinc (https://github.com/sbt/zinc/issues/305).

To enable the feature, one should specify output as .jar file. This will cause scalac to write files to jar directly. This worked before the PR, but obviously some stuff had to be adjusted for the actual incremental compilation to work.

# Most important things that had to be handled
 - pruning - deleting files from jar instead of from a folder
 - merging - if we have a previous output jar it has to be merged with the one produced in next compilation
 - javac output - javac is not able to compile to jar, I am zipping the output and merging it with scalac output
 - representing jared products - I used sytanx like: `/develop/zinc/target/output.jar!sbt/internal/inc/Compile.class`
 - code that relies on classes being plain files - had to be ifed to work with jars as well

Most of the details related to the feature are in `sbt.internal.inc.STJ` object and something similar in `xsbt.STJ` as it is difficult to share code between those.

# Optimizations
ZipFileSystem was not good enough as it was rewriting jars. What I done is I took that code and kept only the code that allows to manipulate the index. Reading and writing the index to file from ZipFileSystem was most efficient implementation I could find. On top of that I implemented the required operations in performant manner.
 - merging: The jars are concated except for the index. Then the indices are read from both files, merged and written the new index at the end.
 - deleting: Files are only removed from the index.
 - transactional class file manager: The index is stored at the beginning of compilation. In case of a failure, The old index is written back to the jar,
 - reading stamps: The whole index is read once and timestamps are cached.

# Other changes
API of `ReadStamps` was altered - I added `reset()` method to easly allow reseting cache of product timestamps between compilations. This is because I made the stamper stateful to avoid reopening jar for each product (that would kill the performance).

Scripted tests were updated to run for both STJ and regular compilation. Running scripted with STJ requires changing a hardcoded flag in `IncHandler`. I was just using it for development. I am open for discussion on how to do it properly and whether we should e.g. run all scripted tests twice for each build and how to implement that.

Slight addition was to allow disabling compression with a flag when exporting analysis (performance).

Another small addition is to ignore change of `-d` option for javac as it is overriden anyway.

This PR also contains multiple changes related to Windows file system. Mostly about closing things properly to avoid locks (mostly jars). This includes fixing scripted tests on Windows (large percentage of them were failing because of inability to clear the temp dir between tests). There are still a couple of them that are flaky, but I didn't investigate it further.

---

```
THIS PROGRAM IS SUBJECT TO THE TERMS OF THE BSD 3-CLAUSE LICENSE.

THE FOLLOWING DISCLAIMER APPLIES TO ALL SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE:
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR
ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
ONLY THE SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE, IF ANY, THAT ARE ATTACHED TO (OR OTHERWISE ACCOMPANY) THIS SUBMISSION (AND ORDINARY
COURSE CONTRIBUTIONS OF FUTURES PATCHES THERETO) ARE TO BE CONSIDERED A CONTRIBUTION. NO OTHER SOFTWARE CODE OR MATERIALS ARE A CONTRIBUTION.
```