### PR TITLE
Remove false error message (compile-to-jar)

### DIFF
--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Analyze.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Analyze.scala
@@ -214,9 +214,7 @@ private[sbt] object Analyze {
   ): File = {
     IO.relativize(outputDir, realClassFile) match {
       case Some(relativeClass) => JarUtils.ClassInJar(outputJar, relativeClass).toFile
-      case None =>
-        log.error(s"Class file $realClassFile is not relative to $outputDir")
-        realClassFile
+      case None => realClassFile
     }
   }
 


### PR DESCRIPTION
The error here is not an error actually. If the classFile is not relative to output it just most likely means it is an external jar or something. It should be returned as is and will be handled elsewhere to be recognized as external dependency. Notice that for non compile-to-jar flow there is no such check.

It turned out that this innocent error message can cause some serious problems. As we report error here, when building from intellij using this version of zinc it will be recognized as compilation error and the building will fail.