### PR TITLE
Handle compile to jar switch

### DIFF
--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/JarUtils.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/JarUtils.scala
@@ -102,7 +102,7 @@ object JarUtils {
    * that changes between compilation runs (incremental compilation cycles).
    * Caching may hide those changes and lead into incorrect results.
    */
-  val scalacOptions = Set("-YdisableFlatCpCaching")
+  val scalacOptions: Set[ClassFilePath] = Set("-YdisableFlatCpCaching")
 
   /**
    * Options that have to be specified when running javac in order
@@ -111,7 +111,7 @@ object JarUtils {
    * -XDuseOptimizedZip=false holds jars open that causes problems
    * with locks on Windows.
    */
-  val javacOptions = Set("-XDuseOptimizedZip=false")
+  val javacOptions: Set[ClassFilePath] = Set("-XDuseOptimizedZip=false")
 
   /** Reads current index of a jar file to allow restoring it later with `unstashIndex` */
   def stashIndex(jar: File): IndexBasedZipFsOps.CentralDir = {


### PR DESCRIPTION
I added a small check. If previously we were compiling to class files, the analysis with previous products will contain plain files. If current compilation is to jar (compile-to-jar was just enabled), it will try to do incremental compilation based on plain class files, which does not make sense. Most of the code in zinc assumes that if compile to jar is enabled for current compilation it was enabled for the previous one, which is convenient. So I added this simple check in the beginning - if a product of previous compilation was not a class in jar, compilation starts with empty analysis.