### PR TITLE
Ignore annotations are inadvertently added to NoSymbol

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/ExtractAPI.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ExtractAPI.scala
@@ -241,7 +241,7 @@ class ExtractAPI[GlobalType <: Global](
       //  b) there is no way to distinguish them from user-defined methods
       if (b.hasGetter) {
         val annotations = collection.mutable.LinkedHashSet[xsbti.api.Annotation]()
-        def add(sym: Symbol) = {
+        def add(sym: Symbol) = if (sym != NoSymbol) {
           val anns = mkAnnotations(in, sym.annotations)
           var i = 0
           while (i < anns.length) {

--- a/internal/compiler-bridge/src/main/scala/xsbt/ExtractAPI.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ExtractAPI.scala
@@ -252,7 +252,7 @@ class ExtractAPI[GlobalType <: Global](
         add(b)
         add(b.getterIn(b.enclClass))
         add(b.setterIn(b.enclClass))
-        annotations.toArray.distinct
+        annotations.toArray
       } else {
         if (b.annotations.isEmpty) ExtractAPI.emptyAnnotationArray
         else mkAnnotations(in, b.annotations)


### PR DESCRIPTION
Scala.js seems to do this (noted in https://github.com/scala-js/scala-js/issues/4089).

In Zinc, we should defend against this by excluding `NoSymbol` from our annotation
collection.

Fixes #718, a regression since https://github.com/sbt/zinc/pull/492 Zinc 1.1.6