### PR TITLE
Allow disabling compression when saving analysis

### DIFF
--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/FileAnalysisStore.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/FileAnalysisStore.scala
@@ -11,7 +11,7 @@ package inc
 
 import java.io._
 import java.util.Optional
-import java.util.zip.{ ZipEntry, ZipInputStream }
+import java.util.zip.{ ZipOutputStream, ZipEntry, Deflater, ZipInputStream }
 
 import com.google.protobuf.{ CodedInputStream, CodedOutputStream }
 import sbt.internal.inc.binary.BinaryAnalysisFormat
@@ -45,6 +45,7 @@ object FileAnalysisStore {
 
     private final val format = new BinaryAnalysisFormat(readWriteMappers)
     private final val TmpEnding = ".tmp"
+    private final val useCompression = sys.props.get("zinc.binary-file-store.use-compression").fold(true)(_ == "true")
 
     /**
      * Get `CompileAnalysis` and `MiniSetup` instances for current `Analysis`.
@@ -82,6 +83,10 @@ object FileAnalysisStore {
 
       val outputStream = new FileOutputStream(tmpAnalysisFile)
       Using.zipOutputStream(outputStream) { outputStream =>
+        if (!useCompression) {
+          outputStream.setMethod(ZipOutputStream.DEFLATED)
+          outputStream.setLevel(Deflater.NO_COMPRESSION)
+        }
         val protobufWriter = CodedOutputStream.newInstance(outputStream)
         outputStream.putNextEntry(new ZipEntry(analysisFileName))
         format.write(protobufWriter, analysis, setup)


### PR DESCRIPTION
This is a thing that was on my compile-to-jar PR but we decided to leave for later, so here it is.
This adds an option to disable zip compression while storing analysis. It allows to save some time when storing the analysis if the space is not big of a concern. 
It is implemented through system property. Makes it easy to enable globally and does not require changing the API, but I am open for suggestions how to do it better.