### PR TITLE
Remove illegal reflective acces warnings in sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,8 +79,10 @@ def commonSettings: Seq[Setting[_]] = Seq(
     "-YdisableFlatCpCaching",
     "-target:jvm-1.8",
   ),
-  // Override the version that scalapb depends on
-  dependencyOverrides += "com.google.protobuf" % "protobuf-java" % "3.7.0"
+  // Override the version that scalapb depends on. This adds an explicit dependency on
+  // protobuf-java. This will cause sbt to evict the older version that is used by
+  // scalapb-runtime.
+  libraryDependencies += "com.google.protobuf" % "protobuf-java" % "3.7.0"
 )
 
 def compilerVersionDependentScalacOptions: Seq[Setting[_]] = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,7 @@ addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.4.1")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.3")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "3.0.2")
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.12-rc5")
-libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin" % "0.6.0"
+libraryDependencies += // Remember to remove the explicit dependency on java-protobuf:3.7.0 when updating this dependency
+  "com.trueaccord.scalapb" %% "compilerplugin" % "0.6.0"
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.13")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")


### PR DESCRIPTION
Ref #459

Setting the dependencyOverrides  key is enough to prevent the illegal
reflective access warnings in the zinc build, but they still persist in
any program that depends on zinc-core or zinc-persist because those
modules still have a dependency on scalapb-runtime which has a
transitive dependency on the older protobuf-java version that prints
these warnings.

This should be reverted as soon as a new version of scalapb-runtime is
published with the updated dependency.