### PR TITLE
Break the dependency on LM, and thus Ivy

### DIFF
--- a/internal/zinc-ivy-integration/src/main/scala/sbt/internal/inc/ZincLmUtil.scala
+++ b/internal/zinc-ivy-integration/src/main/scala/sbt/internal/inc/ZincLmUtil.scala
@@ -1,0 +1,49 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright 2011 - 2017, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * This software is released under the terms written in LICENSE.
+ */
+
+package sbt.internal.inc
+
+import java.io.File
+import java.net.URLClassLoader
+
+import sbt.librarymanagement.{ DependencyResolution, ModuleID }
+import sbt.internal.inc.classpath.ClassLoaderCache
+import xsbti._
+import xsbti.compile._
+
+object ZincLmUtil {
+  import xsbti.compile.ScalaInstance
+
+  /**
+   * Instantiate a Scala compiler that is instrumented to analyze dependencies.
+   * This Scala compiler is useful to create your own instance of incremental
+   * compilation.
+   */
+  def scalaCompiler(
+      scalaInstance: ScalaInstance,
+      classpathOptions: ClasspathOptions,
+      globalLock: GlobalLock,
+      componentProvider: ComponentProvider,
+      secondaryCacheDir: Option[File],
+      dependencyResolution: DependencyResolution,
+      compilerBridgeSource: ModuleID,
+      scalaJarsTarget: File,
+      log: Logger
+  ): AnalyzingCompiler = {
+    val compilerBridgeProvider = ZincComponentCompiler.interfaceProvider(
+      compilerBridgeSource,
+      new ZincComponentManager(globalLock, componentProvider, secondaryCacheDir, log),
+      dependencyResolution,
+      scalaJarsTarget,
+    )
+    val loader = Some(new ClassLoaderCache(new URLClassLoader(new Array(0))))
+    new AnalyzingCompiler(scalaInstance, compilerBridgeProvider, classpathOptions, _ => (), loader)
+  }
+
+  def getDefaultBridgeModule(scalaVersion: String): ModuleID =
+    ZincComponentCompiler.getDefaultBridgeModule(scalaVersion)
+}

--- a/internal/zinc-ivy-integration/src/test/scala/sbt/internal/inc/IvyBridgeProviderSpecification.scala
+++ b/internal/zinc-ivy-integration/src/test/scala/sbt/internal/inc/IvyBridgeProviderSpecification.scala
@@ -2,7 +2,6 @@ package sbt.internal.inc
 
 import java.io.File
 
-import sbt.io.IO
 import sbt.io.syntax._
 import sbt.librarymanagement._
 import sbt.librarymanagement.ivy._
@@ -14,7 +13,7 @@ import xsbti.compile.CompilerBridgeProvider
  *
  * This is a very good example on how to instantiate the compiler bridge provider.
  */
