### PR TITLE
[1.2.x] ignore non-matching extra hash for classes

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalNameHashing.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalNameHashing.scala
@@ -47,6 +47,10 @@ private final class IncrementalNameHashing(log: sbt.util.Logger, options: IncOpt
         } else {
           // if the extra hash does not match up, but the API is "same" we can ignore it.
           // see also https://github.com/sbt/sbt/issues/4441
+          debug(s"""different extra api hashes for non-traits:
+               |  `${a.name}`: ${a.extraHash()}
+               |  `${b.name}`: ${b.extraHash()}
+             """.stripMargin)
           None
         }
       }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalNameHashing.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalNameHashing.scala
@@ -45,13 +45,9 @@ private final class IncrementalNameHashing(log: sbt.util.Logger, options: IncOpt
         if (isATrait && isBTrait) {
           Some(TraitPrivateMembersModified(className))
         } else {
-          // As we don't cover more cases here, we protect ourselves from a potential programming error
-          sys.error(
-            s"""A fatal error happened in `SameAPI`: different extra api hashes for no traits!
-               |  `${a.name}`: ${a.extraHash()}
-               |  `${b.name}`: ${b.extraHash()}
-             """.stripMargin
-          )
+          // if the extra hash does not match up, but the API is "same" we can ignore it.
+          // see also https://github.com/sbt/sbt/issues/4441
+          None
         }
       }
     } else {


### PR DESCRIPTION
This is a backport of https://github.com/sbt/zinc/pull/617
Fixes sbt/sbt#4441
