### PR TITLE
[1.2.x] exclude Bintray repos out of POM 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -782,6 +782,9 @@ def customCommands: Seq[Setting[_]] = Seq(
   }
 )
 
+// Remove all additional repository other than Maven Central from POM
+ThisBuild / pomIncludeRepository := { _ => false }
+
 inThisBuild(Seq(
   whitesourceProduct                   := "Lightbend Reactive Platform",
   whitesourceAggregateProjectName      := "sbt-zinc-master",


### PR DESCRIPTION
This is a backport of https://github.com/sbt/zinc/pull/667
Fixes #666
Fixes #119
