### PR TITLE
Throw when javadoc generation fails

### DIFF
--- a/internal/zinc-compile-core/src/test/resources/sbt/internal/inc/javac/bad.java
+++ b/internal/zinc-compile-core/src/test/resources/sbt/internal/inc/javac/bad.java
@@ -1,0 +1,4 @@
+// Interfaces must be public, so this is invalid:
+private interface Foo {
+
+}

--- a/zinc-compile/src/main/scala/sbt/inc/Doc.scala
+++ b/zinc-compile/src/main/scala/sbt/inc/Doc.scala
@@ -55,14 +55,15 @@ object Doc {
                   incToolOptions: IncToolOptions,
                   log: Logger,
                   reporter: Reporter): Unit = {
-            doc.javadoc.run(
+            val success = doc.javadoc.run(
               (sources filter javaSourcesOnly).toArray,
               JavaCompilerArguments(sources, classpath, Some(outputDirectory), options).toArray,
               incToolOptions,
               reporter,
               log
             )
-            ()
+            if (success) ()
+            else throw new JavadocGenerationFailed()
           }
         }
       )
@@ -120,7 +121,13 @@ object Doc {
     }
   private[sbt] val javaSourcesOnly: File => Boolean = _.getName.endsWith(".java")
 
+  class JavadocGenerationFailed extends Exception
+
   trait JavaDoc {
+
+    /**
+     * @throws JavadocGenerationFailed when generating javadoc fails
+     */
     def run(sources: List[File],
             classpath: List[File],
             outputDirectory: File,

--- a/zinc-compile/src/test/scala/inc/DocSpec.scala
+++ b/zinc-compile/src/test/scala/inc/DocSpec.scala
@@ -3,6 +3,7 @@ package inc
 
 import java.io.File
 
+import sbt.inc.Doc.JavadocGenerationFailed
 import sbt.io.IO
 import sbt.internal.inc.javac.{ JavaCompiler, JavaTools, Javadoc }
 import sbt.internal.inc.javac.JavaCompilerSpec
@@ -42,6 +43,22 @@ class DocSpec extends UnitSpec {
       }
     }
   }
+  it should "throw when generating javadoc fails" in {
+    assertThrows[JavadocGenerationFailed] {
+      IO.withTemporaryDirectory { cacheDir =>
+        IO.withTemporaryDirectory { out =>
+          val javadoc = Doc.cachedJavadoc("Foo", CacheStoreFactory(cacheDir), local)
+          javadoc.run(List(knownSampleBadFile),
+                      Nil,
+                      out,
+                      Nil,
+                      IncToolOptionsUtil.defaultIncToolOptions(),
+                      log,
+                      reporter)
+        }
+      }
+    }
+  }
 
   def local =
     JavaTools(
@@ -51,4 +68,6 @@ class DocSpec extends UnitSpec {
   lazy val reporter = new ManagedLoggedReporter(10, log)
   def knownSampleGoodFile =
     new File(classOf[JavaCompilerSpec].getResource("good.java").toURI)
+  def knownSampleBadFile =
+    new File(classOf[JavaCompilerSpec].getResource("bad.java").toURI)
 }


### PR DESCRIPTION
As discussed in #414. Unfortunately I haven't been able to run the tests,
as 'sbt clean publishBridges' already fails for me.