### PR TITLE
Use the real 2.12 scala.reflect.io.PlainNioFile

### DIFF
--- a/internal/compiler-bridge/src/main/scala-2.11/scala/ZincCompat.scala
+++ b/internal/compiler-bridge/src/main/scala-2.11/scala/ZincCompat.scala
@@ -1,0 +1,23 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Lightbend, Inc. and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+
+import java.nio.file.Path
+
+import scala.reflect.io.AbstractFile
+
+object ZincCompat {
+  type PlainNioFile = xsbt.PlainNioFile
+
+  def plainNioFile(path: Path): AbstractFile = new PlainNioFile(path)
+  def unwrapPlainNioFile(pf: PlainNioFile): Path = pf.nioPath
+}

--- a/internal/compiler-bridge/src/main/scala-2.11/xsbt/Compat.scala
+++ b/internal/compiler-bridge/src/main/scala-2.11/xsbt/Compat.scala
@@ -12,22 +12,16 @@
 package xsbt
 
 import java.io.PrintWriter
-import java.nio.file.Path
 import xsbti.compile.Output
 import scala.tools.nsc.Settings
-import scala.reflect.io.AbstractFile
 
 abstract class Compat
 object Compat {
-  type PlainNioFile = xsbt.PlainNioFile
-
   // IR is renamed to Results
   val Results = scala.tools.nsc.interpreter.IR
 
   // IMain in 2.13 accepts ReplReporter
   def replReporter(settings: Settings, writer: PrintWriter) = writer
-
-  def plainNioFile(path: Path): AbstractFile = new PlainNioFile(path)
 }
 
 /** Defines compatibility utils for [[ZincCompiler]]. */

--- a/internal/compiler-bridge/src/main/scala-2.12/scala/ZincCompat.scala
+++ b/internal/compiler-bridge/src/main/scala-2.12/scala/ZincCompat.scala
@@ -1,0 +1,27 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Lightbend, Inc. and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+
+import java.nio.file.Path
+
+import scala.reflect.io.AbstractFile
+
+object ZincCompat {
+  type PlainNioFile = scala.reflect.io.PlainNioFile
+
+  def plainNioFile(path: Path): AbstractFile = new PlainNioFile(path)
+  def unwrapPlainNioFile(pf: PlainNioFile): Path = {
+    val f = pf.getClass.getDeclaredField("nioPath") // it's not val'd in 2.12 :-/
+    f.setAccessible(true)
+    f.get(pf).asInstanceOf[Path]
+  }
+}

--- a/internal/compiler-bridge/src/main/scala-2.12/xsbt/Compat.scala
+++ b/internal/compiler-bridge/src/main/scala-2.12/xsbt/Compat.scala
@@ -14,16 +14,14 @@ package xsbt
 import java.io.PrintWriter
 import xsbti.compile.Output
 import scala.tools.nsc.Settings
-import scala.tools.nsc.interpreter.shell.ReplReporterImpl
 
 abstract class Compat
 object Compat {
   // IR is renamed to Results
-  val Results = scala.tools.nsc.interpreter.Results
+  val Results = scala.tools.nsc.interpreter.IR
 
   // IMain in 2.13 accepts ReplReporter
-  def replReporter(settings: Settings, writer: PrintWriter) =
-    new ReplReporterImpl(settings, writer)
+  def replReporter(settings: Settings, writer: PrintWriter) = writer
 }
 
 /** Defines compatibility utils for [[ZincCompiler]]. */

--- a/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
@@ -180,7 +180,7 @@ sealed class ZincCompiler(settings: Settings, dreporter: DelegatingReporter, out
             outputDirs
               .map(_.resolve(classFilePath))
               .find(Files.exists(_))
-              .map(Compat.plainNioFile(_))
+              .map(ZincCompat.plainNioFile(_))
       }
     }
 

--- a/internal/compiler-bridge/src/main/scala/xsbt/Dependency.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/Dependency.scala
@@ -137,9 +137,9 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile with 
               if (!ignore)
                 binaryDependency(zip.file.toPath, binaryClassName)
             }
-          case pf: xsbt.Compat.PlainNioFile =>
+          case pf: ZincCompat.PlainNioFile =>
             // The dependency comes from a class file
-            binaryDependency(pf.nioPath, binaryClassName)
+            binaryDependency(ZincCompat.unwrapPlainNioFile(pf), binaryClassName)
           case pf: PlainFile =>
             // The dependency comes from a class file
             binaryDependency(pf.file.toPath, binaryClassName)

--- a/internal/compiler-bridge/src/main/scala_2.10/scala/ZincCompat.scala
+++ b/internal/compiler-bridge/src/main/scala_2.10/scala/ZincCompat.scala
@@ -1,0 +1,23 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Lightbend, Inc. and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+
+import java.nio.file.Path
+
+import scala.reflect.io.AbstractFile
+
+object ZincCompat {
+  type PlainNioFile = xsbt.PlainNioFile
+
+  def plainNioFile(path: Path): AbstractFile = new PlainNioFile(path)
+  def unwrapPlainNioFile(pf: PlainNioFile): Path = pf.nioPath
+}

--- a/internal/compiler-bridge/src/main/scala_2.10/xsbt/Compat.scala
+++ b/internal/compiler-bridge/src/main/scala_2.10/xsbt/Compat.scala
@@ -12,11 +12,9 @@
 package xsbt
 
 import java.io.PrintWriter
-import java.nio.file.Path
 import xsbti.compile.Output
 import scala.reflect.{ internal => sri }
 import scala.reflect.internal.{ util => sriu }
-import scala.reflect.io.AbstractFile
 import scala.tools.nsc.{ Global, Settings }
 import scala.tools.nsc.interactive.RangePositions
 import scala.tools.nsc.symtab.Flags, Flags._
@@ -166,8 +164,6 @@ trait ZincGlobalCompat {
 }
 
 object Compat {
-  type PlainNioFile = xsbt.PlainNioFile
-
   // IR is renamed to Results
   val Results = scala.tools.nsc.interpreter.IR
 
@@ -188,8 +184,6 @@ object Compat {
     // Missing in 2.10
     @inline final def finalPosition: sriu.Position = self.source positionInUltimateSource self
   }
-
-  def plainNioFile(path: Path): AbstractFile = new PlainNioFile(path)
 }
 
 private trait CachedCompilerCompat { self: CachedCompiler0 =>

--- a/internal/compiler-bridge/src/main/scala_2.13/scala/ZincCompat.scala
+++ b/internal/compiler-bridge/src/main/scala_2.13/scala/ZincCompat.scala
@@ -1,0 +1,23 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Lightbend, Inc. and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+
+import java.nio.file.Path
+
+import scala.reflect.io.AbstractFile
+
+object ZincCompat {
+  type PlainNioFile = scala.reflect.io.PlainNioFile
+
+  def plainNioFile(path: Path): AbstractFile = new PlainNioFile(path)
+  def unwrapPlainNioFile(pf: PlainNioFile): Path = pf.nioPath
+}


### PR DESCRIPTION
In 2.12 scala.reflect.io.PlainNioFile is private[scala] with no nioPath 
val, so first we need to define the alias in the scala package and then we
need to unwrap it with Java reflection... :sadface:

Builds on #827.