### PR TITLE
Reluctantly restore compatibility of xsbti.*

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -367,6 +367,10 @@ lazy val zincCompileCore = (projectMatrix in internalPath / "zinc-compile-core")
   )
   .settings(
     name := "zinc Compile Core",
+    libraryDependencies ++= (scalaVersion.value match {
+      case v if v.startsWith("2.12.") => List(compilerPlugin(silencerPlugin))
+      case _                          => List()
+    }),
     libraryDependencies ++= Seq(
       scalaCompiler.value % Test,
       launcherInterface,
@@ -407,18 +411,18 @@ lazy val compilerInterface = (projectMatrix in internalPath / "compiler-interfac
     mimaSettings,
     mimaBinaryIssueFilters ++= Seq(
       // 1.4.0 changed to VirtualFile. These should be internal to Zinc.
-      exclude[Problem]("xsbti.AnalysisCallback.*"),
+      exclude[ReversedMissingMethodProblem]("xsbti.AnalysisCallback.*"),
       exclude[Problem]("xsbti.compile.PerClasspathEntryLookup.*"),
       exclude[Problem]("xsbti.compile.ExternalHooks*"),
       exclude[Problem]("xsbti.compile.FileHash.*"),
-      exclude[Problem]("xsbti.compile.Output.*"),
-      exclude[Problem]("xsbti.compile.OutputGroup.*"),
-      exclude[Problem]("xsbti.compile.SingleOutput.*"),
-      exclude[Problem]("xsbti.compile.MultipleOutput.*"),
-      exclude[Problem]("xsbti.compile.CachedCompiler.*"),
+      exclude[ReversedMissingMethodProblem]("xsbti.compile.Output.*"),
+      exclude[ReversedMissingMethodProblem]("xsbti.compile.OutputGroup.*"),
+      exclude[ReversedMissingMethodProblem]("xsbti.compile.SingleOutput.*"),
+      exclude[ReversedMissingMethodProblem]("xsbti.compile.MultipleOutput.*"),
+      exclude[ReversedMissingMethodProblem]("xsbti.compile.CachedCompiler.*"),
       exclude[Problem]("xsbti.compile.ClassFileManager.*"),
       exclude[Problem]("xsbti.compile.WrappedClassFileManager.*"),
-      exclude[Problem]("xsbti.compile.DependencyChanges.*"),
+      exclude[ReversedMissingMethodProblem]("xsbti.compile.DependencyChanges.*"),
       exclude[Problem]("xsbti.compile.ScalaCompiler.*"),
       exclude[Problem]("xsbti.compile.JavaTool.*"),
       exclude[Problem]("xsbti.compile.JavaTool.*"),

--- a/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
@@ -39,9 +39,9 @@ sealed abstract class CallbackGlobal(
 
   lazy val outputDirs: Iterable[Path] = {
     output match {
-      case single: SingleOutput => List(single.getOutputDirectory)
+      case single: SingleOutput => List(single.getOutputDirectoryAsPath)
       // Use Stream instead of List because Analyzer maps intensively over the directories
-      case multi: MultipleOutput => multi.getOutputGroups.toStream map (_.getOutputDirectory)
+      case multi: MultipleOutput => multi.getOutputGroups.toStream map (_.getOutputDirectoryAsPath)
     }
   }
 

--- a/internal/compiler-bridge/src/main/scala/xsbt/CompilerInterface.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CompilerInterface.scala
@@ -19,16 +19,16 @@ import scala.reflect.io.AbstractFile
 import Log.debug
 import java.io.File
 
-final class CompilerInterface {
-  def newCompiler(
+final class CompilerInterface extends CompilerInterface2 {
+  override def newCompiler(
       options: Array[String],
       output: Output,
       initialLog: Logger,
       initialDelegate: Reporter
-  ): CachedCompiler =
+  ): CachedCompiler2 =
     new CachedCompiler0(options, output, new WeakLog(initialLog, initialDelegate))
 
-  def run(
+  override def run(
       sources: Array[VirtualFile],
       changes: DependencyChanges,
       callback: AnalysisCallback,
@@ -63,7 +63,7 @@ private final class WeakLog(private[this] var log: Logger, private[this] var del
 }
 
 private final class CachedCompiler0(args: Array[String], output: Output, initialLog: WeakLog)
-    extends CachedCompiler
+    extends CachedCompiler2
     with CachedCompilerCompat
     with java.io.Closeable {
 
@@ -77,11 +77,11 @@ private final class CachedCompiler0(args: Array[String], output: Output, initial
       for (out <- multi.getOutputGroups)
         settings.outputDirs
           .add(
-            out.getSourceDirectory.toAbsolutePath.toString,
-            out.getOutputDirectory.toAbsolutePath.toString
+            out.getSourceDirectoryAsPath.toAbsolutePath.toString,
+            out.getOutputDirectoryAsPath.toAbsolutePath.toString
           )
     case single: SingleOutput =>
-      val outputFilepath = single.getOutputDirectory.toAbsolutePath
+      val outputFilepath = single.getOutputDirectoryAsPath.toAbsolutePath
       settings.outputDirs.setSingleOutput(outputFilepath.toString)
   }
 
@@ -115,7 +115,17 @@ private final class CachedCompiler0(args: Array[String], output: Output, initial
   def infoOnCachedCompiler(compilerId: String): String =
     s"[zinc] Running cached compiler $compilerId for Scala compiler $versionString"
 
-  def run(
+  // This is kept for compatibility purpose only.
+  override def run(
+      sources: Array[File],
+      changes: DependencyChanges,
+      callback: AnalysisCallback,
+      log: Logger,
+      delegate: Reporter,
+      progress: CompileProgress
+  ): Unit = ???
+
+  override def run(
       sources: Array[VirtualFile],
       changes: DependencyChanges,
       callback: AnalysisCallback,

--- a/internal/compiler-bridge/src/main/scala/xsbt/CompilerInterface.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CompilerInterface.scala
@@ -19,6 +19,9 @@ import scala.reflect.io.AbstractFile
 import Log.debug
 import java.io.File
 
+/**
+ * This is the entry point for the compiler bridge (implementation of CompilerInterface)
+ */
 final class CompilerInterface extends CompilerInterface2 {
   override def newCompiler(
       options: Array[String],
@@ -35,7 +38,7 @@ final class CompilerInterface extends CompilerInterface2 {
       log: Logger,
       delegate: Reporter,
       progress: CompileProgress,
-      cached: CachedCompiler
+      cached: CachedCompiler2
   ): Unit =
     cached.run(sources, changes, callback, log, delegate, progress)
 }
@@ -114,16 +117,6 @@ private final class CachedCompiler0(args: Array[String], output: Output, initial
   import scala.tools.nsc.Properties.versionString
   def infoOnCachedCompiler(compilerId: String): String =
     s"[zinc] Running cached compiler $compilerId for Scala compiler $versionString"
-
-  // This is kept for compatibility purpose only.
-  override def run(
-      sources: Array[File],
-      changes: DependencyChanges,
-      callback: AnalysisCallback,
-      log: Logger,
-      delegate: Reporter,
-      progress: CompileProgress
-  ): Unit = ???
 
   override def run(
       sources: Array[VirtualFile],

--- a/internal/compiler-bridge/src/main/scala/xsbt/CompilerInterface.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CompilerInterface.scala
@@ -119,8 +119,31 @@ private final class CachedCompiler0(args: Array[String], output: Output, initial
     s"[zinc] Running cached compiler $compilerId for Scala compiler $versionString"
 
   override def run(
+      sources: Array[File],
+      changes: DependencyChanges,
+      callback: AnalysisCallback,
+      log: Logger,
+      delegate: Reporter,
+      progress: CompileProgress
+  ): Unit = {
+    val srcs = sources.toList.map(AbstractFile.getFile(_)).sortBy(_.path)
+    doRun(srcs, callback, log, delegate, progress)
+  }
+
+  override def run(
       sources: Array[VirtualFile],
       changes: DependencyChanges,
+      callback: AnalysisCallback,
+      log: Logger,
+      delegate: Reporter,
+      progress: CompileProgress
+  ): Unit = {
+    val srcs = sources.toList.map(AbstractZincFile(_)).sortBy(_.underlying.id)
+    doRun(srcs, callback, log, delegate, progress)
+  }
+
+  private[this] def doRun(
+      sources: List[AbstractFile],
       callback: AnalysisCallback,
       log: Logger,
       delegate: Reporter,
@@ -129,7 +152,7 @@ private final class CachedCompiler0(args: Array[String], output: Output, initial
     debug(log, infoOnCachedCompiler(hashCode().toLong.toHexString))
     val dreporter = DelegatingReporter(settings, delegate)
     try {
-      run(sources.toList, changes, callback, log, dreporter, progress)
+      run(sources, callback, log, dreporter, progress)
     } finally {
       dreporter.dropDelegate()
     }
@@ -137,10 +160,11 @@ private final class CachedCompiler0(args: Array[String], output: Output, initial
 
   private def prettyPrintCompilationArguments(args: Array[String]) =
     args.mkString("[zinc] The Scala compiler is invoked with:\n\t", "\n\t", "")
+
   private val StopInfoError = "Compiler option supplied that disabled Zinc compilation."
+
   private[this] def run(
-      sources: List[VirtualFile],
-      changes: DependencyChanges,
+      sources: List[AbstractFile],
       callback: AnalysisCallback,
       log: Logger,
       underlyingReporter: DelegatingReporter,
@@ -157,10 +181,7 @@ private final class CachedCompiler0(args: Array[String], output: Output, initial
       compiler.set(callback, underlyingReporter)
       val run = new compiler.ZincRun(compileProgress)
 
-      val wrappedFiles = sources.map(AbstractZincFile(_))
-      val sortedSourceFiles: List[AbstractFile] =
-        wrappedFiles.sortWith(_.underlying.id < _.underlying.id)
-      run.compileFiles(sortedSourceFiles)
+      run.compileFiles(sources)
       processUnreportedWarnings(run)
       underlyingReporter.problems.foreach(
         p => callback.problem(p.category, p.position, p.message, p.severity, true)

--- a/internal/compiler-bridge/src/main/scala/xsbt/ScaladocInterface.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ScaladocInterface.scala
@@ -15,7 +15,7 @@ import xsbti.{ Logger, VirtualFile }
 import scala.reflect.io.AbstractFile
 import Log.debug
 
-class ScaladocInterface {
+class ScaladocInterface extends xsbti.compile.ScaladocInterface2 {
   def run(sources: Array[VirtualFile], args: Array[String], log: Logger, delegate: xsbti.Reporter) =
     (new Runner(sources, args, log, delegate)).run
 }

--- a/internal/compiler-interface/src/main/java/xsbti/AnalysisCallback.java
+++ b/internal/compiler-interface/src/main/java/xsbti/AnalysisCallback.java
@@ -18,6 +18,14 @@ import java.nio.file.Path;
 import java.util.EnumSet;
 
 public interface AnalysisCallback {
+
+    /**
+     * This is kept around for sbt-dotty.
+     * @deprecated Use @link{#startSource(VirtualFile)} instead. 
+     */
+    @Deprecated
+    void startSource(File source);
+
     /**
      * Set the source file mapped to a concrete {@link AnalysisCallback}.
      * @param source Source file mapped to this instance of {@link AnalysisCallback}.
@@ -44,6 +52,17 @@ public interface AnalysisCallback {
     void classDependency(String onClassName,
                          String sourceClassName,
                          DependencyContext context);
+
+    /**
+     * This is kept around for sbt-dotty.
+     * @deprecated Use @link{#binaryDependency(Path, String, String, VirtualFileRef, DependencyContext)} instead. 
+     */
+    @Deprecated
+    void binaryDependency(File onBinaryEntry,
+                          String onBinaryClassName,
+                          String fromClassName,
+                          File fromSourceFile,
+                          DependencyContext context);
 
     /**
      * Indicate that the class <code>fromClassName</code> depends on a class
@@ -78,6 +97,15 @@ public interface AnalysisCallback {
                           DependencyContext context);
 
     /**
+     * This is kept around for sbt-dotty.
+     * @deprecated Use @link{#generatedNonLocalClass(VirtualFileRef, Path, String, String)} instead. 
+     */
+    @Deprecated
+    void generatedNonLocalClass(File source,
+                                File classFile,
+                                String binaryClassName,
+                                String srcClassName);
+    /**
      * Map the source class name (<code>srcClassName</code>) of a top-level
      * Scala class coming from a given source file to a binary class name
      * (<code>binaryClassName</code>) coming from a given class file.
@@ -100,6 +128,13 @@ public interface AnalysisCallback {
                                 String srcClassName);
 
     /**
+     * This is kept around for sbt-dotty.
+     * @deprecated Use @link{#generatedLocalClass(VirtualFileRef, Path)} instead. 
+     */
+    @Deprecated
+    void generatedLocalClass(File source, File classFile);
+
+    /**
      * Map the product relation between <code>classFile</code> and
      * <code>source</code> to indicate that <code>classFile</code> is the
      * product of compilation from <code>source</code>.
@@ -110,12 +145,26 @@ public interface AnalysisCallback {
     void generatedLocalClass(VirtualFileRef source, Path classFile);
 
     /**
+     * This is kept around for sbt-dotty.
+     * @deprecated Use @link{#api(VirtualFileRef, xsbti.api.ClassLike)} instead. 
+     */
+    @Deprecated
+    void api(File sourceFile, xsbti.api.ClassLike classApi);
+
+    /**
      * Register a public API entry coming from a given source file.
      *
      * @param sourceFile Source file where <code>classApi</code> comes from.
      * @param classApi The extracted public class API.
      */
     void api(VirtualFileRef sourceFile, xsbti.api.ClassLike classApi);
+
+    /**
+     * This is kept around for sbt-dotty.
+     * @deprecated Use @link{#mainClass(VirtualFileRef, String)} instead. 
+     */
+    @Deprecated
+    void mainClass(File sourceFile, String className);
 
     /**
      * Register a class containing an entry point coming from a given source file.

--- a/internal/compiler-interface/src/main/java/xsbti/compile/CachedCompiler.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/CachedCompiler.java
@@ -44,20 +44,9 @@ public interface CachedCompiler {
    * @param logger The logger of the incremental compilation.
    * @param delegate The reporter that informs on the compiler's output.
    * @param progress The compiler progress associated with a Scala compiler.
-   * @deprecated Use run with VirtualFile instead.
+   * @deprecated Use CachedCompiler2#run with VirtualFile instead.
    */
   @Deprecated
   void run(File[] sources, DependencyChanges changes, AnalysisCallback callback, Logger logger, Reporter delegate, CompileProgress progress);
-  
-  /**
-   * Run the cached Scala compiler with inputs of incremental compilation.
-   *
-   * @param sources The source files to be compiled.
-   * @param changes The changes that have occurred since last compilation.
-   * @param callback The callback injected by the incremental compiler.
-   * @param logger The logger of the incremental compilation.
-   * @param delegate The reporter that informs on the compiler's output.
-   * @param progress The compiler progress associated with a Scala compiler.
-   */
-  void run(VirtualFile[] sources, DependencyChanges changes, AnalysisCallback callback, Logger logger, Reporter delegate, CompileProgress progress);
 }
+

--- a/internal/compiler-interface/src/main/java/xsbti/compile/CachedCompiler.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/CachedCompiler.java
@@ -25,25 +25,39 @@ import java.io.File;
  *
  */
 public interface CachedCompiler {
-	/**
-	 * Return an array of arguments that represent a command-line like
-	 * equivalent of a call to the Scala compiler, but without the command itself.
-	 *
-     * @param sources The source files that the compiler must compile.
-	 *
-	 * @return The array of arguments of the Scala compiler.
-	 */
-	String[] commandArguments(File[] sources);
+  /**
+   * * Return an array of arguments that represent a command-line like
+   * equivalent of a call to the Scala compiler, but without the command itself.
+   *
+   * @param sources The source files that the compiler must compile.
+   *
+   * @return The array of arguments of the Scala compiler.
+   */
+  String[] commandArguments(File[] sources);
 
-	/**
-	 * Run the cached Scala compiler with inputs of incremental compilation.
-	 *
-	 * @param sources The source files to be compiled.
-	 * @param changes The changes that have occurred since last compilation.
-	 * @param callback The callback injected by the incremental compiler.
-	 * @param logger The logger of the incremental compilation.
-	 * @param delegate The reporter that informs on the compiler's output.
-	 * @param progress The compiler progress associated with a Scala compiler.
-	 */
-	void run(VirtualFile[] sources, DependencyChanges changes, AnalysisCallback callback, Logger logger, Reporter delegate, CompileProgress progress);
+  /**
+   * Run the cached Scala compiler with inputs of incremental compilation.
+   *
+   * @param sources The source files to be compiled.
+   * @param changes The changes that have occurred since last compilation.
+   * @param callback The callback injected by the incremental compiler.
+   * @param logger The logger of the incremental compilation.
+   * @param delegate The reporter that informs on the compiler's output.
+   * @param progress The compiler progress associated with a Scala compiler.
+   * @deprecated Use run with VirtualFile instead.
+   */
+  @Deprecated
+  void run(File[] sources, DependencyChanges changes, AnalysisCallback callback, Logger logger, Reporter delegate, CompileProgress progress);
+  
+  /**
+   * Run the cached Scala compiler with inputs of incremental compilation.
+   *
+   * @param sources The source files to be compiled.
+   * @param changes The changes that have occurred since last compilation.
+   * @param callback The callback injected by the incremental compiler.
+   * @param logger The logger of the incremental compilation.
+   * @param delegate The reporter that informs on the compiler's output.
+   * @param progress The compiler progress associated with a Scala compiler.
+   */
+  void run(VirtualFile[] sources, DependencyChanges changes, AnalysisCallback callback, Logger logger, Reporter delegate, CompileProgress progress);
 }

--- a/internal/compiler-interface/src/main/java/xsbti/compile/CachedCompiler.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/CachedCompiler.java
@@ -14,7 +14,6 @@ package xsbti.compile;
 import xsbti.AnalysisCallback;
 import xsbti.Logger;
 import xsbti.Reporter;
-import xsbti.VirtualFile;
 import java.io.File;
 
 /**
@@ -22,7 +21,7 @@ import java.io.File;
  *
  * This cached compiler hides the implementation of a compiler by just
  * defining two operations: {@link #commandArguments(File[])} and
- *
+ * {@link #run(File[], DependencyChanges, AnalysisCallback, Logger, Reporter, CompileProgress)}.
  */
 public interface CachedCompiler {
   /**

--- a/internal/compiler-interface/src/main/java/xsbti/compile/CachedCompiler2.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/CachedCompiler2.java
@@ -25,16 +25,20 @@ import java.io.File;
  *
  */
 public interface CachedCompiler2 extends CachedCompiler {
-	/**
-	 * Run the cached Scala compiler with inputs of incremental compilation.
-	 *
-	 * @param sources The source files to be compiled.
-	 * @param changes The changes that have occurred since last compilation.
-	 * @param callback The callback injected by the incremental compiler.
-	 * @param logger The logger of the incremental compilation.
-	 * @param delegate The reporter that informs on the compiler's output.
-	 * @param progress The compiler progress associated with a Scala compiler.
-	 */
-	void run(VirtualFile[] sources, DependencyChanges changes, AnalysisCallback callback, Logger logger, Reporter delegate, CompileProgress progress);
+  default void run(File[] sources, DependencyChanges changes, AnalysisCallback callback, Logger logger, Reporter delegate, CompileProgress progress) {
+    throw new RuntimeException("run method with Array[File] is not supported for this compiler bridge (see sbt/zinc#829)"); 
+  }
+
+  /**
+   * Run the cached Scala compiler with inputs of incremental compilation.
+   *
+   * @param sources The source files to be compiled.
+   * @param changes The changes that have occurred since last compilation.
+   * @param callback The callback injected by the incremental compiler.
+   * @param logger The logger of the incremental compilation.
+   * @param delegate The reporter that informs on the compiler's output.
+   * @param progress The compiler progress associated with a Scala compiler.
+   */
+  void run(VirtualFile[] sources, DependencyChanges changes, AnalysisCallback callback, Logger logger, Reporter delegate, CompileProgress progress);
 }
 

--- a/internal/compiler-interface/src/main/java/xsbti/compile/CachedCompiler2.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/CachedCompiler2.java
@@ -1,0 +1,40 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Lightbend, Inc. and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package xsbti.compile;
+
+import xsbti.AnalysisCallback;
+import xsbti.Logger;
+import xsbti.Reporter;
+import xsbti.VirtualFile;
+import java.io.File;
+
+/**
+ * Define the interface of a cached Scala compiler that can be run.
+ *
+ * This cached compiler hides the implementation of a compiler by just
+ * defining two operations: {@link #commandArguments(File[])} and
+ *
+ */
+public interface CachedCompiler2 extends CachedCompiler {
+	/**
+	 * Run the cached Scala compiler with inputs of incremental compilation.
+	 *
+	 * @param sources The source files to be compiled.
+	 * @param changes The changes that have occurred since last compilation.
+	 * @param callback The callback injected by the incremental compiler.
+	 * @param logger The logger of the incremental compilation.
+	 * @param delegate The reporter that informs on the compiler's output.
+	 * @param progress The compiler progress associated with a Scala compiler.
+	 */
+	void run(VirtualFile[] sources, DependencyChanges changes, AnalysisCallback callback, Logger logger, Reporter delegate, CompileProgress progress);
+}
+

--- a/internal/compiler-interface/src/main/java/xsbti/compile/CachedCompiler2.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/CachedCompiler2.java
@@ -15,20 +15,17 @@ import xsbti.AnalysisCallback;
 import xsbti.Logger;
 import xsbti.Reporter;
 import xsbti.VirtualFile;
-import java.io.File;
+
+import java.io.Closeable;
 
 /**
  * Define the interface of a cached Scala compiler that can be run.
  *
  * This cached compiler hides the implementation of a compiler by just
- * defining two operations: {@link #commandArguments(File[])} and
- *
+ * defining one operation:
+ * {@link #run(VirtualFile[], DependencyChanges, AnalysisCallback, Logger, Reporter, CompileProgress)}.
  */
-public interface CachedCompiler2 extends CachedCompiler {
-  default void run(File[] sources, DependencyChanges changes, AnalysisCallback callback, Logger logger, Reporter delegate, CompileProgress progress) {
-    throw new RuntimeException("run method with Array[File] is not supported for this compiler bridge (see sbt/zinc#829)"); 
-  }
-
+public interface CachedCompiler2 extends CachedCompiler, Closeable {
   /**
    * Run the cached Scala compiler with inputs of incremental compilation.
    *
@@ -41,4 +38,3 @@ public interface CachedCompiler2 extends CachedCompiler {
    */
   void run(VirtualFile[] sources, DependencyChanges changes, AnalysisCallback callback, Logger logger, Reporter delegate, CompileProgress progress);
 }
-

--- a/internal/compiler-interface/src/main/java/xsbti/compile/CompilerInterface1.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/CompilerInterface1.java
@@ -1,0 +1,39 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Lightbend, Inc. and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package xsbti.compile;
+
+import java.io.File;
+import xsbti.AnalysisCallback;
+import xsbti.Logger;
+import xsbti.Reporter;
+import xsbti.VirtualFile;
+
+/** Compiler interface as of Zinc 1.2.0. */
+public interface CompilerInterface1 {
+  CachedCompiler newCompiler(
+    String[] options,
+    Output output,
+    Logger initialLog,
+    Reporter initialDelegate
+  );
+
+  void run(
+    File[] sources,
+    DependencyChanges changes,
+    AnalysisCallback callback,
+    Logger log,
+    Reporter delegate,
+    CompileProgress progress,
+    CachedCompiler cached
+  );
+}
+

--- a/internal/compiler-interface/src/main/java/xsbti/compile/CompilerInterface2.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/CompilerInterface2.java
@@ -31,7 +31,7 @@ public interface CompilerInterface2 {
     Logger log,
     Reporter delegate,
     CompileProgress progress,
-    CachedCompiler cached
+    CachedCompiler2 cached
   );
 }
 

--- a/internal/compiler-interface/src/main/java/xsbti/compile/CompilerInterface2.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/CompilerInterface2.java
@@ -1,0 +1,37 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Lightbend, Inc. and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package xsbti.compile;
+
+import xsbti.AnalysisCallback;
+import xsbti.Logger;
+import xsbti.Reporter;
+import xsbti.VirtualFile;
+
+public interface CompilerInterface2 {
+  CachedCompiler2 newCompiler(
+    String[] options,
+    Output output,
+    Logger initialLog,
+    Reporter initialDelegate
+  );
+
+  void run(
+    VirtualFile[] sources,
+    DependencyChanges changes,
+    AnalysisCallback callback,
+    Logger log,
+    Reporter delegate,
+    CompileProgress progress,
+    CachedCompiler cached
+  );
+}
+

--- a/internal/compiler-interface/src/main/java/xsbti/compile/ConsoleInterface1.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/ConsoleInterface1.java
@@ -1,0 +1,33 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Lightbend, Inc. and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package xsbti.compile;
+
+import xsbti.Logger;
+import xsbti.Reporter;
+
+/** Console Interface as of Zinc 1.2.0. */
+public interface ConsoleInterface1 {
+  void run(
+      String[] args,
+      String bootClasspathString,
+      String classpathString,
+      String initialCommands,
+      String cleanupCommands,
+      ClassLoader loader,
+      String[] bindNames,
+      Object[] bindValues,
+      Logger log);
+
+  String[] commandArguments(
+      String[] args, String bootClasspathString, String classpathString, Logger log);
+}
+

--- a/internal/compiler-interface/src/main/java/xsbti/compile/DependencyChanges.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/DependencyChanges.java
@@ -11,24 +11,34 @@
 
 package xsbti.compile;
 
+import java.io.File;
 import xsbti.VirtualFileRef;
 
 /**
  * Define the changes that can occur to the dependencies of a given compilation run.
  */
 public interface DependencyChanges {
-    /** Check whether there have been any change in the compilation dependencies. */
-	boolean isEmpty();
+  /** Check whether there have been any change in the compilation dependencies. */
+  boolean isEmpty();
 
-    /**
-     * Return the modified binaries since the last compilation run.
-     * These modified binaries are either class files or jar files.
-     */
-	VirtualFileRef[] modifiedLibraries();
+  /**
+   * Return the modified binaries since the last compilation run.
+   * These modified binaries are either class files or jar files.
+   * @deprecated Use @link{#modifiedLibraries()} instead.
+   */
+  @Deprecated
+  File[] modifiedBinaries();
 
-	/**
-	 * Return the modified class names since the last compilation run.
+  /**
+   * Return the modified binaries since the last compilation run.
+   * These modified binaries are either class files or jar files.
+   */
+  VirtualFileRef[] modifiedLibraries();
+
+  /**
+   * Return the modified class names since the last compilation run.
      * These class names are mapped to sources and not binaries.
-	 */
-	String[] modifiedClasses();
+   */
+  String[] modifiedClasses();
 }
+

--- a/internal/compiler-interface/src/main/java/xsbti/compile/MultipleOutput.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/MultipleOutput.java
@@ -11,6 +11,7 @@
 
 package xsbti.compile;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.util.Optional;
 
@@ -30,7 +31,12 @@ public interface MultipleOutput extends Output {
     public OutputGroup[] getOutputGroups();
 
     @Override
-    public default Optional<Path> getSingleOutput() {
+    public default Optional<File> getSingleOutput() {
+        return Optional.empty();
+    }
+
+    @Override
+    public default Optional<Path> getSingleOutputAsPath() {
         return Optional.empty();
     }
 

--- a/internal/compiler-interface/src/main/java/xsbti/compile/Output.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/Output.java
@@ -12,6 +12,7 @@
 package xsbti.compile;
 
 import java.nio.file.Path;
+import java.io.File;
 import java.io.Serializable;
 import java.util.Optional;
 
@@ -46,6 +47,17 @@ public interface Output extends Serializable {
      * If multiple outputs are used, it returns {@link java.util.Optional#EMPTY}.
      *
      * @see xsbti.compile.SingleOutput
+     * @deprecated use {@link #getSingleOutputAsPath()} instead.
      */
-    public Optional<Path> getSingleOutput();
+    @Deprecated
+    public Optional<File> getSingleOutput();
+
+    /**
+     * Returns the single output passed or to be passed to the Scala or Java compiler.
+     * If multiple outputs are used, it returns {@link java.util.Optional#EMPTY}.
+     *
+     * @see xsbti.compile.SingleOutput
+     */
+    public Optional<Path> getSingleOutputAsPath();
 }
+

--- a/internal/compiler-interface/src/main/java/xsbti/compile/OutputGroup.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/OutputGroup.java
@@ -11,6 +11,7 @@
 
 package xsbti.compile;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.io.Serializable;
 
@@ -23,8 +24,33 @@ public interface OutputGroup extends Serializable {
      * <p>
      * Note that source directories should uniquely identify the group
      * for a certain source file.
+     *
+     * @deprecated use {@link #getSourceDirectoryAsPath()} instead.
      */
-    public Path getSourceDirectory();
+    @Deprecated
+    public File getSourceDirectory();
+
+    /**
+     * Return the directory where source files are stored for this group.
+     * <p>
+     * Note that source directories should uniquely identify the group
+     * for a certain source file.
+     */
+    public default Path getSourceDirectoryAsPath() {
+        return getSourceDirectory().toPath();
+    }
+ 
+    /**
+     * Return the directory where class files should be generated.
+     * <p>
+     * Incremental compilation manages the class files in this directory, so
+     * don't play with this directory out of the Zinc API. Zinc already takes
+     * care of deleting classes before every compilation run.
+     * <p>
+     * This directory must be exclusively used for one set of sources.
+     */
+    @Deprecated
+    public File getOutputDirectory();
 
     /**
      * Return the directory where class files should be generated.
@@ -35,5 +61,8 @@ public interface OutputGroup extends Serializable {
      * <p>
      * This directory must be exclusively used for one set of sources.
      */
-    public Path getOutputDirectory();
+    public default Path getOutputDirectoryAsPath() {
+        return getOutputDirectory().toPath();
+    }
 }
+

--- a/internal/compiler-interface/src/main/java/xsbti/compile/ScalaCompiler.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/ScalaCompiler.java
@@ -12,6 +12,7 @@
 package xsbti.compile;
 
 import xsbti.AnalysisCallback;
+import xsbti.FileConverter;
 import xsbti.Logger;
 import xsbti.Reporter;
 import xsbti.VirtualFile;
@@ -36,28 +37,6 @@ public interface ScalaCompiler {
 	 * Recompile the subset of <code>sources</code> impacted by the
 	 * changes defined in <code>changes</code> and collect the new APIs.
 	 *
-	 * @param sources  All the sources of the project.
-	 * @param changes  The changes that have been detected at the previous step.
-	 * @param callback The callback to which the extracted information should be
-	 *                 reported.
-	 * @param log      The logger in which the Scala compiler will log info.
-	 * @param reporter The reporter to which errors and warnings should be
-	 *                 reported during compilation.
-	 * @param progress Where to report the file being currently compiled.
-	 * @param compiler The actual compiler that will perform the compilation step.
-	 */
-	void compile(VirtualFile[] sources,
-	             DependencyChanges changes,
-	             AnalysisCallback callback,
-	             Logger log,
-	             Reporter reporter,
-	             CompileProgress progress,
-	             CachedCompiler compiler);
-
-	/**
-	 * Recompile the subset of <code>sources</code> impacted by the
-	 * changes defined in <code>changes</code> and collect the new APIs.
-	 *
 	 * @param sources     All the sources of the project.
 	 * @param changes     The changes that have been detected at the previous step.
 	 * @param options     The arguments to give to the Scala compiler.
@@ -73,12 +52,14 @@ public interface ScalaCompiler {
 	 *                    will report on the file being compiled.
 	 */
 	void compile(VirtualFile[] sources,
+	             FileConverter converter,
 	             DependencyChanges changes,
 	             String[] options,
 	             Output output,
 	             AnalysisCallback callback,
 	             Reporter reporter,
 	             GlobalsCache cache,
-	             Logger log,
-	             Optional<CompileProgress> progressOpt);
+	             Optional<CompileProgress> progressOpt,
+				 Logger log);
 }
+

--- a/internal/compiler-interface/src/main/java/xsbti/compile/ScaladocInterface1.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/ScaladocInterface1.java
@@ -1,0 +1,21 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Lightbend, Inc. and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package xsbti.compile;
+
+import xsbti.Logger;
+import xsbti.Reporter;
+
+/** Scaladoc Interface as of Zinc 1.2.0. */
+public interface ScaladocInterface1 {
+  void run(String[] args, Logger log, Reporter delegate);
+}
+

--- a/internal/compiler-interface/src/main/java/xsbti/compile/ScaladocInterface2.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/ScaladocInterface2.java
@@ -1,0 +1,22 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Lightbend, Inc. and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package xsbti.compile;
+
+import xsbti.Logger;
+import xsbti.Reporter;
+import xsbti.VirtualFile;
+
+/** Scaladoc Interface as of Zinc 1.4.0. */
+public interface ScaladocInterface2 {
+  void run(VirtualFile[] sources, String[] args, Logger log, Reporter delegate);
+}
+

--- a/internal/compiler-interface/src/main/java/xsbti/compile/SingleOutput.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/SingleOutput.java
@@ -11,6 +11,7 @@
 
 package xsbti.compile;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.util.Optional;
 
@@ -29,16 +30,40 @@ public interface SingleOutput extends Output {
      * of deleting classes before every compilation run.
      * <p>
      * This file or directory must be exclusively used for one set of sources.
+     *
+     * @deprecated use {@link #getOutputDirectoryAsPath()} instead.
      */
-    public Path getOutputDirectory();
+    @Deprecated
+    public File getOutputDirectory();
+
+    /**
+     * Return the **directory or jar** where class files should be generated
+     * and written to. The method name is a misnamer since it can return a
+     * jar file when straight-to-jar compilation is enabled.
+     * <p>
+     * Incremental compilation manages the class files in this file, so don't
+     * play with this directory out of the Zinc API. Zinc already takes care
+     * of deleting classes before every compilation run.
+     * <p>
+     * This file or directory must be exclusively used for one set of sources.
+     */
+    public default Path getOutputDirectoryAsPath() {
+        return getOutputDirectory().toPath();
+    }
 
     @Override
-    public default Optional<Path> getSingleOutput() {
+    public default Optional<File> getSingleOutput() {
         return Optional.of(getOutputDirectory());
     }
 
+    @Override
+    public default Optional<Path> getSingleOutputAsPath() {
+        return Optional.of(getOutputDirectoryAsPath());
+    }
+    
     @Override
     public default Optional<OutputGroup[]> getMultipleOutput() {
         return Optional.empty();
     }
 }
+

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/JarUtils.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/JarUtils.scala
@@ -317,7 +317,7 @@ object JarUtils {
   def getOutputJar(output: Output): Option[Path] = {
     output match {
       case s: SingleOutput =>
-        Some(s.getOutputDirectory).filter(_.toString.endsWith(".jar"))
+        Some(s.getOutputDirectoryAsPath).filter(_.toString.endsWith(".jar"))
       case _ => None
     }
   }

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/JavaAnalyze.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/JavaAnalyze.scala
@@ -45,7 +45,7 @@ private[sbt] object JavaAnalyze {
       .groupBy(_.name)
     // For performance reasons, precompute these as they are static throughout this analysis
     val outputJarOrNull: Path = finalJarOutput.getOrElse(null)
-    val singleOutputOrNull: Path = output.getSingleOutput.orElse(null)
+    val singleOutputOrNull: Path = output.getSingleOutputAsPath.orElse(null)
 
     def load(tpe: String, errMsg: => Option[String]): Option[Class[_]] = {
       if (tpe.endsWith("module-info")) None

--- a/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/JavaCompilerForUnitTesting.scala
+++ b/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/JavaCompilerForUnitTesting.scala
@@ -87,7 +87,10 @@ object JavaCompilerForUnitTesting {
       // - extract all base classes.
       // we extract just parents as this is enough for testing
 
-      val output = new SingleOutput { def getOutputDirectory: Path = classesDir.toPath }
+      val output = new SingleOutput {
+        override def getOutputDirectoryAsPath: Path = classesDir.toPath
+        override def getOutputDirectory: File = getOutputDirectoryAsPath.toFile
+      }
       JavaAnalyze(classFiles, srcFiles, logger, output, finalJarOutput = None)(
         analysisCallback,
         classloader,

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala
@@ -81,7 +81,9 @@ final class AnalyzingCompiler(
       progressOpt: Optional[CompileProgress],
       log: xLogger
   ): Unit = {
-    val cached = cache(options, output, !changes.isEmpty, this, log, reporter)
+    val cached = cache(options, output, !changes.isEmpty, this, log, reporter) match {
+      case c: CachedCompiler2 => c
+    }
     try {
       val progress = if (progressOpt.isPresent) progressOpt.get else IgnoreProgress
       compile(sources, converter, changes, callback, log, reporter, progress, cached)
@@ -101,7 +103,7 @@ final class AnalyzingCompiler(
       log: xLogger,
       reporter: Reporter,
       progress: CompileProgress,
-      compiler: CachedCompiler
+      compiler: CachedCompiler2
   ): Unit = {
     val (bridge, bridgeClass) = bridgeInstance(compilerBridgeClassName, log)
     bridge match {

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompileOutput.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompileOutput.scala
@@ -14,6 +14,7 @@ package internal
 package inc
 
 import xsbti.compile.{ Output, OutputGroup }
+import java.io.File
 import java.nio.file.Path
 import java.util.Optional
 
@@ -53,13 +54,15 @@ object CompileOutput {
     new ConcreteOutputGroup(source, output)
 
   private final class EmptyOutput extends xsbti.compile.Output {
-    override def getSingleOutput(): Optional[Path] = Optional.empty()
+    override def getSingleOutput(): Optional[File] = Optional.empty()
+    override def getSingleOutputAsPath(): Optional[Path] = Optional.empty()
     override def getMultipleOutput(): Optional[Array[OutputGroup]] = Optional.empty()
     override def toString: String = "EmptyOutput()"
   }
 
-  private final class ConcreteSingleOutput(val getOutputDirectory: Path)
+  private final class ConcreteSingleOutput(override val getOutputDirectoryAsPath: Path)
       extends xsbti.compile.SingleOutput {
+    override def getOutputDirectory: File = getOutputDirectoryAsPath.toFile
     override def toString: String = s"SingleOutput($getOutputDirectory)"
   }
 
@@ -69,9 +72,11 @@ object CompileOutput {
   }
 
   private final class ConcreteOutputGroup(
-      val getSourceDirectory: Path,
-      val getOutputDirectory: Path
+      override val getSourceDirectoryAsPath: Path,
+      override val getOutputDirectoryAsPath: Path
   ) extends xsbti.compile.OutputGroup {
-    override def toString = s"OutputGroup($getSourceDirectory -> $getOutputDirectory)"
+    override def getSourceDirectory: File = getSourceDirectoryAsPath.toFile
+    override def getOutputDirectory: File = getOutputDirectoryAsPath.toFile
+    override def toString = s"OutputGroup($getSourceDirectoryAsPath -> $getOutputDirectoryAsPath)"
   }
 }

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala
@@ -190,7 +190,7 @@ object CompilerArguments {
      * make use of it (e.g. the Eclipse compiler does this via EJC).
      * See https://github.com/sbt/zinc/issues/163. */
     val target = output match {
-      case so: SingleOutput  => Some(so.getOutputDirectory)
+      case so: SingleOutput  => Some(so.getOutputDirectoryAsPath)
       case _: MultipleOutput => None
     }
     outputOption(target)

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerCache.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerCache.scala
@@ -16,6 +16,7 @@ package inc
 import java.io.File
 import java.util
 
+import com.github.ghik.silencer.silent
 import xsbti.{ AnalysisCallback, Reporter, Logger => xLogger }
 import xsbti.compile._
 import sbt.util.InterfaceUtil.{ toSupplier => f0 }
@@ -56,6 +57,17 @@ final class CompilerCache(val maxInstances: Int) extends GlobalsCache {
         val newCompiler: CachedCompiler = new CachedCompiler with java.io.Closeable {
           override def commandArguments(sources: Array[File]): Array[String] = {
             compiler.commandArguments(sources)
+          }
+          @silent
+          override def run(
+              sources: Array[File],
+              changes: DependencyChanges,
+              callback: AnalysisCallback,
+              logger: xLogger,
+              delegate: Reporter,
+              progress: CompileProgress
+          ): Unit = {
+            compiler.run(sources, changes, callback, logger, delegate, progress)
           }
           override def run(
               sources: Array[VirtualFile],

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Analysis.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Analysis.scala
@@ -14,6 +14,7 @@ package internal
 package inc
 
 import sbt.internal.inc.Analysis.{ LocalProduct, NonLocalProduct }
+import java.io.File
 import java.nio.file.{ Path, Paths }
 
 import xsbti.VirtualFileRef
@@ -126,7 +127,8 @@ object Analysis {
     }
 
   lazy val dummyOutput: Output = new SingleOutput {
-    def getOutputDirectory: Path = Paths.get("/tmp/dummy")
+    override def getOutputDirectoryAsPath: Path = Paths.get("/tmp/dummy")
+    override def getOutputDirectory: File = getOutputDirectoryAsPath.toFile
   }
 }
 

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
@@ -860,7 +860,8 @@ object IncrementalCommon {
     }
   }
 
-  def emptyChanges: DependencyChanges = new DependencyChanges {
+  lazy val emptyChanges: DependencyChanges = new DependencyChanges {
+    override val modifiedBinaries = new Array[java.io.File](0)
     override val modifiedLibraries = new Array[VirtualFileRef](0)
     override val modifiedClasses = new Array[String](0)
     override def isEmpty = true

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/MiniSetupUtil.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/MiniSetupUtil.scala
@@ -85,7 +85,7 @@ object MiniSetupUtil {
   implicit val equivOutput: Equiv[APIOutput] = {
     new Equiv[APIOutput] {
       implicit val outputGroupsOrdering =
-        Ordering.by((og: OutputGroup) => og.getSourceDirectory)
+        Ordering.by((og: OutputGroup) => og.getSourceDirectoryAsPath)
 
       def equiv(out1: APIOutput, out2: APIOutput) = (out1, out2) match {
         case (m1: MultipleOutput, m2: MultipleOutput) =>
@@ -93,11 +93,11 @@ object MiniSetupUtil {
             (m1.getOutputGroups.sorted zip m2.getOutputGroups.sorted forall {
               case (a, b) =>
                 equivFile
-                  .equiv(a.getSourceDirectory, b.getSourceDirectory) && equivFile
-                  .equiv(a.getOutputDirectory, b.getOutputDirectory)
+                  .equiv(a.getSourceDirectoryAsPath, b.getSourceDirectoryAsPath) && equivFile
+                  .equiv(a.getOutputDirectoryAsPath, b.getOutputDirectoryAsPath)
             })
         case (s1: SingleOutput, s2: SingleOutput) =>
-          equivFile.equiv(s1.getOutputDirectory, s2.getOutputDirectory)
+          equivFile.equiv(s1.getOutputDirectoryAsPath, s2.getOutputDirectoryAsPath)
         case _ =>
           false
       }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/VirtualFileUtil.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/VirtualFileUtil.scala
@@ -26,7 +26,9 @@ object VirtualFileUtil {
   implicit val sbtInternalIncVirtualFileRefOrdering: Ordering[VirtualFileRef] = Ordering.by(_.id)
 
   def outputDirectory(output: Output): Path =
-    output.getSingleOutput.orElseThrow(() => new RuntimeException(s"unexpected output $output"))
+    output.getSingleOutputAsPath.orElseThrow(
+      () => new RuntimeException(s"unexpected output $output")
+    )
 
   def sourcePositionMapper(converter: FileConverter): Position => Position =
     new DelegatingPosition(_, converter)

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/binary/converters/ProtobufWriters.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/binary/converters/ProtobufWriters.scala
@@ -119,8 +119,8 @@ final class ProtobufWriters(mapper: WriteMapper) {
   }
 
   def toOutputGroup(outputGroup: OutputGroup): Schema.OutputGroup = {
-    val newSource = mapper.mapSourceDir(outputGroup.getSourceDirectory)
-    val newTarget = mapper.mapOutputDir(outputGroup.getOutputDirectory)
+    val newSource = mapper.mapSourceDir(outputGroup.getSourceDirectoryAsPath)
+    val newTarget = mapper.mapOutputDir(outputGroup.getOutputDirectoryAsPath)
     val sourcePath = toStringPath(newSource)
     val targetPath = toStringPath(newTarget)
     Schema.OutputGroup.newBuilder
@@ -135,7 +135,7 @@ final class ProtobufWriters(mapper: WriteMapper) {
   ): Schema.Compilation.Builder = {
     output match {
       case single0: SingleOutput =>
-        val newOutputDir = mapper.mapOutputDir(single0.getOutputDirectory)
+        val newOutputDir = mapper.mapOutputDir(single0.getOutputDirectoryAsPath)
         val targetPath = toStringPath(newOutputDir)
         val single = Schema.SingleOutput.newBuilder.setTarget(targetPath).build
         builder.setSingleOutput(single)
@@ -264,7 +264,7 @@ final class ProtobufWriters(mapper: WriteMapper) {
   ): Schema.MiniSetup.Builder =
     output match {
       case single0: SingleOutput =>
-        val newOutputDir = mapper.mapOutputDir(single0.getOutputDirectory)
+        val newOutputDir = mapper.mapOutputDir(single0.getOutputDirectoryAsPath)
         val targetPath = toStringPath(newOutputDir)
         val single = Schema.SingleOutput.newBuilder.setTarget(targetPath).build
         builder.setSingleOutput(single)

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/text/TextAnalysisFormat.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/text/TextAnalysisFormat.scala
@@ -428,10 +428,12 @@ object TextAnalysisFormat extends TextAnalysisFormat(ReadWriteMappers.getEmptyMa
       val (mode, outputAsMap) = Analysis.dummyOutput match {
         case s: SingleOutput =>
           // just to be compatible with multipleOutputMode
-          val ignored = s.getOutputDirectory
-          (singleOutputMode, Map(ignored -> s.getOutputDirectory))
+          val ignored = s.getOutputDirectoryAsPath
+          (singleOutputMode, Map(ignored -> s.getOutputDirectoryAsPath))
         case m: MultipleOutput =>
-          val map = m.getOutputGroups.map(x => x.getSourceDirectory -> x.getOutputDirectory).toMap
+          val map = m.getOutputGroups
+            .map(x => x.getSourceDirectoryAsPath -> x.getOutputDirectoryAsPath)
+            .toMap
           (multipleOutputMode, map)
       }
       val mappedClasspathHash = setup.options.classpathHash

--- a/internal/zinc-persist/src/test/scala/sbt/inc/AnalysisFormatHelpers.scala
+++ b/internal/zinc-persist/src/test/scala/sbt/inc/AnalysisFormatHelpers.scala
@@ -32,7 +32,7 @@ object AnalysisFormatHelpers {
   val mappers: ReadWriteMappers = ReadWriteMappers.getMachineIndependentMappers(RootFilePath)
 
   val commonSetup: MiniSetup = {
-    val output: SingleOutput = () => RootFilePath.resolve("out")
+    val output: Output = CompileOutput(RootFilePath.resolve("out"))
     val opts = MiniOptions.of(Array(), Array(), Array())
     MiniSetup.of(output, opts, "2.10.4", Mixed, true, Array(t2("key" -> "value")))
   }

--- a/internal/zinc-testing/src/main/scala/xsbti/TestCallback.scala
+++ b/internal/zinc-testing/src/main/scala/xsbti/TestCallback.scala
@@ -11,6 +11,7 @@
 
 package xsbti
 
+import java.io.File
 import java.nio.file.Path
 import java.util
 
@@ -37,6 +38,7 @@ class TestCallback extends AnalysisCallback {
 
   def usedNames = usedNamesAndScopes.mapValues(_.map(_.name))
 
+  override def startSource(source: File): Unit = ???
   override def startSource(source: VirtualFile): Unit = {
     assert(
       !apis.contains(source),
@@ -56,6 +58,14 @@ class TestCallback extends AnalysisCallback {
   }
 
   override def binaryDependency(
+      classFile: File,
+      onBinaryClassName: String,
+      fromClassName: String,
+      fromSourceFile: File,
+      context: DependencyContext
+  ): Unit = ???
+
+  override def binaryDependency(
       onBinary: Path,
       onBinaryClassName: String,
       fromClassName: String,
@@ -65,6 +75,13 @@ class TestCallback extends AnalysisCallback {
     binaryDependencies += ((onBinary, onBinaryClassName, fromClassName, context))
     ()
   }
+
+  override def generatedNonLocalClass(
+      sourceFile: File,
+      classFile: File,
+      binaryClassName: String,
+      srcClassName: String
+  ): Unit = ???
 
   override def generatedNonLocalClass(
       sourceFile: VirtualFileRef,
@@ -78,6 +95,11 @@ class TestCallback extends AnalysisCallback {
   }
 
   override def generatedLocalClass(
+      sourceFile: File,
+      classFile: File
+  ): Unit = ???
+
+  override def generatedLocalClass(
       sourceFile: VirtualFileRef,
       classFile: Path
   ): Unit = {
@@ -88,10 +110,14 @@ class TestCallback extends AnalysisCallback {
   def usedName(className: String, name: String, scopes: util.EnumSet[UseScope]): Unit =
     usedNamesAndScopes(className) += TestUsedName(name, scopes)
 
+  override def api(source: File, api: ClassLike): Unit = ???
+
   override def api(source: VirtualFileRef, api: ClassLike): Unit = {
     apis(source) += api
     ()
   }
+
+  override def mainClass(source: File, className: String): Unit = ()
 
   override def mainClass(source: VirtualFileRef, className: String): Unit = ()
 

--- a/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
@@ -280,11 +280,11 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
         val numberSources = s"$sourceCount sources"
         val outputString = output match {
           case singleOutput: SingleOutput =>
-            singleOutput.getOutputDirectory().toString
+            singleOutput.getOutputDirectoryAsPath().toString
           case multiOutput: MultipleOutput =>
             multiOutput
               .getOutputGroups()
-              .map(_.getOutputDirectory().toString)
+              .map(_.getOutputDirectoryAsPath().toString)
               .mkString("[", ", ", "]")
           case _ =>
             s"other output ($output)"

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -81,7 +81,7 @@ final class MixedAnalyzingCompiler(
     logInputs(log, javaSrcs.size, scalaSrcs.size, outputDirs)
     val isPickleJava = config.currentSetup.order == Mixed && config.incOptions.pipelining && javaSrcs.nonEmpty
 
-    val earlyOut = config.earlyOutput.flatMap(_.getSingleOutput.toOption)
+    val earlyOut = config.earlyOutput.flatMap(_.getSingleOutputAsPath.toOption)
     val pickleWrite = earlyOut.toList.flatMap { out =>
       val sbv = scalac.scalaInstance.version.take(4)
       if (out.toString.endsWith(".jar") && !Files.exists(out))
@@ -105,14 +105,15 @@ final class MixedAnalyzingCompiler(
           timed("Scala compilation", log) {
             config.compiler.compile(
               sources.toArray,
+              config.converter,
               changes,
               arguments.toArray,
               output,
               callback,
               config.reporter,
               config.cache,
-              log,
-              config.progress.toOptional
+              config.progress.toOptional,
+              log
             )
           }
         }
@@ -197,8 +198,8 @@ final class MixedAnalyzingCompiler(
 
   private[this] def outputDirectories(output: Output): Seq[Path] = {
     output match {
-      case single: SingleOutput => List(single.getOutputDirectory)
-      case mult: MultipleOutput => mult.getOutputGroups map (_.getOutputDirectory)
+      case single: SingleOutput => List(single.getOutputDirectoryAsPath)
+      case mult: MultipleOutput => mult.getOutputGroups map (_.getOutputDirectoryAsPath)
     }
   }
 

--- a/zinc/src/main/scala/sbt/internal/inc/javac/AnalyzingJavaCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/javac/AnalyzingJavaCompiler.scala
@@ -117,18 +117,18 @@ final class AnalyzingJavaCompiler private[sbt] (
       // Outline chunks of compiles so that .class files end up in right location
       val chunks: Map[Option[Path], Seq[VirtualFile]] = output match {
         case single: SingleOutput =>
-          Map(Option(single.getOutputDirectory) -> sources)
+          Map(Option(single.getOutputDirectoryAsPath) -> sources)
         case multi: MultipleOutput =>
           sources.groupBy { src =>
             multi.getOutputGroups
               .find { out =>
                 val sourceDir: VirtualFileRef = sourceDirs.getOrElseUpdate(
-                  out.getSourceDirectory,
-                  converter.toVirtualFile(out.getSourceDirectory)
+                  out.getSourceDirectoryAsPath,
+                  converter.toVirtualFile(out.getSourceDirectoryAsPath)
                 )
                 src.id.startsWith(sourceDir.id)
               }
-              .map(_.getOutputDirectory)
+              .map(_.getOutputDirectoryAsPath)
           }
       }
 


### PR DESCRIPTION
Fixes https://github.com/sbt/zinc/issues/779

As it stands, compiler-interface and compiler bridge implementation are of internal concern of Zinc implementation. We _should_ be able to remove methods or change the method signatures. The word "interface" here is between Scalac and Zinc internal, not to the world.

In reality, the situation is more complicated because we have Dotty compiler out there that is bound to specific version of compiler-interface. So when I released sbt 1.4.0-M1 this resulted in NoSuchMethodErrors:

```
[error] ## Exception when compiling 1 sources to /private/tmp/hello-dotty/target/scala-0.24/classes
[error] java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
[error] xsbt.CompilerInterface.newCompiler(CompilerInterface.java:35)
....
[error] Caused by: java.lang.NoSuchMethodError: xsbti.compile.SingleOutput.getOutputDirectory()Ljava/io/File;
[error]   at xsbt.CachedCompilerImpl.<init>(CachedCompilerImpl.java:35)
```

To smooth things out, one approach we've discussed is to create a separate compiler-interface (in a different package) that is less dependent on Zinc specifics. Related to that, in https://github.com/sbt/zinc/pull/661 I've created Java interface for `CompilerInterface1`, and we can use pattern matching to see which capability the compiler bridge implementation supports. This PR brings in the Java interfaces proposed in #661 + scala/compiler-interface.

In any case, this commit brings back the old `java.io.File`-based methods, and locally I was able to get hello world from Dotty.