### PR TITLE
Tests: improve resource management and reduce IO

### DIFF
--- a/zinc/src/test/scala/sbt/inc/ClassFileManagerHookSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/ClassFileManagerHookSpec.scala
@@ -40,7 +40,8 @@ class ClassFileManagerHookSpec extends BaseCompilerSpec {
 
       val compiler =
         setup.createCompiler().copy(incOptions = incOptions.withExternalHooks(newExternalHooks))
-      compiler.doCompile()
+      try compiler.doCompile()
+      finally compiler.close()
 
       callbackCalled.shouldEqual(3)
     }

--- a/zinc/src/test/scala/sbt/inc/ClasspathHashingHookSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/ClasspathHashingHookSpec.scala
@@ -35,10 +35,14 @@ class ClasspathHashingHookSpec extends BaseCompilerSpec {
       val hooks = new DefaultExternalHooks(Optional.of(lookup), Optional.empty())
       val compiler =
         setup.createCompiler().copy(incOptions = IncOptions.of().withExternalHooks(hooks))
-      val result = compiler.doCompile()
+      try {
+        val result = compiler.doCompile()
 
-      result.setup().options().classpathHash().foreach { original =>
-        original shouldEqual hashFile(setup.converter.toVirtualFile(original.file()))
+        result.setup().options().classpathHash().foreach { original =>
+          original shouldEqual hashFile(setup.converter.toVirtualFile(original.file()))
+        }
+      } finally {
+        compiler.close()
       }
     }
   }

--- a/zinc/src/test/scala/sbt/inc/NameHashingCompilerSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/NameHashingCompilerSpec.scala
@@ -16,7 +16,6 @@ import java.nio.file.Paths
 import sbt.io.IO
 
 class NameHashingCompilerSpec extends BaseCompilerSpec {
-
   def testIncrementalCompilation(
       changes: Seq[(String, String => String)],
       transitiveChanges: Set[String],

--- a/zinc/src/test/scala/sbt/inc/TestProjectSetup.scala
+++ b/zinc/src/test/scala/sbt/inc/TestProjectSetup.scala
@@ -259,6 +259,9 @@ object TestProjectSetup {
       store.set(AnalysisContents.create(newResult.analysis(), newResult.setup()))
       newResult
     }
+    def close(): Unit = {
+      sc.classLoaderCache.foreach(_.close())
+    }
   }
 
   case class MockedLookup(am: VirtualFile => Optional[CompileAnalysis])


### PR DESCRIPTION
I noticed this error when locally running the test suite:

```
[info] - should trigger full compilation if extra changes
OpenJDK 64-Bit Server VM warning: CodeCache is full. Compiler has been disabled.
OpenJDK 64-Bit Server VM warning: Try increasing the code cache size using -XX:ReservedCodeCacheSize=
CodeCache: size=245760Kb used=243676Kb max_used=243740Kb free=2083Kb
 bounds [0x0000000108254000, 0x0000000117254000, 0x0000000117254000]
 total_blobs=108491 nmethods=107492 adapters=900
 compilation: disabled (not enough contiguous free space left)
```

I didn't to a proper analysis to find what was causing this,
but on a hunch modified the tests to close the classloaders
they create.

I also found a test to be very slow when collecting its
test data from $IVY_HOME. I changed this to use a lazy
file walk to get the first 500 JARs, rather than traversing
full directory structure.

The test suite now runs for me cleanly.

```
[info] All tests passed.
[info] Passed: Total 17, Failed 0, Errors 0, Passed 17
[success] Total time: 149 s (02:29), completed 28/04/2020 3:06:32 PM
sbt:zinc Root>
```