### PR TITLE
Fix tab-completion of scripted (page.total == 0)

### DIFF
--- a/project/Scripted.scala
+++ b/project/Scripted.scala
@@ -35,7 +35,7 @@ object Scripted {
     // Grabs the filenames from a given test group in the current page definition.
     def pagedFilenames(group: String, page: ScriptedTestPage): Seq[String] = {
       val files = pairMap(group).toSeq.sortBy(_.toLowerCase)
-      val pageSize = files.size / page.total
+      val pageSize = if (page.total == 0) 0 else files.size / page.total
       // The last page may loose some values, so we explicitly keep them
       val dropped = files.drop(pageSize * (page.page - 1))
       if (page.page == page.total) dropped


### PR DESCRIPTION
> scripted macros/<TAB>

leads to

    > scripted macros/java.lang.ArithmeticException: / by zero
    	at localzinc.Scripted$.pagedFilenames$1(Scripted.scala:38)
    	at localzinc.Scripted$.$anonfun$scriptedParser$9(Scripted.scala:51)
    	at scala.Function1.$anonfun$andThen$1(Function1.scala:57)
    	at scala.Function1.$anonfun$andThen$1(Function1.scala:57)
    	at scala.Function1.$anonfun$andThen$1(Function1.scala:57)

Without finding out why that happens, just avoid the problem.