### PR TITLE
Hide "Done compiling" messages if super shell is enabled

### DIFF
--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -22,6 +22,7 @@ import sbt.internal.inc.JavaInterfaceUtil.EnrichOption
 import sbt.internal.inc.caching.ClasspathCache
 import sbt.internal.inc.javac.AnalyzingJavaCompiler
 import xsbti.compile.{ ClassFileManager => XClassFileManager }
+import sbt.internal.util.ConsoleAppender
 
 /** An instance of an analyzing compiler that can run both javac + scalac. */
 final class MixedAnalyzingCompiler(
@@ -137,8 +138,10 @@ final class MixedAnalyzingCompiler(
       compileScala(); compileJava()
     }
 
-    if (javaSrcs.size + scalaSrcs.size > 0)
-      log.info("Done compiling.")
+    if (javaSrcs.size + scalaSrcs.size > 0) {
+      if (ConsoleAppender.showProgress) log.debug("Done compiling.")
+      else log.info("Done compiling.")
+    }
   }
 
   private def putJavacOutputInJar(outputJar: File, outputDir: File): Unit = {


### PR DESCRIPTION
Fixes sbt/sbt#3939
Ref #635

Super shell will be enabled in sbt, but it's an opt-in for Zinc, so this won't have any effect if you're using Zinc as a library.