### PR TITLE
Fix scaladoc reference for java11 to fix broken doc build

### DIFF
--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/RawURL.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/RawURL.scala
@@ -49,7 +49,7 @@ object RawURL {
 /** A ClassLoader that looks up resource requests in a `Map` prior to the base ClassLoader's resource lookups. */
 trait RawResources extends FixedResources {
 
-  /** The map from resource paths to the raw String content to provide via the URL returned by [[findResource]] or [[findResources]]. */
+  /** The map from resource paths to the raw String content to provide via the URL returned by [[sbt.internal.inc.classpath.FixedResources!.findResource(s:String)*]] or [[findResources]]. */
   protected def resources: Map[String, String]
   override protected final val resourceURL = resources.transform(RawURL.apply)
 }
@@ -57,7 +57,7 @@ trait RawResources extends FixedResources {
 /** A ClassLoader that looks up resource requests in a `Map` prior to the base ClassLoader's resource lookups. */
 trait FixedResources extends ClassLoader {
 
-  /** The map from resource paths to URL to provide in [[findResource]] and [[findResources]]. */
+  /** The map from resource paths to URL to provide in [[sbt.internal.inc.classpath.FixedResources!.findResource(s:String)*]] and [[findResources]]. */
   protected def resourceURL: Map[String, URL]
 
   override def findResource(s: String): URL = resourceURL.getOrElse(s, super.findResource(s))


### PR DESCRIPTION
Fixes:

```
[info] Main Scala API documentation successful.
[error] /c/Users/Eric Peters/IdeaProjects/zinc/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/RawURL.scala:60:3: The link target "findResource" is ambiguous. Several members fit the target:
[error] (s: String): java.net.URL in trait FixedResources [chosen]
[error] (x$1: String,x$2: String): java.net.URL in trait FixedResources
[error]
[error]
[error] Quick crash course on using Scaladoc links
[error] ==========================================
[error] Disambiguating terms and types: Prefix terms with '$' and types with '!' in case both names are in use:
[error]  - [[scala.collection.immutable.List!.apply class List's apply method]] and
[error]  - [[scala.collection.immutable.List$.apply object List's apply method]]
[error] Disambiguating overloaded members: If a term is overloaded, you can indicate the first part of its signature followed by *:
[error]  - [[[scala.collection.immutable.List$.fill[A](Int)(⇒A):List[A]* Fill with a single parameter]]]
[error]  - [[[scala.collection.immutable.List$.fill[A](Int,Int)(⇒A):List[List[A]]* Fill with a two parameters]]]
[error] Notes:
[error]  - you can use any number of matching square brackets to avoid interference with the signature
[error]  - you can use \\. to escape dots in prefixes (don't forget to use * at the end to match the signature!)
[error]  - you can use \\# to escape hashes, otherwise they will be considered as delimiters, like dots.
[error]   /** The map from resource paths to URL to provide in [[findResource]] and [[findResources]]. */
[error]   ^
[info] Packaging /c/Users/Eric Peters/IdeaProjects/zinc/zinc-compile/target/scala-2.12/zinc-compile_2.12-1.3.0-SNAPSHOT-javadoc.jar ...
[error] /c/Users/Eric Peters/IdeaProjects/zinc/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/RawURL.scala:52:3: The link target "findResource" is ambiguous. Several members fit the target:
[error] (s: String): java.net.URL in trait RawResources [chosen]
[error] (x$1: String,x$2: String): java.net.URL in trait RawResources
[error]
[error]   /** The map from resource paths to the raw String content to provide via the URL returned by [[findResource]] or [[findResources]]. */
[error]   ^
```

Ambiguous Reference: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/ClassLoader.html#findClass(java.lang.String,java.lang.String)