### PR TITLE
Add missing mapping of MiniSetup

### DIFF
--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/binary/converters/ProtobufReaders.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/binary/converters/ProtobufReaders.scala
@@ -227,7 +227,8 @@ final class ProtobufReaders(mapper: ReadMapper, currentVersion: schema.Version) 
     val compileOrder = fromCompileOrder(miniSetup.compileOrder)
     val storeApis = miniSetup.storeApis
     val extra = miniSetup.extra.map(fromStringTuple).toArray
-    MiniSetup.of(output, miniOptions, compilerVersion, compileOrder, storeApis, extra)
+    val original = MiniSetup.of(output, miniOptions, compilerVersion, compileOrder, storeApis, extra)
+    mapper.mapMiniSetup(original)
   }
 
   implicit class EfficientTraverse[T](seq: Seq[T]) {


### PR DESCRIPTION
The call to `mapMiniSetup` is missing in `ProtobufReaders`.