### PR TITLE
[backport] Fix output of `show scalaInstance`

### DIFF
--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/ScalaInstance.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/ScalaInstance.scala
@@ -108,8 +108,9 @@ final class ScalaInstance(
 
   /** Get the string representation of all the available jars. */
   private def jarStrings: String = {
+    val libs = libraryJars.mkString(", ")
     val other = otherJars.mkString(", ")
-    s"""library jars: $libraryJars, compiler jar: $compilerJar, other jars: $other"""
+    s"""library jars: $libs, compiler jar: $compilerJar, other jars: $other"""
   }
 
   override def toString: String =


### PR DESCRIPTION
libraryJars is an array, so we can't just call toString on it to display
its content.

This is a backport of 4ae22604cc5d855badb686d7182f16609a76d4b8.