### PR TITLE
[Fix] Make DiagnosticsReporter check scheme before converting to File

### DIFF
--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/DiagnosticsReporter.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/DiagnosticsReporter.scala
@@ -104,7 +104,13 @@ object DiagnosticsReporter {
         }
 
       val source: Option[JavaFileObject] = Option(d.getSource)
-      val sourcePath: Option[String] = source map (obj => IO.toFile(obj.toUri).getAbsolutePath)
+      val sourcePath: Option[String] = source.map { obj =>
+        val uri = obj.toUri
+        if (uri.isAbsolute)
+          IO.urlAsFile(uri.toURL).map(_.getAbsolutePath).getOrElse(uri.toString)
+        else
+          uri.toString
+      }
       val line: Optional[Integer] = o2jo(checkNoPos(d.getLineNumber) map (_.toInt))
       val offset: Optional[Integer] = o2jo(checkNoPos(d.getPosition) map (_.toInt))
       val startOffset: Optional[Integer] = o2jo(checkNoPos(d.getStartPosition) map (_.toInt))


### PR DESCRIPTION
Closes: https://github.com/sbt/sbt/issues/4305

DiagnosticsReporter was eagerly turning URIs into Files without checking whether or not the URI is indeed a file. This adds a check to make sure that the scheme is defined (isAbsolute) before doing the conversion, and calling `getAbsolutePath.`

@eed3si9n this targets `develop` and https://github.com/sbt/sbt/issues/4305 has `1.4.0` as the target version.. is there any way to get this on `1.3.x`? I will gladly do the work to backport if needed.