### PR TITLE
Specify a location in "Done compiling" messages

### DIFF
--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -137,8 +137,10 @@ final class MixedAnalyzingCompiler(
       compileScala(); compileJava()
     }
 
-    if (javaSrcs.size + scalaSrcs.size > 0)
-      log.info("Done compiling.")
+    if (javaSrcs.size + scalaSrcs.size > 0) {
+      val targets = outputDirs.map(_.getAbsolutePath).mkString(",")
+      log.info(s"Done compiling to $targets .")
+    }
   }
 
   private def putJavacOutputInJar(outputJar: File, outputDir: File): Unit = {


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/3939, which was closed without comment a while back.

In a multi-module build, the "Done compiling" messages can feel spammy and uninformative - this change makes them correspond to the "Compiling..." message that's printed out when compilation starts.
