### PR TITLE
Workaround for 'symbol is missing from the classpath' error

### DIFF
--- a/zinc/src/sbt-test/source-dependencies/no-type-annotation/Before.scala
+++ b/zinc/src/sbt-test/source-dependencies/no-type-annotation/Before.scala
@@ -1,0 +1,1 @@
+class Before

--- a/zinc/src/sbt-test/source-dependencies/no-type-annotation/Problem.scala
+++ b/zinc/src/sbt-test/source-dependencies/no-type-annotation/Problem.scala
@@ -1,0 +1,3 @@
+class Problem(wrapper: Wrapper) {
+  def x = wrapper.x
+}

--- a/zinc/src/sbt-test/source-dependencies/no-type-annotation/ProblemUser.scala
+++ b/zinc/src/sbt-test/source-dependencies/no-type-annotation/ProblemUser.scala
@@ -1,0 +1,7 @@
+class ProblemUser {
+  val y: Seq[Before] = ???
+
+  private def method(p: Problem): Unit = {
+    println(p.x)
+  }
+}

--- a/zinc/src/sbt-test/source-dependencies/no-type-annotation/Wrapper.scala
+++ b/zinc/src/sbt-test/source-dependencies/no-type-annotation/Wrapper.scala
@@ -1,0 +1,3 @@
+class Wrapper {
+  def x: Before = new Before
+}

--- a/zinc/src/sbt-test/source-dependencies/no-type-annotation/changes/Before.scala
+++ b/zinc/src/sbt-test/source-dependencies/no-type-annotation/changes/Before.scala
@@ -1,0 +1,1 @@
+class After

--- a/zinc/src/sbt-test/source-dependencies/no-type-annotation/changes/ProblemUser.scala
+++ b/zinc/src/sbt-test/source-dependencies/no-type-annotation/changes/ProblemUser.scala
@@ -1,0 +1,7 @@
+class ProblemUser {
+  val y: Seq[After] = ???
+
+  private def method(p: Problem): Unit = {
+    println(p.x)
+  }
+}

--- a/zinc/src/sbt-test/source-dependencies/no-type-annotation/changes/Wrapper.scala
+++ b/zinc/src/sbt-test/source-dependencies/no-type-annotation/changes/Wrapper.scala
@@ -1,0 +1,3 @@
+class Wrapper {
+  def x: After = new After
+}

--- a/zinc/src/sbt-test/source-dependencies/no-type-annotation/test
+++ b/zinc/src/sbt-test/source-dependencies/no-type-annotation/test
@@ -1,0 +1,7 @@
+> compile
+
+$ copy-file changes/Before.scala Before.scala
+$ copy-file changes/ProblemUser.scala ProblemUser.scala
+$ copy-file changes/Wrapper.scala Wrapper.scala
+
+> compile


### PR DESCRIPTION
We faced an odd problem while renaming a type. In case of the test it is Before -> After. The problem is in `Problem` class. It is not selected during initial invalidation, but without that happening the 3 other classes won't compile at all which will prevent zinc from building the Problem class in the next cycle. Without ProblemUser class it would work properly.
It seems like there is no reasonable way to detect that `Problem` needs to be recompiled without running the compilation (or usually including too many sources to recompile).



The workaround is to just detect this specific compile error:
```
[error] /tmp/sbt_dbac1806/ProblemUser.scala:5:13: Symbol 'type <empty>.Before' is missing from the classpath.
[error] This symbol is required by 'method Problem.x'.
[error] Make sure that type Before is in your classpath and check for conflicting dependencies with `-Ylog-classpath`.
[error] A full rebuild may help if 'Problem.class' was compiled against an incompatible version of <empty>.
[error]     println(p.x)
[error]             ^
```
and if it happens invalidate all sources. I can see how hacky it is, so if you have any suggestions to improve that... 
I also know that we don't need to invalidate all sources, but we could just use the analysis and parse the error to figure out what is actually relevant but I rather went with a simple solution and as the error is quite rare it shouldn't be a distaster to recompile the whole module when this happens.