### PR TITLE
Update IO.classfileLocation usage

### DIFF
--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
@@ -204,7 +204,7 @@ object ClassToAPI {
 
   /** TODO: over time, ClassToAPI should switch the majority of access to the classfile parser */
   private[this] def classFileForClass(c: Class[_]): ClassFile =
-    classfile.Parser.apply(IO.classfileLocation(c))
+    classfile.Parser.apply(c)
 
   @inline private[this] def lzyS[T <: AnyRef](t: T): xsbti.api.Lazy[T] = SafeLazyProxy.strict(t)
   @inline final def lzy[T <: AnyRef](t: => T): xsbti.api.Lazy[T] = SafeLazyProxy(t)

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Parser.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Parser.scala
@@ -23,6 +23,15 @@ import sbt.io.Using
 import Constants._
 
 private[sbt] object Parser {
+  def apply(clazz: Class[_]): ClassFile = {
+    val name = clazz.getName.replace('.', '/') + ".class"
+    val url = sbt.io.IO.classfileLocation(clazz)
+    val isJar = url.getProtocol == "jar"
+    val sanitized =
+      new URL(if (isJar) "jar" else "file", "", s"${url.getFile}${if (isJar) "!" else ""}/$name")
+    apply(sanitized)
+  }
+
   def apply(file: File): ClassFile =
     Using.fileInputStream(file)(parse(file.toString)).right.get
 

--- a/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/ParserSpecification.scala
+++ b/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/ParserSpecification.scala
@@ -7,8 +7,8 @@ import org.scalacheck._
 import Prop._
 
 object ParserSpecification extends Properties("Parser") {
-  property("able to parse all relevant classes") = Prop.forAll(classes) { (c: Class[_]) =>
-    Parser(sbt.io.IO.classfileLocation(c)) ne null
+  property("able to parse all relevant classes") = Prop.forAll(classes) { c =>
+    Parser(c) ne null
   }
 
   implicit def classes: Gen[Class[_]] =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val scala212 = "2.12.6"
   val scala213 = "2.13.0-M2"
 
-  private val ioVersion = "1.2.0"
+  private val ioVersion = "1.2.2-SNAPSHOT"
   private val utilVersion = "1.2.1"
   private val lmVersion = "1.2.0"
 


### PR DESCRIPTION
I was having trouble getting sbt tests to pass with the new version of
io. I determined that the big issue is that value returned by
IO.classfileLocation was different from what was previously expected.
Zinc specifically relied on the IO.classfileLocation returning a full
path name. In the case of a jar, this meant a jar url with a
"!/$CLASSNAME" at the end. In the case of a file in a directory, it was
a file url that ended with $CLASSNAME. After io/185, the
IO.classfileLocation would generally return the class file directory for
a particular class, but not the full absolute path to the class.

In the io project, I updated IO.classfileLocation to always return a url
to just the jar file or the base directory. It is then up to the caller
to append the classname. If I made IO.classfileLocation return the
absolute path of the class path, that broke other tests in sbt that
assumed it returned the base directory for the class.

Linked to 
https://github.com/sbt/io/pull/188