### PR TITLE
xsbti.* compatibility follow-up

### DIFF
--- a/internal/compiler-bridge-test/src/test/scala/sbt/internal/inc/CompilingSpecification.scala
+++ b/internal/compiler-bridge-test/src/test/scala/sbt/internal/inc/CompilingSpecification.scala
@@ -211,7 +211,6 @@ trait CompilingSpecification extends BridgeProviderSpecification {
         val reporter = ReporterManager.getReporter(log, reporterConfig)
         sc.compile(
           sources = sources,
-          converter = converter,
           changes = emptyChanges,
           options = arguments.toArray,
           output = CompileOutput(targetDir.toPath),

--- a/internal/compiler-interface/src/main/java/xsbti/compile/ScalaCompiler.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/ScalaCompiler.java
@@ -17,49 +17,84 @@ import xsbti.Logger;
 import xsbti.Reporter;
 import xsbti.VirtualFile;
 
+import java.io.File;
 import java.util.Optional;
 
 /**
  * Represent the interface of a Scala compiler.
  */
 public interface ScalaCompiler {
-	/**
-	 * Return the {@link ScalaInstance} used by this instance of the compiler.
-	 */
-	ScalaInstance scalaInstance();
+  /**
+   * Return the {@link ScalaInstance} used by this instance of the compiler.
+   */
+  ScalaInstance scalaInstance();
 
-	/**
-	 * Return the {@link ClasspathOptions} used by this instance of the compiler.
-	 */
-	ClasspathOptions classpathOptions();
+  /**
+   * Return the {@link ClasspathOptions} used by this instance of the compiler.
+   */
+  ClasspathOptions classpathOptions();
 
-	/**
-	 * Recompile the subset of <code>sources</code> impacted by the
-	 * changes defined in <code>changes</code> and collect the new APIs.
-	 *
-	 * @param sources     All the sources of the project.
-	 * @param changes     The changes that have been detected at the previous step.
-	 * @param options     The arguments to give to the Scala compiler.
-	 *                    For more information, run `scalac -help`.
-	 * @param output      The location where generated class files should be put.
-	 * @param callback    The callback to which the extracted information should
-	 *                    be reported.
-	 * @param reporter    The reporter to which errors and warnings should be
-	 *                    reported during compilation.
-	 * @param cache       The cache from where we retrieve the compiler to use.
-	 * @param log         The logger in which the Scala compiler will log info.
-	 * @param progressOpt The progress interface in which the Scala compiler
-	 *                    will report on the file being compiled.
-	 */
-	void compile(VirtualFile[] sources,
-	             FileConverter converter,
-	             DependencyChanges changes,
-	             String[] options,
-	             Output output,
-	             AnalysisCallback callback,
-	             Reporter reporter,
-	             GlobalsCache cache,
-	             Optional<CompileProgress> progressOpt,
-				 Logger log);
+  /**
+   * Return 2 for CompilerInterface2.
+   * Return 1 for CompilerInterface1.
+   * Return 0 otherwise.
+   */
+  int bridgeCompatibilityLevel(Logger log);
+
+  /**
+   * Recompile the subset of <code>sources</code> impacted by the
+   * changes defined in <code>changes</code> and collect the new APIs.
+   *
+   * @param sources     All the sources of the project.
+   * @param changes     The changes that have been detected at the previous step.
+   * @param options     The arguments to give to the Scala compiler.
+   *                    For more information, run `scalac -help`.
+   * @param output      The location where generated class files should be put.
+   * @param callback    The callback to which the extracted information should
+   *                    be reported.
+   * @param reporter    The reporter to which errors and warnings should be
+   *                    reported during compilation.
+   * @param cache       The cache from where we retrieve the compiler to use.
+   * @param log         The logger in which the Scala compiler will log info.
+   * @param progressOpt The progress interface in which the Scala compiler
+   *                    will report on the file being compiled.
+   */
+  void compile(File[] sources,
+               DependencyChanges changes,
+               String[] options,
+               Output output,
+               AnalysisCallback callback,
+               Reporter reporter,
+               GlobalsCache cache,
+               Optional<CompileProgress> progressOpt,
+               Logger log);
+
+  /**
+   * Recompile the subset of <code>sources</code> impacted by the
+   * changes defined in <code>changes</code> and collect the new APIs.
+   *
+   * @param sources     All the sources of the project.
+   * @param changes     The changes that have been detected at the previous step.
+   * @param options     The arguments to give to the Scala compiler.
+   *                    For more information, run `scalac -help`.
+   * @param output      The location where generated class files should be put.
+   * @param callback    The callback to which the extracted information should
+   *                    be reported.
+   * @param reporter    The reporter to which errors and warnings should be
+   *                    reported during compilation.
+   * @param cache       The cache from where we retrieve the compiler to use.
+   * @param log         The logger in which the Scala compiler will log info.
+   * @param progressOpt The progress interface in which the Scala compiler
+   *                    will report on the file being compiled.
+   */
+  void compile(VirtualFile[] sources,
+               DependencyChanges changes,
+               String[] options,
+               Output output,
+               AnalysisCallback callback,
+               Reporter reporter,
+               GlobalsCache cache,
+               Optional<CompileProgress> progressOpt,
+               Logger log);
 }
 

--- a/internal/zinc-compile-core/src/main/java/xsbti/compile/CompilerCache.java
+++ b/internal/zinc-compile-core/src/main/java/xsbti/compile/CompilerCache.java
@@ -16,13 +16,12 @@ package xsbti.compile;
  */
 public interface CompilerCache {
     /**
-     * Returns a compiler cache that manages up until <b>5</b> cached Scala compilers,
-     * where 5 is the default number.
+     * Returns a compiler cache that returns a fresh cached Scala compiler.
      *
      * @return A default compiler cache.
      */
     public static GlobalsCache getDefault() {
-        return createCacheFor(5);
+        return fresh();
     }
 
     /**

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala
@@ -62,24 +62,41 @@ final class CompilerArguments(
     CompilerArguments.outputOption(output) ++
       makeArguments(sources, classpath, options)
 
+  def makeArguments0(
+      sources: Seq[VirtualFile],
+      classpath: Seq[Path],
+      output: Option[Path],
+      options: Seq[String]
+  ): Seq[String] =
+    CompilerArguments.outputOption(output) ++
+      makeArguments0(sources, classpath, options)
+
   def makeArguments(
       sources: Seq[VirtualFile],
       classpath: Seq[VirtualFile],
+      options: Seq[String]
+  ): Seq[String] =
+    makeArguments0(
+      sources,
+      classpath map { case x: PathBasedFile => x.toPath },
+      options
+    )
+
+  def makeArguments0(
+      sources: Seq[VirtualFile],
+      classpath: Seq[Path],
       options: Seq[String]
   ): Seq[String] = {
     /* Add dummy to avoid Scalac misbehaviour for empty classpath (as of 2.9.1). */
     def dummy: String = "dummy_" + Integer.toHexString(util.Random.nextInt)
 
     checkScalaHomeUnset()
-    val cp = classpath map {
-      case x: PathBasedFile => x.toPath
-    }
-    val compilerClasspath = finishClasspath(cp)
+    val compilerClasspath = finishClasspath(classpath)
     val stringClasspath =
       if (compilerClasspath.isEmpty) dummy
       else absString(compilerClasspath)
     val classpathOption = Seq("-classpath", stringClasspath)
-    val bootClasspath = bootClasspathOption(hasLibrary(cp))
+    val bootClasspath = bootClasspathOption(hasLibrary(classpath))
     val sources1 = sources map {
       case x: PathBasedFile => x.toPath
     }

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -103,18 +103,33 @@ final class MixedAnalyzingCompiler(
           val arguments =
             cArgs.makeArguments(Nil, cp, config.currentSetup.options.scalacOptions ++ pickleWrite)
           timed("Scala compilation", log) {
-            config.compiler.compile(
-              sources.toArray,
-              config.converter,
-              changes,
-              arguments.toArray,
-              output,
-              callback,
-              config.reporter,
-              config.cache,
-              config.progress.toOptional,
-              log
-            )
+            if (config.compiler.bridgeCompatibilityLevel(log) >= 2)
+              config.compiler.compile(
+                sources.toArray,
+                changes,
+                arguments.toArray,
+                output,
+                callback,
+                config.reporter,
+                config.cache,
+                config.progress.toOptional,
+                log
+              )
+            else {
+              // fall back to using File
+              val fileSources: Array[File] = sources.map(config.converter.toPath(_).toFile).toArray
+              config.compiler.compile(
+                fileSources,
+                changes,
+                arguments.toArray,
+                output,
+                callback,
+                config.reporter,
+                config.cache,
+                config.progress.toOptional,
+                log
+              )
+            }
           }
         }
       }


### PR DESCRIPTION
Ref https://github.com/sbt/zinc/pull/829

Instead of passing `FileConverter` to `AnalyzingCompiler#compile(...)`, this creates 2 different `compile(...)` methods for each entry point. This is a preparation step towards removing compiler cache.
