### PR TITLE
CompilerArguments: remove Dotty special-case

### DIFF
--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala
@@ -121,7 +121,7 @@ final class CompilerArguments(
       (IO.parseClasspath(System.getProperty(k, "")) * "*.jar").get)
 
   private[this] def include(flag: Boolean, jars: File*) =
-    if (flag || ScalaInstance.isDotty(scalaInstance.version)) jars
+    if (flag) jars
     else Nil
 
   private[this] def abs(files: Seq[File]) =


### PR DESCRIPTION
This was always a hack and isn't needed as of sbt-dotty 0.3.0
(https://github.com/lampepfl/dotty/pull/5835).