### PR TITLE
Map mini setup on write

### DIFF
--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/binary/converters/ProtobufWriters.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/binary/converters/ProtobufWriters.scala
@@ -229,7 +229,8 @@ final class ProtobufWriters(mapper: WriteMapper) {
     }
   }
 
-  def toMiniSetup(miniSetup: MiniSetup): schema.MiniSetup = {
+  def toMiniSetup(miniSetup0: MiniSetup): schema.MiniSetup = {
+    val miniSetup = mapper.mapMiniSetup(miniSetup0)
     val output = toMiniSetupOutput(miniSetup.output())
     val miniOptions = Some(toMiniOptions(miniSetup.options()))
     val compilerVersion = miniSetup.compilerVersion()


### PR DESCRIPTION
I recently createda  PR to map MiniSetup on read with protobuf, it turns out the call on write was missing as well...