### PR TITLE
Use javax.tools.ToolProvider.getSystemDocumentationTool

### DIFF
--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavaCompiler.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavaCompiler.scala
@@ -114,8 +114,6 @@ object Javadoc {
 
   /** Returns a local compiler, if the current runtime supports it. */
   def local: Option[XJavadoc] = {
-    // TODO - javax doc tool not supported in JDK6
-    //Option(javax.tools.ToolProvider.getSystemDocumentationTool)
     if (LocalJava.hasLocalJavadoc) Some(new LocalJavadoc)
     else None
   }


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/4350
This was contributed by @xuwei-k.

Basically removes the wacky Java 6 hack that sbt 0.13 used, since we support JDK8 and up, a necessary step for JDK11 compat.
