### PR TITLE
Fix URI path management

### DIFF
--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/LocalJava.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/LocalJava.scala
@@ -187,26 +187,11 @@ object LocalJava {
     }
   }
 
-  private[sbt] def toUri(vf: VirtualFile): URI =
-    new URI(
-      "vf:/tmp/" + vf.id
-        .replaceAllLiterally("$", "%24")
-        .replaceAllLiterally("{", "%7B")
-        .replaceAllLiterally("}", "%7D")
-        .replaceAllLiterally(" ", "%20")
-    )
+  private[sbt] def toUri(vf: VirtualFile): URI = new URI("vf", "tmp", s"/${vf.id}", null)
 
   private[sbt] def fromUri(uri: URI): VirtualFileRef =
     if (uri.getScheme != "vf") sys.error(s"invalid URI for VirtualFileRef: $uri")
-    else {
-      val part = uri.getSchemeSpecificPart.stripPrefix("/tmp/")
-      val id = part
-        .replaceAllLiterally("%24", "$")
-        .replaceAllLiterally("%7B", "{")
-        .replaceAllLiterally("%7D", "}")
-        .replaceAllLiterally("%20", " ")
-      VirtualFileRef.of(id)
-    }
+    else VirtualFileRef.of(uri.getPath.stripPrefix("/"))
 }
 
 /** Implementation of javadoc tool which attempts to run it locally (in-class). */

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/MappedVirtualFile.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/MappedVirtualFile.scala
@@ -21,14 +21,9 @@ class MappedVirtualFile(encodedPath: String, rootPathsMap: Map[String, Path])
     extends BasicVirtualFileRef(encodedPath)
     with PathBasedFile {
   private def path: Path = {
-    rootPathsMap.toSeq.find({
-      case (idx, p) =>
-        encodedPath.startsWith("${" + idx + "}/")
-    }) match {
-      case Some((idx, p)) =>
-        p.resolve(encodedPath.drop(("${" + idx + "}/").size))
-      case None =>
-        Paths.get(encodedPath)
+    rootPathsMap.toSeq.find { case (key, _) => encodedPath.startsWith(s"$${$key}/") } match {
+      case Some((key, p)) => p.resolve(encodedPath.stripPrefix(s"$${$key}/"))
+      case None           => Paths.get(encodedPath)
     }
   }
   override def contentHash: Long = HashUtil.farmHash(path)
@@ -43,34 +38,24 @@ object MappedVirtualFile {
 
 class MappedFileConverter(rootPaths: Map[String, Path], allowMachinePath: Boolean)
     extends FileConverter {
-  val rootPathIdxUri: Seq[(String, String)] = rootPaths.toSeq flatMap {
-    case (idx, p) =>
-      val u = p.toUri.toString
-      if (u.startsWith("file:///var/folders/"))
-        Seq(
-          idx -> u,
-          idx -> u.replaceAllLiterally("file:///var/folders/", "file:///private/var/folders/")
-        )
-      else Seq(idx -> u)
+  val rootPaths2: Seq[(String, Path)] = rootPaths.toSeq.flatMap {
+    case (key, rootPath) =>
+      if (rootPath.startsWith("/var/") || rootPath.startsWith("/tmp/")) {
+        val rootPath2 = Paths.get("/private").resolve(Paths.get("/").relativize(rootPath))
+        Seq(key -> rootPath, key -> rootPath2)
+      } else Seq(key -> rootPath)
   }
 
   def toPath(ref: VirtualFileRef): Path = MappedVirtualFile(ref.id, rootPaths).toPath
   def toVirtualFile(path: Path): VirtualFile = {
-    val s = path.toUri.toString
-    rootPathIdxUri
-      .find({ case (idx, p) => s.startsWith(p) }) match {
-      case Some((idx, p)) =>
-        val encodedPath = s
-          .replaceAllLiterally(p, "${" + idx + "}/")
-          .replaceAllLiterally("%20", " ")
-        MappedVirtualFile(encodedPath, rootPaths)
+    rootPaths2.find { case (_, rootPath) => path.startsWith(rootPath) } match {
+      case Some((key, rootPath)) =>
+        MappedVirtualFile(s"$${$key}/${rootPath.relativize(path)}".replace('\\', '/'), rootPaths)
       case _ =>
-        val fileName = path.getFileName.toString
-        fileName match {
-          case "rt.jar" => DummyVirtualFile("rt.jar", path)
-          case _ =>
-            if (allowMachinePath) MappedVirtualFile(path.toString, rootPaths)
-            else sys.error(s"$s cannot be mapped using the root paths $rootPaths")
+        path.getFileName.toString match {
+          case "rt.jar"              => DummyVirtualFile("rt.jar", path)
+          case _ if allowMachinePath => MappedVirtualFile(s"$path".replace('\\', '/'), rootPaths)
+          case _                     => sys.error(s"$path cannot be mapped using the root paths $rootPaths")
         }
     }
   }


### PR DESCRIPTION
Because I have Artifactory set up as my ~/.sbt/repositories, the
scala-reflect that Zinc's "macros" scripted tests was using was the one
at:

    ~/Library/Caches/Coursier/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/scala-lang/scala-reflect/2.13.2/scala-reflect-2.13.2.jar

but because of how virtual files go through URI.toString, this was
being encoding that file path as:

    ~/Library/Caches/Coursier/v1/http/127.0.0.1%253A8081/artifactory/scala-ci-virtual/org/scala-lang/scala-reflect/2.13.2/scala-reflect-2.13.2.jar

Note the extra "25" (not sure why it's 25, btw).

So, stop URI encoding and use the NIO Path APIs to replace root paths.

Similarly, in LocalJava, use the right URI constructor to minimally
URL-encode and decode the path, adding & removing the needed /-prefix.