### PR TITLE
Don't catch InterruptedException in handleCompilationError

### DIFF
--- a/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
@@ -167,7 +167,8 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
     try {
       compilerRun
     } catch {
-      case e: CompileFailed => throw e // just ignore
+      case e: CompileFailed        => throw e // just ignore
+      case e: InterruptedException => throw e // just ignore
       case e: Throwable =>
         val ex = e // For Intellij debugging purpose
         val numberSources = s"${sources.length} sources"


### PR DESCRIPTION
In combination with https://github.com/sbt/sbt/pull/5450, this PR addresses https://github.com/sbt/sbt/pull/5446#issuecomment-589985382