### PR TITLE
Ignore unexpected method type

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/ExtractAPI.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ExtractAPI.scala
@@ -598,6 +598,8 @@ class ExtractAPI[GlobalType <: Global](
           "sbt-api: Unexpected nullary method type " + in + " in " + in.owner
         )
         Constants.emptyType
+      case MethodType(_, _) =>
+        Constants.emptyType
       case _ =>
         reporter.warning(NoPosition, "sbt-api: Unhandled type " + t.getClass + " : " + t)
         Constants.emptyType


### PR DESCRIPTION
Fixes https://github.com/sbt/zinc/issues/688

There's a long-standing issue about method type warning showing up with the following code:

```scala
object X {
  final case class Y(private[X] val i: Int) extends AnyVal
}
```