### PR TITLE
Exclude rt.jar from dependency tracking

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -459,13 +459,16 @@ private final class AnalysisCallback(
         val targetBinaryClassName = onBinaryName
         externalSourceDependency(sourceClassName, targetBinaryClassName, api, context)
       case None =>
-        // dependency is some other binary on the classpath
-        externalLibraryDependency(
-          vf,
-          onBinaryName,
-          sourceFile,
-          context
-        )
+        // dependency is some other binary on the classpath.
+        // exclude dependency tracking with rt.jar, for example java.lang.String -> rt.jar.
+        if (vf.name != "rt.jar") {
+          externalLibraryDependency(
+            vf,
+            onBinaryName,
+            sourceFile,
+            context
+          )
+        }
     }
   }
 

--- a/zinc/src/test/scala/sbt/inc/BinaryDepSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/BinaryDepSpec.scala
@@ -36,6 +36,8 @@ class BinaryDepSpec extends BaseCompilerSpec {
               analysis.relations.libraryDep._2s
                 .filter(_.id.startsWith(tempDir.toPath.toString)) shouldBe 'empty
 
+              analysis.relations.libraryDep._2s
+                .filter(_.name == "rt.jar") shouldBe 'empty
           }
         } finally {
           compiler2.close()


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/issues/5591

During virtualization I'm faked `rt.jar` since its path is somewhat unpredictable. This is a followup to exclude `rt.jar` from the dependency tracking.
