### PR TITLE
Fix #459: Upgrade protobuf to 3.7.0 to get rid of Java 9+ warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,7 +78,9 @@ def commonSettings: Seq[Setting[_]] = Seq(
   scalacOptions ++= Seq(
     "-YdisableFlatCpCaching",
     "-target:jvm-1.8",
-  )
+  ),
+  // Override the version that scalapb depends on
+  dependencyOverrides += "com.google.protobuf" % "protobuf-java" % "3.7.0"
 )
 
 def compilerVersionDependentScalacOptions: Seq[Setting[_]] = Seq(


### PR DESCRIPTION
I have no idea if this is binary-compatible so fingers crossed.