### PR TITLE
Add an assertion in MCompilations

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Compilations.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Compilations.scala
@@ -36,6 +36,11 @@ object Compilations {
 
 private final class MCompilations(val allCompilations: Seq[Compilation]) extends Compilations {
   // TODO: Sort `allCompilations` chronologically and enforce it in the Zinc API specification
+  assert(
+    { val xs = allCompilations.map(_.getStartTime); xs.distinct.size == xs.size },
+    "Created a Compilations with duplicate compilations"
+  )
+
   def ++(o: Compilations): Compilations = new MCompilations(allCompilations ++ o.allCompilations)
   def add(c: Compilation): Compilations = new MCompilations(allCompilations :+ c)
 }


### PR DESCRIPTION
This... invariant(?).. is mentioned in the TODO.

In the pipelining PR I found it to be the root cause of an erroneous
implementation (merging multiple times).  So I think it would be good to
enforce this on construction, alas with an exception.