-abstract class BridgeProviderSpecification extends UnitSpec {
+abstract class IvyBridgeProviderSpecification extends UnitSpec with AbstractBridgeProviderTestkit {
   def currentBase: File = new File(".")
   def currentTarget: File = currentBase / "target" / "ivyhome"
   def currentManaged: File = currentBase / "target" / "lib_managed"
@@ -35,22 +34,6 @@ abstract class BridgeProviderSpecification extends UnitSpec {
     val manager = new ZincComponentManager(lock, componentProvider, secondaryCache, log)
     val dependencyResolution = IvyDependencyResolution(ivyConfiguration)
     ZincComponentCompiler.interfaceProvider(manager, dependencyResolution, currentManaged)
-  }
-
-  def getCompilerBridge(targetDir: File, log: Logger, scalaVersion: String): File = {
-    val provider = getZincProvider(targetDir, log)
-    val scalaInstance = provider.fetchScalaInstance(scalaVersion, log)
-    val bridge = provider.fetchCompiledBridge(scalaInstance, log)
-    val target = targetDir / s"target-bridge-$scalaVersion.jar"
-    IO.copyFile(bridge, target)
-    target
-  }
-
-  def scalaInstance(scalaVersion: String,
-                    targetDir: File,
-                    logger: Logger): xsbti.compile.ScalaInstance = {
-    val provider = getZincProvider(targetDir, logger)
-    provider.fetchScalaInstance(scalaVersion, logger)
   }
 
   private def getDefaultConfiguration(baseDirectory: File,

--- a/internal/zinc-ivy-integration/src/test/scala/sbt/internal/inc/ZincComponentCompilerSpec.scala
+++ b/internal/zinc-ivy-integration/src/test/scala/sbt/internal/inc/ZincComponentCompilerSpec.scala
@@ -3,7 +3,7 @@ package sbt.internal.inc
 import sbt.internal.util.ConsoleLogger
 import sbt.io.IO
 
-class ZincComponentCompilerSpec extends BridgeProviderSpecification {
+class ZincComponentCompilerSpec extends IvyBridgeProviderSpecification {
   val scala2105 = "2.10.5"
   val scala2106 = "2.10.6"
   val scala2118 = "2.11.8"

--- a/internal/zinc-scripted/src/test/scala/sbt/inc/MainScriptedRunner.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/inc/MainScriptedRunner.scala
@@ -4,11 +4,8 @@ import java.io.File
 
 import sbt.io.IO
 import sbt.internal.inc._
-import sbt.internal.scripted.{ CommentHandler, ScriptConfig, StatementHandler }
-import sbt.internal.util.ManagedLogger
-import xsbti.compile.CompilerBridgeProvider
-import sbt.util.Logger
 
+// WARNING: called via reflection
 final class MainScriptedRunner {
   def run(
       resourceBaseDirectory: File,
@@ -18,61 +15,8 @@ final class MainScriptedRunner {
   ): Unit = {
     IO.withTemporaryDirectory { tempDir =>
       // Create a global temporary directory to store the bridge et al
-      val handlers = new MainScriptedHandlers(tempDir, compileToJar)
+      val handlers = new IncScriptedHandlers(tempDir, compileToJar)
       ScriptedRunnerImpl.run(resourceBaseDirectory, bufferLog, tests, handlers, 4)
     }
   }
-}
-
-final class MainScriptedHandlers(tempDir: File, compileToJar: Boolean)
-    extends IncScriptedHandlers(tempDir, compileToJar) {
-  // Create a provider that uses the bridges from the classes directory of the projects
-  val provider: CompilerBridgeProvider = {
-    val compilerBridge210 = ScalaBridge(
-      BuildInfo.scalaVersion210,
-      BuildInfo.scalaJars210,
-      BuildInfo.classDirectory210
-    )
-    val compilerBridge211 = ScalaBridge(
-      BuildInfo.scalaVersion211,
-      BuildInfo.scalaJars211,
-      BuildInfo.classDirectory211
-    )
-    val compilerBridge212 = ScalaBridge(
-      BuildInfo.scalaVersion212,
-      BuildInfo.scalaJars212,
-      BuildInfo.classDirectory212
-    )
-    val compilerBridge213 = ScalaBridge(
-      BuildInfo.scalaVersion213,
-      BuildInfo.scalaJars213,
-      BuildInfo.classDirectory213
-    )
-
-    val all = List(compilerBridge210, compilerBridge211, compilerBridge212, compilerBridge213)
-    new ScriptedBridgeProvider(all, tempDir)
-  }
-
-  override def getHandlers(config: ScriptConfig): Map[Char, StatementHandler] = Map(
-    '$' -> new SleepingHandler(new ZincFileCommands(config.testDirectory()), 500),
-    '#' -> CommentHandler,
-    '>' -> {
-      val logger: ManagedLogger =
-        config.logger() match {
-          case x: ManagedLogger => x
-          case _                => sys.error("Expected ManagedLogger")
-        }
-      new BloopIncHandler(config.testDirectory(), tempDir, provider, logger, compileToJar)
-    }
-  )
-}
-
-final class BloopIncHandler(
-    directory: File,
-    cacheDir: File,
-    provider: CompilerBridgeProvider,
-    logger: ManagedLogger,
-    compileToJar: Boolean
-) extends IncHandler(directory, cacheDir, logger, compileToJar) {
-  override def getZincProvider(targetDir: File, log: Logger): CompilerBridgeProvider = provider
 }

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncScriptedRunner.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncScriptedRunner.scala
@@ -8,6 +8,7 @@ import sbt.util.Logger
 
 import scala.collection.parallel.ParSeq
 
+// WARNING: called via reflection
 class IncScriptedRunner {
   def run(
       resourceBaseDirectory: File,

--- a/internal/zinc-testing/src/main/scala/sbt/internal/inc/AbstractBridgeProviderTestkit.scala
+++ b/internal/zinc-testing/src/main/scala/sbt/internal/inc/AbstractBridgeProviderTestkit.scala
@@ -1,0 +1,24 @@
+package sbt.internal.inc
+
+import java.io.File
+import sbt.io.IO
+import sbt.io.syntax._
+import sbt.util.Logger
+import xsbti.compile.CompilerBridgeProvider
+
+trait AbstractBridgeProviderTestkit {
+  def getZincProvider(targetDir: File, log: Logger): CompilerBridgeProvider
+
+  def getCompilerBridge(targetDir: File, log: Logger, scalaVersion: String): File = {
+    val provider = getZincProvider(targetDir, log)
+    val scalaInstance = provider.fetchScalaInstance(scalaVersion, log)
+    val bridge = provider.fetchCompiledBridge(scalaInstance, log)
+    val target = targetDir / s"target-bridge-$scalaVersion.jar"
+    IO.copyFile(bridge, target)
+    target
+  }
+
+  import xsbti.compile.ScalaInstance
+  def scalaInstance(scalaVersion: String, targetDir: File, logger: Logger): ScalaInstance =
+    getZincProvider(targetDir, logger).fetchScalaInstance(scalaVersion, logger)
+}

--- a/zinc/src/test/scala/sbt/inc/ConstantBridgeProvider.scala
+++ b/zinc/src/test/scala/sbt/inc/ConstantBridgeProvider.scala
@@ -8,12 +8,15 @@ import xsbti.compile.CompilerBridgeProvider
 
 case class ScalaBridge(version: String, jars: Seq[File], classesDir: File)
 
-final class ScriptedBridgeProvider(
+final class ConstantBridgeProvider(
     bridges: List[ScalaBridge],
     tempDir: File
 ) extends CompilerBridgeProvider {
 
   import xsbti.compile.ScalaInstance
+
+  final val binSeparator = "-bin_"
+  final val javaClassVersion = System.getProperty("java.class.version")
 
   /** Get the location of the compiled Scala compiler bridge for a concrete Scala version. */
   override def fetchCompiledBridge(instance: ScalaInstance, logger: Logger): File = {
@@ -34,7 +37,6 @@ final class ScriptedBridgeProvider(
         sys.error(s"Missing $scalaVersion in supported versions ${bridges.map(_.version).mkString}")
       case Some(bridge) =>
         val targetJar: File = {
-          import sbt.internal.inc.ZincComponentCompiler.{ binSeparator, javaClassVersion }
           val id = s"scriptedCompilerBridge$binSeparator${bridge.version}__$javaClassVersion.jar"
           tempDir.toPath.resolve(id).toFile
         }

--- a/zinc/src/test/scala/sbt/inc/cached/CommonCachedCompilation.scala
+++ b/zinc/src/test/scala/sbt/inc/cached/CommonCachedCompilation.scala
@@ -58,30 +58,6 @@ abstract class CommonCachedCompilation(name: String)
 
   def remoteCacheProvider(): CacheProvider
 
-  /**
-   * Redefine what `currentManaged` is based on the project base location.
-   *
-   * The `lib_managed` folder stores all the cached libraries. It's an equivalent of
-   * `.ivy2` or `.coursier`. The analysis file provides simple read and write mappers
-   * that turn all paths relative to a **concrete position**.
-   *
-   * Note that the assumption that all paths can be made relative to a concrete position
-   * is not correct. There is no guarantee that the paths of the caches, the artifacts,
-   * the classpath entries, the outputs, et cetera share the same prefix.
-   *
-   * Such assumption is broken in our test infrastructure: `lib_managed` does not share
-   * the same prefix, and without redefining it, it fails. Note that this is a conscious
-   * design decision of the relative read and write mappers. They are focused on simplicity.
-   * Build tools that need more careful handling of paths should create their own read and
-   * write mappers.
-   *
-   * @return The file where all the libraries are stored.
-   */
-  override def currentManaged: File = {
-    import sbt.io.syntax.fileToRichFile
-    remoteProject.baseLocation.toFile./("target/lib_managed")
-  }
-
   override protected def beforeAll(): Unit = {
     //don't use temp dir because it might end up on different drive (on windows) and this later fails in sbt.internal.inc.binary.converters.ProtobufWriters due to inability to relativize paths
     val basePath =

--- a/zinc/src/test/scala/sbt/internal/inc/BridgeProviderSpecification.scala
+++ b/zinc/src/test/scala/sbt/internal/inc/BridgeProviderSpecification.scala
@@ -1,0 +1,21 @@
+package sbt.internal.inc
+
+import java.io.File
+import sbt.inc.{ ScalaBridge, ConstantBridgeProvider }
+import sbt.util.Logger
+import xsbti.compile.CompilerBridgeProvider
+
+class BridgeProviderSpecification extends UnitSpec with AbstractBridgeProviderTestkit {
+  val bridges: List[ScalaBridge] = {
+    import sbt.internal.inc.ZincBuildInfo._
+    val compilerBridge210 = ScalaBridge(scalaVersion210, scalaJars210, classDirectory210)
+    val compilerBridge211 = ScalaBridge(scalaVersion211, scalaJars211, classDirectory211)
+    val compilerBridge212 = ScalaBridge(scalaVersion212, scalaJars212, classDirectory212)
+    val compilerBridge213 = ScalaBridge(scalaVersion213, scalaJars213, classDirectory213)
+    List(compilerBridge210, compilerBridge211, compilerBridge212, compilerBridge213)
+  }
+
+  // Create a provider that uses the bridges from the classes directory of the projects
+  def getZincProvider(targetDir: File, log: Logger): CompilerBridgeProvider =
+    new ConstantBridgeProvider(bridges, targetDir)
+}


### PR DESCRIPTION
This patch breaks the dependency that Zinc had on sbt's Library
Management (LM) library abstraction (sbt/librarymanagement) and thus,
transitively, on Ivy.

The reason Zinc depends on LM in the first place is to dynamically
download the compiler bridge sources JAR, which it then compiles in
order to bridge from binary-compatible Zinc to the never-binary-stable
(and most of the time source-compatible) compiler API.

From my research (that is, using GitHub Search) the only user of this
feature is sbt, with all other integrations (e.g. pants, bloop, mill)
providing the compiler bridge sources JAR directly (an alternative API
entry point).

Therefore the dependency on LM and that integration code could be
untangled from Zinc and moved into sbt.  That would also give an
opportunity to move the code in LM (back) into sbt, which I also think
would be a good idea.

For now this patch leaves that integration code in the already existing
`zinc-ivy-integration` module, but which is now no longer a dependency
of any other module of Zinc, specifically it is no longer a dependency
of the `zinc` and `zincScripted` modules.  I think, though,
zinc-ivy-integration should remain in the zinc repo, as a part of the
build, being tested in CI, until it's been moved (back) into sbt.  I'd
be happy to take care of both the remaining move and removal tasks.

In order to allow removing LM, Ivy and zinc-ivy-integration as
transitive dependencies of Zinc, this patch has to make a breaking
change to the `ZincUtil` object in the zinc module.  Despite it being
defined in the `sbt.internal.inc` package (i.e. not declared as public
API) ZincUtil is in fact a used (Scala) API of Zinc (usages discovered
via GitHub Search).  Therefore I chose to leave the object in the zinc
module and only drop from the object the two methods that directly
depend on LM's API.  Specifically (1) the `getDefaultBridgeModule`
method and (2) the `scalaCompiler` overload that depends on LM were
removed.  These methods now live in a new `ZincLmUtil` object in
zinc-ivy-integration, which sbt can switch to using.

In terms of risk, from my research (GitHub Search) the only users of
those methods are sbt and bloop.  I need to confirm but I think bloop
will be able to manage this breaking change (it looks it might be just
fallback usage? TBC).  For sbt we don't actual support using new Zinc
with old sbt, so sbt can also just update its usage on its next release.
Any other usage risks being broken but given it's internal, non-public
API I think it's fair game.

The remaining changes are in the testing so that zinc-ivy-integration's
test suite continues to test its download-and-compile behaviour, while
the rest of Zinc switches to using the prebuilt compiler bridges,
reusing and generalising some pre-existing zincScripted code (as well as
re-wiring some modules) so it can be used by zinc's tests too.

Fixes #614