### PR TITLE
Push lookupAnalyzedClass into Lookup

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -118,14 +118,9 @@ object Incremental {
         (false, previous)
     }
   }
+
   def getExternalAPI(lookup: Lookup): (VirtualFileRef, String) => Option[AnalyzedClass] =
-    (_: VirtualFileRef, binaryClassName: String) =>
-      lookup.lookupAnalysis(binaryClassName) flatMap {
-        case (analysis: Analysis) =>
-          val sourceClassName =
-            analysis.relations.productClassName.reverse(binaryClassName).headOption
-          sourceClassName flatMap analysis.apis.internal.get
-      }
+    (_: VirtualFileRef, binaryClassName: String) => lookup.lookupAnalyzedClass(binaryClassName)
 
   /**
    * Runs the incremental compiler algorithm.

--- a/zinc/src/main/scala/sbt/internal/inc/LookupImpl.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/LookupImpl.scala
@@ -13,6 +13,7 @@ package sbt.internal.inc
 
 import java.util.Optional
 
+import xsbti.api.AnalyzedClass
 import xsbti.compile.{ Changes, CompileAnalysis, FileHash, MiniSetup }
 import xsbti.{ VirtualFile, VirtualFileRef }
 
@@ -54,6 +55,13 @@ class LookupImpl(compileConfiguration: CompileConfiguration, previousSetup: Opti
   lazy val externalLookup = Option(compileConfiguration.incOptions.externalHooks())
     .flatMap(ext => ext.getExternalLookup().toOption)
     .collect { case externalLookup: ExternalLookup => externalLookup }
+
+  override def lookupAnalyzedClass(binaryClassName: String): Option[AnalyzedClass] = {
+    externalLookup match { // not flatMap so that external lookup can fast-track returning None
+      case Some(externalLookup) => externalLookup.lookupAnalyzedClass(binaryClassName)
+      case _                    => super.lookupAnalyzedClass(binaryClassName)
+    }
+  }
 
   override def changedSources(previousAnalysis: CompileAnalysis): Option[Changes[VirtualFileRef]] =
     externalLookup.flatMap(_.changedSources(previousAnalysis))


### PR DESCRIPTION
... allowing users to optimize it - in both directions: in finding the
class or in not finding the class (i.e. without having to
lookupAnalysis).