### PR TITLE
Convert VirtualFile to PlainFile in the compiler bridge

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/CompilerInterface.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CompilerInterface.scala
@@ -154,7 +154,7 @@ private final class CachedCompiler0(args: Array[String], output: Output, initial
       compiler.set(callback, underlyingReporter)
       val run = new compiler.ZincRun(compileProgress)
 
-      val wrappedFiles = sources.map(new VirtualFileWrap(_))
+      val wrappedFiles = sources.map(VirtualFileWrap(_))
       val sortedSourceFiles: List[AbstractFile] =
         wrappedFiles.sortWith(_.underlying.id < _.underlying.id)
       run.compileFiles(sortedSourceFiles)

--- a/internal/compiler-bridge/src/main/scala/xsbt/DelegatingReporter.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/DelegatingReporter.scala
@@ -89,7 +89,9 @@ private object DelegatingReporter {
 
     def makePosition(pos: Position): xsbti.Position = {
       val src = pos.source
-      val sourcePath = src.file.path
+      val sourcePath = src.file match {
+        case VirtualFileWrap(virtualFile) => virtualFile.id
+      }
       val sourceFile = new File(src.file.path)
       val line = pos.line
       val lineContent = pos.lineContent.stripLineEnd

--- a/internal/compiler-bridge/src/main/scala/xsbt/ScaladocInterface.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ScaladocInterface.scala
@@ -64,7 +64,7 @@ private class Runner(
       def document(ignore: Seq[String]): Unit = {
         import compiler._
         val run = new Run
-        val wrappedFiles = sources.toList.map(new VirtualFileWrap(_))
+        val wrappedFiles = sources.toList.map(VirtualFileWrap(_))
         val sortedSourceFiles: List[AbstractFile] =
           wrappedFiles.sortWith(_.underlying.id < _.underlying.id)
         run.compileFiles(sortedSourceFiles)


### PR DESCRIPTION
Fixes #770 
Fixes #784
Fixes [#2053](https://github.com/scalameta/scalameta/issues/2053) in [scalameta](https://github.com/scalameta/scalameta)

Wrap a `xsbti.VirtualFile` inside a `scala.reflect.io.PlainFile` or a `scala.reflect.io.VirtualFile` depending on the PathBased nature of the file. I am not sure if it is a good idea to extend those `scala.reflect.io` classes, but it has several benefits:
- The compiler will see `PlainFile`s and it can optimize on that fact.
- The downstream tooling will see `PlainFile` as well and it can perform on that fact:
  - scalameta can publish the semanticdb files
  - the sbt reporter can print the compiler diagnostics
  - ...
- Zinc will be able to retrieve the underlying `VirtualFile` without having to maintain a `Map[AbstractFile, VirtualFile]`
