### PR TITLE
Fix sbt/sbt#5058: error messages coming from Dotty are incorrectly reported

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -303,9 +303,15 @@ lazy val zincPersist = (project in internalPath / "zinc-persist")
         exclude[DirectMissingMethodProblem]("sbt.internal.inc.schema.Problem#ProblemLens.rendered"),
         exclude[MissingClassProblem]("sbt.internal.inc.text.Java678Encoder"),
         // Added {start,end}{Offset,Line,Column}
+        // Added Position#{start,end}{Offset,Line,Column}
         exclude[DirectMissingMethodProblem]("sbt.internal.inc.schema.Position.apply"),
         exclude[DirectMissingMethodProblem]("sbt.internal.inc.schema.Position.copy"),
         exclude[DirectMissingMethodProblem]("sbt.internal.inc.schema.Position.this"),
+
+        // Added Problem#reported
+        exclude[DirectMissingMethodProblem]("sbt.internal.inc.schema.Problem.apply"),
+        exclude[DirectMissingMethodProblem]("sbt.internal.inc.schema.Problem.copy"),
+        exclude[DirectMissingMethodProblem]("sbt.internal.inc.schema.Problem.this"),
       )
     }
   )

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/ProblemStringFormats.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/ProblemStringFormats.scala
@@ -24,20 +24,21 @@ import sbt.util.InterfaceUtil.jo2o
 trait ProblemStringFormats {
   implicit lazy val ProblemStringFormat: ShowLines[Problem] = new ShowLines[Problem] {
     def showLines(p: Problem): Seq[String] =
-      p match {
-        case p if !p.position.sourcePath.isPresent && !p.position.line.isPresent =>
-          Vector(p.message)
-        case _ =>
-          val pos = p.position
-          val sourcePrefix = jo2o(pos.sourcePath).getOrElse("")
-          val columnNumber = jo2o(pos.pointer).fold(1)(_.toInt + 1)
-          val lineNumberString = jo2o(pos.line).fold(":")(":" + _ + ":" + columnNumber + ":") + " "
-          val line1 = sourcePrefix + lineNumberString + p.message
-          val lineContent = pos.lineContent
-          if (!lineContent.isEmpty) {
-            Vector(line1, lineContent) ++
-              (for { space <- jo2o(pos.pointerSpace) } yield (space + "^")).toVector // pointer to the column position of the error/warning
-          } else Vector(line1)
+      if (p.rendered.isPresent)
+        Vector(p.rendered.get)
+      else if (!p.position.sourcePath.isPresent && !p.position.line.isPresent)
+        Vector(p.message)
+      else {
+        val pos = p.position
+        val sourcePrefix = jo2o(pos.sourcePath).getOrElse("")
+        val columnNumber = jo2o(pos.pointer).fold(1)(_.toInt + 1)
+        val lineNumberString = jo2o(pos.line).fold(":")(":" + _ + ":" + columnNumber + ":") + " "
+        val line1 = sourcePrefix + lineNumberString + p.message
+        val lineContent = pos.lineContent
+        if (!lineContent.isEmpty) {
+          Vector(line1, lineContent) ++
+            (for { space <- jo2o(pos.pointerSpace) } yield (space + "^")).toVector // pointer to the column position of the error/warning
+        } else Vector(line1)
       }
   }
 }

--- a/internal/zinc-persist/src/main/protobuf/schema.proto
+++ b/internal/zinc-persist/src/main/protobuf/schema.proto
@@ -79,6 +79,7 @@ message Problem {
     Severity severity = 2;
     string message = 3;
     Position position = 4;
+    string rendered = 5;
 }
 
 message SourceInfo {

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/text/TextAnalysisFormat.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/text/TextAnalysisFormat.scala
@@ -48,8 +48,8 @@ object TextAnalysisFormat extends TextAnalysisFormat(ReadWriteMappers.getEmptyMa
     asProduct3(read)(a => (a.name(), a.scope().name(), a.hash()))
   }
   private implicit val companionsFomrat: Format[Companions] = CompanionsFormat
-  private implicit def problemFormat: Format[Problem] = {
-    asProduct4(problem)(p => (p.category, p.position, p.message, p.severity))
+  private implicit def problemFormat: Format[Problem] =
+    asProduct5(problem)(p => (p.category, p.position, p.message, p.severity, jo2o(p.rendered)))
   private implicit def positionFormat: Format[Position] =
     asProduct13(position)(
       p =>

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/text/TextAnalysisFormat.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/text/TextAnalysisFormat.scala
@@ -50,9 +50,8 @@ object TextAnalysisFormat extends TextAnalysisFormat(ReadWriteMappers.getEmptyMa
   private implicit val companionsFomrat: Format[Companions] = CompanionsFormat
   private implicit def problemFormat: Format[Problem] = {
     asProduct4(problem)(p => (p.category, p.position, p.message, p.severity))
-  }
-  private implicit def positionFormat: Format[Position] = {
-    asProduct7(position)(
+  private implicit def positionFormat: Format[Position] =
+    asProduct13(position)(
       p =>
         (
           jo2o(p.line),
@@ -61,10 +60,15 @@ object TextAnalysisFormat extends TextAnalysisFormat(ReadWriteMappers.getEmptyMa
           jo2o(p.pointer),
           jo2o(p.pointerSpace),
           jo2o(p.sourcePath),
-          jo2o(p.sourceFile)
+          jo2o(p.sourceFile),
+          jo2o(p.startOffset),
+          jo2o(p.endOffset),
+          jo2o(p.startLine),
+          jo2o(p.startColumn),
+          jo2o(p.endLine),
+          jo2o(p.endColumn)
         )
     )
-  }
   private implicit val severityFormat: Format[Severity] =
     wrap[Severity, Byte](_.ordinal.toByte, b => Severity.values.apply(b.toInt))
   private implicit val integerFormat: Format[Integer] =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -67,7 +67,7 @@ object Dependencies {
   val scalaCompiler = Def.setting { "org.scala-lang" % "scala-compiler" % scalaVersion.value }
 
   val parserCombinator = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2"
-  val sbinary = "org.scala-sbt" %% "sbinary" % "0.4.4"
+  val sbinary = "org.scala-sbt" %% "sbinary" % "0.5.0"
   val silencerPlugin = "com.github.ghik" %% "silencer-plugin" % "1.4.2"
   val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.14.0"
   val scalatest = "org.scalatest" %% "scalatest" % "3.0.8"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.0-RC4
+sbt.version=1.3.2


### PR DESCRIPTION
One year ago in https://github.com/sbt/zinc/pull/588, I wrote:
> After having a look at https://discuss.lightbend.com/t/patching-strategy/1924 I have no idea whether I'm supposed to open things against 1.2.x or 1.x, so I'm opening against 1.2.x since that's what I care about right now.

Afterwards this PR was merged and then... it was never forward-ported to the develop branch. This reveals a deep flaw in the development model of sbt, long-living branches are only an acceptable practice if there's some process in place to make sure that they stay synchronized in some way, this is usually achieved by periodically merging one branch into another (example: https://github.com/scala/scala/pull/8405). Alternatively, just give up on long-lived branches and have shorter, frequent releases from master.

Anyway, this PR forward-ports https://github.com/sbt/zinc/pull/588 to 1.3.x. Once this is merged I will also forward-port it to develop since I apparently can't trust any process to do that for me.