### PR TITLE
Flush classloader cache

### DIFF
--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaderCache.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaderCache.scala
@@ -21,7 +21,6 @@ import java.util.HashMap
 import sbt.io.IO
 import scala.util.control.NonFatal
 
-// Hack for testing only
 final class ClassLoaderCache(val commonParent: ClassLoader) extends AutoCloseable {
   private[this] val delegate =
     new HashMap[List[File], Reference[CachedClassLoader]]


### PR DESCRIPTION
I am trying to clean up as many of the URLClassLoaders created by sbt as possible. The loaders managed by a ClassLoaderCache cannot presently be closed, even when we are sure they won't be used again.