### PR TITLE
Make Zinc work with Metals

### DIFF
--- a/project/bloop-plugins.sbt
+++ b/project/bloop-plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.2.5")


### PR DESCRIPTION
1. Disables project generation for bridge templates.
</s>2. Fixes a formatting change that happens when using latest scalafmt.</s>

A side-effect of disabling project generation for bridge templates is that the
bloop plugin must be added to the build.
  
EDIT: The formatting change was due to a wrong rebase on top of latest develop branch.