### PR TITLE
Call Global.close when finished compiling

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
@@ -246,6 +246,10 @@ sealed class ZincCompiler(settings: Settings, dreporter: DelegatingReporter, out
     callback0 = null
     superDropRun()
     reporter = null
+    this match {
+      case c: java.io.Closeable => c.close()
+      case _                    =>
+    }
   }
 
   // Scala 2.10.x and later

--- a/internal/compiler-bridge/src/main/scala/xsbt/CompilerInterface.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CompilerInterface.scala
@@ -54,7 +54,8 @@ private final class WeakLog(private[this] var log: Logger, private[this] var del
 
 private final class CachedCompiler0(args: Array[String], output: Output, initialLog: WeakLog)
     extends CachedCompiler
-    with CachedCompilerCompat {
+    with CachedCompilerCompat
+    with java.io.Closeable {
 
   /////////////////////////////////////////////////////////////////////////////////////////////////
   //////////////////////////////////// INITIALIZATION CODE ////////////////////////////////////////
@@ -84,6 +85,13 @@ private final class CachedCompiler0(args: Array[String], output: Output, initial
   val compiler: ZincCompiler = newCompiler(command.settings, dreporter, output)
 
   /////////////////////////////////////////////////////////////////////////////////////////////////
+
+  def close(): Unit = {
+    compiler match {
+      case c: java.io.Closeable => c.close()
+      case _                    =>
+    }
+  }
 
   def noErrors(dreporter: DelegatingReporter) = !dreporter.hasErrors && command.ok
 

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala
@@ -86,8 +86,15 @@ final class AnalyzingCompiler(
       progressOpt: Optional[CompileProgress]
   ): Unit = {
     val cached = cache(options, output, !changes.isEmpty, this, log, reporter)
-    val progress = if (progressOpt.isPresent) progressOpt.get else IgnoreProgress
-    compile(sources, changes, callback, log, reporter, progress, cached)
+    try {
+      val progress = if (progressOpt.isPresent) progressOpt.get else IgnoreProgress
+      compile(sources, changes, callback, log, reporter, progress, cached)
+    } finally {
+      cached match {
+        case c: java.io.Closeable => c.close()
+        case _                    =>
+      }
+    }
   }
 
   def compile(


### PR DESCRIPTION
This will close file handles to JARs within recent versions
of Scalac.

References https://github.com/scala/scala/pull/7366