### PR TITLE
ScalaInstance: support using multiple jars for the library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -506,6 +506,7 @@ lazy val compilerInterface212 = (project in internalPath / "compiler-interface")
       Seq(
         exclude[ReversedMissingMethodProblem]("xsbti.compile.ExternalHooks#Lookup.hashClasspath"),
         exclude[ReversedMissingMethodProblem]("xsbti.compile.ScalaInstance.loaderLibraryOnly"),
+        exclude[ReversedMissingMethodProblem]("xsbti.compile.ScalaInstance.libraryJars"), // Added in 1.3.0
         exclude[DirectMissingMethodProblem]("xsbti.api.AnalyzedClass.of"),
         exclude[DirectMissingMethodProblem]("xsbti.api.AnalyzedClass.create"),
         exclude[ReversedMissingMethodProblem]("xsbti.AnalysisCallback.classesInOutputJar"),

--- a/internal/compiler-interface/src/main/java/xsbti/compile/ScalaInstance.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/ScalaInstance.java
@@ -32,23 +32,28 @@ public interface ScalaInstance {
 	 */
 	String version();
 
-	/** A class loader providing access to the classes and resources in the library and compiler jars. */
+	/** A class loader providing access to the classes and resources in all the jars of this Scala instance. */
 	ClassLoader loader();
 
-	/** A class loader providing access to the classes and resources in the library. */
+	/** A class loader providing access to the classes and resources in the library jars of this Scala instance. */
 	ClassLoader loaderLibraryOnly();
 
-	/** Only `jars` can be reliably provided for modularized Scala. */
-	File libraryJar();
+	/** Classpath entries that stores the Scala library classes. */
+	File[] libraryJars();
 
-	/** Only `jars` can be reliably provided for modularized Scala. */
+	/** @deprecated Use `libraryJars` instead (since 1.3.0). */
+	@Deprecated
+	default File libraryJar() {
+		return libraryJars()[0];
+	}
+
+	/** Classpath entry that stores the Scala compiler classes. */
 	File compilerJar();
 
-	/** @deprecated Only `jars` can be reliably provided for modularized Scala (since 0.13.0). */
-	@Deprecated
+	/** All the jars except `libraryJars` and `compilerJar`. */
 	File[] otherJars();
 
-	/** All jar files provided by this Scala instance. */
+	/** Classpath entries for the `loader`. */
 	File[] allJars();
 
 	/**

--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClasspathUtilities.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClasspathUtilities.scala
@@ -75,7 +75,7 @@ object ClasspathUtilities {
       classpath: Seq[File],
       instance: ScalaInstance
   ): Map[String, String] = {
-    createClasspathResources(classpath, Array(instance.libraryJar))
+    createClasspathResources(classpath, instance.libraryJars)
   }
 
   def createClasspathResources(appPaths: Seq[File], bootPaths: Seq[File]): Map[String, String] = {

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala
@@ -357,9 +357,9 @@ object AnalyzingCompiler {
         log.info(msg)
         val start = System.currentTimeMillis
         handleCompilationError {
-          val scalaLibraryJar = compiler.scalaInstance.libraryJar
+          val scalaLibraryJars = compiler.scalaInstance.libraryJars
           val restClasspath = xsbtiJars.toSeq ++ sourceJars
-          val classpath = scalaLibraryJar +: restClasspath
+          val classpath = scalaLibraryJars ++ restClasspath
           compiler(sourceFiles, classpath, outputDirectory, "-nowarn" :: Nil)
 
           val end = (System.currentTimeMillis - start) / 1000.0

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala
@@ -74,10 +74,7 @@ final class CompilerArguments(
   def finishClasspath(classpath: Seq[File]): Seq[File] = {
     val filteredClasspath = filterLibrary(classpath)
     val extraCompiler = include(cpOptions.compiler, scalaInstance.compilerJar)
-    val otherJars = scalaInstance.allJars().toList diff List(
-      scalaInstance.compilerJar,
-      scalaInstance.libraryJar
-    )
+    val otherJars = scalaInstance.otherJars.toList
     val extraClasspath = include(cpOptions.extra, otherJars: _*)
     filteredClasspath ++ extraCompiler ++ extraClasspath
   }
@@ -103,7 +100,7 @@ final class CompilerArguments(
       val newBootPrefix =
         if (originalBoot.isEmpty) ""
         else originalBoot + File.pathSeparator
-      newBootPrefix + scalaInstance.libraryJar.getAbsolutePath
+      newBootPrefix + absString(scalaInstance.libraryJars)
     } else originalBoot
   }
 
@@ -147,7 +144,7 @@ final class CompilerArguments(
   private[this] val isScalaLibrary: File => Boolean = file => {
     val name = file.getName
     name.contains(ArtifactInfo.ScalaLibraryID) ||
-    name == scalaInstance.libraryJar.getName
+    scalaInstance.libraryJars.exists(_.getName == name)
   }
 }
 
@@ -161,5 +158,7 @@ object CompilerArguments {
   def absString(files: Seq[File]): String =
     abs(files).mkString(File.pathSeparator)
 
-  def absString(files: Set[File]): String = absString(files.toSeq)
+  def absString(files: Set[File]): String = absString(files.toList)
+
+  def absString(files: Array[File]): String = absString(files.toList)
 }

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavaCompiler.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavaCompiler.scala
@@ -103,10 +103,9 @@ object JavaCompiler {
       case so: SingleOutput  => Some(so.getOutputDirectory)
       case _: MultipleOutput => None
     }
-    // TODO(jvican): Fix the `libraryJar` deprecation.
     val augmentedClasspath =
       if (!cpOptions.autoBoot) classpath
-      else classpath ++ Seq(scalaInstance.libraryJar)
+      else classpath ++ scalaInstance.libraryJars
     val javaCp = ClasspathOptionsUtil.javac(cpOptions.compiler)
     val compilerArgs = new CompilerArguments(scalaInstance, javaCp)
     compilerArgs(Array[File](), augmentedClasspath, target, options)


### PR DESCRIPTION
This is helpful for Dotty, where the standard library is currently
composed of a scala-library jar compiled by Scala 2 and a dotty-library
compiled by itself, see
https://github.com/lampepfl/dotty/blob/3bcaf1d36be8e9f56578c4326cad2e9e0729b1ee/sbt-dotty/src/dotty/tools/sbtplugin/DottyPlugin.scala#L194-L228

Also undeprecate otherJars in the same way that libraryJar and
compilerJar were undeprecated previously (I don't understand why they
were ever deprecated).