### PR TITLE
Upgrade scalapb machinery to modern version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -86,11 +86,7 @@ def commonSettings: Seq[Setting[_]] = Seq(
   scalacOptions ++= Seq(
     "-YdisableFlatCpCaching",
     "-target:jvm-1.8",
-  ),
-  // Override the version that scalapb depends on. This adds an explicit dependency on
-  // protobuf-java. This will cause sbt to evict the older version that is used by
-  // scalapb-runtime.
-  libraryDependencies += "com.google.protobuf" % "protobuf-java" % "3.7.0"
+  )
 )
 
 def compilerVersionDependentScalacOptions: Seq[Setting[_]] = Seq(
@@ -325,12 +321,17 @@ lazy val zincPersist = (project in internalPath / "zinc-persist")
         exclude[DirectMissingMethodProblem]("sbt.internal.inc.schema.Problem.apply"),
         exclude[DirectMissingMethodProblem]("sbt.internal.inc.schema.Problem.copy"),
         exclude[DirectMissingMethodProblem]("sbt.internal.inc.schema.Problem.this"),
-        exclude[IncompatibleSignatureProblem]("sbt.internal.inc.schema.Problem.unapply"),
-        exclude[IncompatibleSignatureProblem]("sbt.internal.inc.schema.Position.unapply"),
-        exclude[IncompatibleSignatureProblem]("sbt.internal.inc.schema.AnalyzedClass.unapply"),
-        exclude[IncompatibleSignatureProblem]("sbt.internal.inc.schema.AnalyzedClass.unapply"),
-        exclude[IncompatibleSignatureProblem]("sbt.internal.inc.schema.Version.values"),
-        exclude[IncompatibleSignatureProblem]("sbt.internal.inc.schema.Position.unapply"),
+        // Upgraded scalapb
+        exclude[FinalClassProblem]("sbt.internal.inc.schema.*"),
+        exclude[IncompatibleMethTypeProblem]("sbt.internal.inc.schema.*"),
+        exclude[IncompatibleMethTypeProblem]("sbt.internal.inc.zprof.*"),
+        exclude[IncompatibleResultTypeProblem]("sbt.internal.inc.schema.*"),
+        exclude[IncompatibleResultTypeProblem]("sbt.internal.inc.zprof.*"),
+        exclude[IncompatibleSignatureProblem]("sbt.internal.inc.schema.*"),
+        exclude[IncompatibleSignatureProblem]("sbt.internal.inc.zprof.*"),
+        exclude[InheritedNewAbstractMethodProblem]("sbt.internal.inc.schema.*"),
+        exclude[MissingTypesProblem]("sbt.internal.inc.schema.*"),
+        exclude[MissingTypesProblem]("sbt.internal.inc.zprof.*"),
       )
     }
   )
@@ -431,6 +432,11 @@ lazy val zincCore = (project in internalPath / "zinc-core")
         exclude[DirectMissingMethodProblem]("sbt.internal.inc.AnalysisCallback#Builder.this"),
         exclude[DirectMissingMethodProblem]("sbt.internal.inc.AnalysisCallback.this"),
         exclude[IncompatibleSignatureProblem]("sbt.internal.inc.MiniSetupUtil.equivCompileSetup"),
+        // Upgraded scalapb
+        exclude[IncompatibleMethTypeProblem]("sbt.internal.inc.zprof.*"),
+        exclude[IncompatibleResultTypeProblem]("sbt.internal.inc.zprof.*"),
+        exclude[IncompatibleSignatureProblem]("sbt.internal.inc.zprof.*"),
+        exclude[MissingTypesProblem]("sbt.internal.inc.zprof.*"),
       )
     }
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,9 +5,8 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.4")
 addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.4.4")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "3.0.2")
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.12-rc5")
-libraryDependencies += // Remember to remove the explicit dependency on java-protobuf:3.7.0 when updating this dependency
-  "com.trueaccord.scalapb" %% "compilerplugin" % "0.6.0"
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.26")
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.9.3"
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.16")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.6.1")


### PR DESCRIPTION
Fixes https://github.com/sbt/zinc/issues/546

Motivation:

Protobuf machinery currently uses com.trueaccord.scalapb:compilerplugin which is the old groupId and is not available for Scala 2.13.

Modifications:

* Upgrade com.thesamet:sbt-protoc to 0.99.26
* Switch to com.thesamet.scalapb:compilerplugin 0.9.3
* Remove com.google.protobuf:protobuf-java forced version upgrade as version now pulled is 3.8.0

Note:

* scala-maven-plugin test suite passes with Scala 2.12 build with those changes.

Result:

Zinc now uses a modern version of scalapb, where a crosscompiled version for Scala 2.13 is available.