### PR TITLE
Reduce overhead of workaround for Scala 2.11 on JDK9+

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/Dependency.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/Dependency.scala
@@ -126,9 +126,12 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile with 
             // The dependency comes from a JAR
             for {
               zip <- zipEntry.underlyingSource
-              jarFile <- Option(zip.file)
-              if !jarFile.isDirectory // workaround for JDK9 and Scala 2.10/2.11, see https://github.com/sbt/sbt/pull/3701
-            } binaryDependency(jarFile.toPath, binaryClassName)
+            } {
+              // workaround for JDK9 and Scala 2.10/2.11, see https://github.com/sbt/sbt/pull/3701
+              val ignore = zip.file == null || (!zip.hasExtension("jar") && zip.isDirectory)
+              if (!ignore)
+                binaryDependency(zip.file.toPath, binaryClassName)
+            }
           case pf: xsbt.Compat.PlainNioFile =>
             // The dependency comes from a class file
             binaryDependency(Paths.get(pf.path), binaryClassName)


### PR DESCRIPTION
Calling isDirectory on every reference is pretty excessive!