### PR TITLE
Fix c.getCanonicalName to be JDK 11 and JLS compliant

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -648,7 +648,8 @@ lazy val zincApiInfoTemplate = (project in internalPath / "zinc-apiinfo")
          exclude[DirectMissingMethodProblem]("xsbt.api.HashAPI.hashStructure0"),
          exclude[DirectMissingMethodProblem]("xsbt.api.HashAPI.hashStructure"),
          exclude[DirectMissingMethodProblem]("xsbt.api.HashAPI.hashDefinitions"),
-         exclude[DirectMissingMethodProblem]("xsbt.api.HashAPI.this")
+         exclude[DirectMissingMethodProblem]("xsbt.api.HashAPI.this"),
+         exclude[DirectMissingMethodProblem]("sbt.internal.inc.ClassToAPI.handleMalformedNameOf*"),
       )
     }
   )

--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
@@ -74,48 +74,42 @@ object ClassToAPI {
                  new mutable.HashSet)
 
   /**
-   * The binary name encoding for Scala has been broken for a while. It does not
-   * follow the Java source name rules because it does not append a `$` after the
-   * mirror class of an object, which already ends in `$`.
+   * Returns the canonical name given a class based on https://docs.oracle.com/javase/specs/jls/se11/html/jls-6.html#jls-6.7
    *
-   * Zinc works around this fix in the only way it can: it gets the enclosing class,
-   * which is obtained from the `InnerClasses` java classfile metadata, and it
-   * reconstructs the path from there. It circumvents, by design, the core issue:
-   * it doesn't call Java's name parser at all.
+   * 1. A named package returns its package name.
+   * 2A. A top-level class returns package name + "." + simple name.
+   * 2B. A top-level Scala object returns object's name + "$".
+   * 3A. Nested class M of a class C returns C's canonical name + "." + M's simple name.
+   * 3B. Nested class M of a top-level Scala object O returns O's name + "." + M's simple name.
+   * 3C. Nested class M of a non-top-level Scala object O returns's O's canonical name + "." + M's simple name.
    *
-   * This issue has been fixed in the JDK9, but unfortunately it's going to be tormenting
-   * us for a while because 2.13 does not target Java 9, and we're still at 2.12.x.
-   *
-   * <a href="http://bugs.java.com/bugdatabase/view_bug.do?bug_id=8057919">This is the fix in Java 9.</a>
-   *
-   * In order to fully fix this issue, the Scala compiler should do the desired behaviour
-   * in 2.13.x. 2.12.x is already lost since this fix is binary incompatible. The appropriate
-   * issue is here: https://github.com/scala/bug/issues/2034.
-   *
+   * For example OOO (object in object in object) returns `p1.O1.O2$.O3$`.
    * @return The canonical name if not null, the blank string otherwise.
    */
-  def handleMalformedNameOf(c: Class[_], isRecursive: Boolean = false): String = {
-    if (c == null) "" // Return nothing if it hits the top-level class
-    else {
-      val className = c.getName
-      // Adds a `dollar` if it's a recursive call, else nothing
-      val atEnd: String = if (isRecursive) "$" else ""
-      try {
-        val canonicalName = c.getCanonicalName
-        if (canonicalName == null) className
-        else canonicalName + atEnd
-      } catch {
-        case malformedError: java.lang.InternalError
-            if malformedError.getMessage.contains("Malformed class name") =>
-          val enclosingClass = c.getEnclosingClass
-          val enclosingName = enclosingClass.getName
-          val restOfName = c.getName.stripPrefix(enclosingName)
-          handleMalformedNameOf(enclosingClass, true) + restOfName + atEnd
+  def classCanonicalName(c: Class[_]): String = {
+    def handleMalformedNameOf(c: Class[_]): String = {
+      if (c == null) "" // Return nothing if it hits the top-level class
+      else {
+        val className = c.getName
+        try {
+          val canonicalName = c.getCanonicalName
+          if (canonicalName == null) className
+          else canonicalName
+        } catch {
+          case malformedError: java.lang.InternalError
+              if malformedError.getMessage.contains("Malformed class name") =>
+            val enclosingClass = c.getEnclosingClass
+            val enclosingName = enclosingClass.getName
+            val restOfName = c.getName.stripPrefix(enclosingName)
+            // https://docs.oracle.com/javase/specs/jls/se11/html/jls-6.html#jls-6.7
+            // A member class or member interface M declared in another class or interface C has a canonical name if and only if C has a canonical name.
+            // In that case, the canonical name of M consists of the canonical name of C, followed by ".", followed by the simple name of M.
+            handleMalformedNameOf(enclosingClass) + "." + restOfName
+        }
       }
     }
+    handleMalformedNameOf(c)
   }
-
-  def classCanonicalName(c: Class[_]): String = handleMalformedNameOf(c)
 
   def toDefinitions(cmap: ClassMap)(c: Class[_]): Seq[api.ClassLikeDef] =
     cmap.memo.getOrElseUpdate(classCanonicalName(c), toDefinitions0(c, cmap))


### PR DESCRIPTION
Fixes #567

On JDK 8, given

```
package p1
object O1 {
  object O2 {
    object O3 {
    }
  }
}
```

`p1.O1.O2.O3.getClass.getCanonicalName` fails with java.lang.InternalError: Malformed class name. #374 adds a workaround for this by connecting enclosing class's canonical name + member simple name with `$`.

Now that https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8057919 is fixed, on JDK 11 `p1.O1.O2.O3.getClass.getCanonicalName` succeeds with `p1.O1.O2$.O3$`. This makes sense because Java Language Specification [6.7](https://docs.oracle.com/javase/specs/jls/se11/html/jls-6.html#jls-6.7) says:

> A member class or member interface M declared in another class or interface C has a canonical name if and only if C has a canonical name.
> In that case, the canonical name of M consists of the canonical name of C, followed by `"."`, followed by the simple name of M.

This fixes the implementation to follow JLS by changing `$` to `.`.

Ref #540