### PR TITLE
Avoid rewriting zip index when there is nothing to remove

### DIFF
--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/IndexBasedZipOps.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/IndexBasedZipOps.scala
@@ -140,10 +140,12 @@ abstract class IndexBasedZipOps extends CreateZip {
   }
 
   private def removeEntries(path: Path, toRemove: Set[String]): Unit = {
-    val centralDir = readCentralDir(path)
-    removeEntriesFromCentralDir(centralDir, toRemove)
-    val writeOffset = truncateCentralDir(centralDir, path)
-    finalizeZip(centralDir, path, writeOffset)
+    if (toRemove.nonEmpty) {
+      val centralDir = readCentralDir(path)
+      removeEntriesFromCentralDir(centralDir, toRemove)
+      val writeOffset = truncateCentralDir(centralDir, path)
+      finalizeZip(centralDir, path, writeOffset)
+    }
   }
 
   private def removeEntriesFromCentralDir(centralDir: CentralDir, toRemove: Set[String]): Unit = {


### PR DESCRIPTION
A small optimization, as the method may be called with empty list, there is no need to do any IO then.