### PR TITLE
Delay Java compilation during pipelining

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,6 +75,8 @@ ThisBuild / publishTo := {
 }
 ThisBuild / pomIncludeRepository := (_ => false) // drop repos other than Maven Central from POM
 ThisBuild / mimaPreviousArtifacts := Set.empty
+// limit the number of concurrent test so testQuick works
+Global / concurrentRestrictions += Tags.limit(Tags.Test, 4)
 
 def baseSettings: Seq[Setting[_]] = Seq(
   resolvers += Resolver.typesafeIvyRepo("releases"),

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/compile/IncOptions.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/compile/IncOptions.java
@@ -74,7 +74,7 @@ public final class IncOptions implements java.io.Serializable {
         return true;
     }
     public static boolean defaultPipelining() {
-        return true;
+        return false;
     }
     public static IncOptions create() {
         return new IncOptions();

--- a/internal/compiler-interface/src/main/contraband/incremental.contra
+++ b/internal/compiler-interface/src/main/contraband/incremental.contra
@@ -161,7 +161,7 @@ type IncOptions {
   #x     return true;
   #x }
   #x public static boolean defaultPipelining() {
-  #x     return true;
+  #x     return false;
   #x }
 }
 

--- a/internal/zinc-benchmarks/src/main/scala/xsbt/BenchmarkBase.scala
+++ b/internal/zinc-benchmarks/src/main/scala/xsbt/BenchmarkBase.scala
@@ -61,7 +61,8 @@ class BenchmarkBase extends BridgeProviderSpecification {
     val scalaVersion = ZincBenchmark.scalaVersion
     val bridge = getCompilerBridge(_dir.toPath, noLogger, scalaVersion)
     val si = scalaInstance(scalaVersion, _dir.toPath, noLogger)
-    _compilerSetup = _setup.createCompiler(scalaVersion, si, bridge, log)
+    val pipelining = false
+    _compilerSetup = _setup.createCompiler(scalaVersion, si, bridge, pipelining, log)
     printCompilationDetails()
   }
 

--- a/internal/zinc-core/src/main/java/xsbti/compile/IncOptionsUtil.java
+++ b/internal/zinc-core/src/main/java/xsbti/compile/IncOptionsUtil.java
@@ -65,7 +65,17 @@ public class IncOptionsUtil {
      * @return An instance of {@link IncOptions}.
      */
     public static IncOptions fromStringMap(Map<String, String> values, Logger logger) {
-        IncOptions base = IncOptions.of();
+        return fromStringMap(IncOptions.of(), values, logger);
+    }
+
+    /**
+     * Reads and returns an instance of {@link IncOptions} from a mapping of values.
+     *
+     * @param values The values read from a properties file.
+     * @param logger The logger used for reporting **and** for the transactional manager type.
+     * @return An instance of {@link IncOptions}.
+     */
+    public static IncOptions fromStringMap(IncOptions base, Map<String, String> values, Logger logger) {
         logger.debug(f0("Reading incremental options from map"));
 
         if (values.containsKey(TRANSITIVE_STEP_KEY)) {

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
@@ -179,7 +179,8 @@ private[inc] abstract class IncrementalCommon(
           completingCycle: Boolean
       ): CompileCycleResult = {
         val analysis =
-          if (isFullCompilation) partialAnalysis
+          if (isFullCompilation)
+            partialAnalysis.copy(compilations = pruned.compilations ++ partialAnalysis.compilations)
           else pruned ++ partialAnalysis
         val recompiledClasses: Set[String] = {
           // Represents classes detected as changed externally and internally (by a previous cycle)

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -273,6 +273,8 @@ case class ProjectStructure(
     incrementalCompiler: IncrementalCompilerImpl
 ) extends BridgeProviderSpecification {
   import scala.concurrent.ExecutionContext.Implicits._
+  // This will test pipelining unless incOptions.properties overrides it
+  val defaultPipelining = true
   val maxErrors = 100
   val targetDir = baseDirectory / "target"
   // val targetDir = Paths.get("/tmp/pipelining") / name / "target"
@@ -723,9 +725,9 @@ case class ProjectStructure(
     import scala.collection.JavaConverters._
     val map = new java.util.HashMap[String, String]
     properties.asScala foreach { case (k: String, v: String) => map.put(k, v) }
-
+    val base = IncOptions.of().withPipelining(defaultPipelining)
     val incOptions = {
-      val opts = IncOptionsUtil.fromStringMap(map, scriptedLog)
+      val opts = IncOptionsUtil.fromStringMap(base, map, scriptedLog)
       if (opts.recompileAllFraction() != IncOptions.defaultRecompileAllFraction()) opts
       else opts.withRecompileAllFraction(1.0)
     }

--- a/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
@@ -28,6 +28,61 @@ import xsbti.compile.analysis.ReadStamps
 class IncrementalCompilerImpl extends IncrementalCompiler {
 
   /**
+   * Compile all Java compilation based on xsbti.compile.Inputs.
+   *
+   * This is a Scala implementation of xsbti.compile.IncrementalCompiler,
+   * check the docs for more information on the specification of this method.
+   *
+   * @param in An instance of xsbti.compile.Inputs that collect all the
+   *           inputs required to run the compiler (from sources and classpath,
+   *           to compilation order, previous results, current setup, etc).
+   * @param logger An instance of `xsbti.Logger` to log Zinc output.
+   *
+   * @return An instance of `xsbti.compile.CompileResult` that holds
+   *         information about the results of the compilation. The returned
+   *         `xsbti.compile.CompileResult` must be used for subsequent
+   *         compilations that depend on the same inputs, check its api and its
+   *         field `xsbti.compile.CompileAnalysis`.
+   */
+  def compileAllJava(in: Inputs, logger: Logger): CompileResult = {
+    val config = in.options()
+    val setup = in.setup()
+    import config._
+    import setup._
+    val compilers = in.compilers
+    val javacChosen = compilers.javaTools.javac
+    val scalac = compilers.scalac
+    val extraOptions = extra.toList.map(_.toScalaTuple)
+    val conv = converter.toOption.getOrElse(???)
+    val defaultStampReader = Stamps.timeWrapLibraryStamps(conv)
+    compileIncrementally(
+      scalac,
+      javacChosen,
+      sources,
+      classpath,
+      CompileOutput(classesDirectory),
+      earlyOutput.toOption,
+      earlyAnalysisStore.toOption,
+      cache,
+      progress().toOption,
+      scalacOptions,
+      javacOptions,
+      in.previousResult.analysis.toOption,
+      in.previousResult.setup.toOption,
+      perClasspathEntryLookup,
+      reporter,
+      order,
+      skip = false,
+      recompileAllJava = true,
+      incrementalCompilerOptions,
+      temporaryClassesDirectory.toOption,
+      extraOptions,
+      conv,
+      stamper.toOption.getOrElse(defaultStampReader),
+    )(logger)
+  }
+
+  /**
    * Performs an incremental compilation based on xsbti.compile.Inputs.
    *
    * This is a Scala implementation of xsbti.compile.IncrementalCompiler,
@@ -73,6 +128,7 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
       reporter,
       order,
       skip,
+      recompileAllJava = false,
       incrementalCompilerOptions,
       temporaryClassesDirectory.toOption,
       extraOptions,
@@ -162,6 +218,7 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
       reporter,
       compileOrder,
       skip: Boolean,
+      recompileAllJava = false,
       incrementalOptions,
       temporaryClassesDirectory.toOption,
       extraInScala,
@@ -253,6 +310,7 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
       reporter,
       compileOrder,
       skip: Boolean,
+      recompileAllJava = false,
       incrementalOptions,
       temporaryClassesDirectory.toOption,
       extraInScala,
@@ -350,6 +408,7 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
       reporter: Reporter,
       compileOrder: CompileOrder = Mixed,
       skip: Boolean = false,
+      recompileAllJava: Boolean = false,
       incrementalOptions: IncOptions,
       temporaryClassesDirectory: Option[Path],
       extra: List[(String, String)],
@@ -409,7 +468,18 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
         extra
       )
       if (skip) CompileResult.of(prev, config.currentSetup, false)
-      else {
+      else if (recompileAllJava) {
+        JarUtils.setupTempClassesDir(temporaryClassesDirectory)
+        val (analysis, changed) = compileAllJava(
+          MixedAnalyzingCompiler(config)(logger),
+          equivCompileSetup(
+            equivOpts0(equivScalacOptions(incrementalOptions.ignoredScalacOptions))
+          ),
+          equivPairs,
+          logger
+        )
+        CompileResult.of(analysis, config.currentSetup, changed)
+      } else {
         JarUtils.setupTempClassesDir(temporaryClassesDirectory)
         val (analysis, changed) = compileInternal(
           MixedAnalyzingCompiler(config)(logger),
@@ -422,6 +492,38 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
         CompileResult.of(analysis, config.currentSetup, changed)
       }
     }
+  }
+
+  /**
+   * Compila all Java sources using the given mixed compiler.
+   *
+   * This operation prunes the inputs based on [[MiniSetup]].
+   */
+  private[sbt] def compileAllJava(
+      mixedCompiler: MixedAnalyzingCompiler,
+      equiv: Equiv[MiniSetup],
+      equivPairs: Equiv[Array[T2[String, String]]],
+      log: Logger
+  ): (Analysis, Boolean) = {
+    import mixedCompiler.config._, currentSetup.output
+    val lookup = new LookupImpl(mixedCompiler.config, previousSetup)
+    val javaSrcs = sources.filter(MixedAnalyzingCompiler.javaOnly)
+    val compile = Incremental.compileAllJava(
+      javaSrcs,
+      converter,
+      lookup,
+      previousAnalysis,
+      incOptions,
+      currentSetup,
+      stampReader,
+      output,
+      outputJarContent,
+      earlyOutput,
+      earlyAnalysisStore,
+      progress,
+      log
+    )(mixedCompiler.compileJava)
+    compile.swap
   }
 
   /**

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -53,6 +53,59 @@ final class MixedAnalyzingCompiler(
     new CompilerArguments(config.compiler.scalaInstance, config.compiler.classpathOptions)
 
   /**
+   * Compile java and run analysis.
+   */
+  def compileJava(
+      javaSrcs: Seq[VirtualFile],
+      callback: XAnalysisCallback,
+      classfileManager: XClassFileManager,
+  ): Unit = {
+    if (javaSrcs.nonEmpty)
+      timed("Java compilation + analysis", log) {
+        val output = config.currentSetup.output
+        val incToolOptions =
+          IncToolOptions.of(
+            Optional.of(classfileManager),
+            config.incOptions.useCustomizedFileManager()
+          )
+        val joptions = config.currentSetup.options.javacOptions
+
+        JarUtils.getOutputJar(output) match {
+          case Some(outputJar) =>
+            val outputDir = JarUtils.javacTempOutput(outputJar)
+            Files.createDirectories(outputDir)
+            javac.compile(
+              javaSrcs,
+              config.converter,
+              joptions,
+              CompileOutput(outputDir),
+              Some(outputJar),
+              callback,
+              incToolOptions,
+              config.reporter,
+              log,
+              config.progress
+            )
+            putJavacOutputInJar(outputJar.toFile, outputDir.toFile)
+          case None =>
+            javac.compile(
+              javaSrcs,
+              config.converter,
+              joptions,
+              output,
+              finalJarOutput = None,
+              callback,
+              incToolOptions,
+              config.reporter,
+              log,
+              config.progress
+            )
+        }
+      } // timed
+    else ()
+  }
+
+  /**
    * Compiles the given Java/Scala files.
    *
    * @param include          The files to compile right now
@@ -77,7 +130,7 @@ final class MixedAnalyzingCompiler(
     }
 
     val incSrc = config.sources.filter(include)
-    val (javaSrcs, scalaSrcs) = incSrc.partition(javaOnly(_))
+    val (javaSrcs, scalaSrcs) = incSrc.partition(MixedAnalyzingCompiler.javaOnly)
     logInputs(log, javaSrcs.size, scalaSrcs.size, outputDirs)
     val isPickleJava = config.currentSetup.order == Mixed && config.incOptions.pipelining && javaSrcs.nonEmpty
 
@@ -118,59 +171,14 @@ final class MixedAnalyzingCompiler(
           }
         }
       }
-
-    // Compile java and run analysis.
-    def compileJava(): Unit = {
-      if (javaSrcs.nonEmpty) {
-        timed("Java compilation + analysis", log) {
-          val incToolOptions =
-            IncToolOptions.of(
-              Optional.of(classfileManager),
-              config.incOptions.useCustomizedFileManager()
-            )
-          val joptions = config.currentSetup.options.javacOptions
-
-          JarUtils.getOutputJar(output) match {
-            case Some(outputJar) =>
-              val outputDir = JarUtils.javacTempOutput(outputJar)
-              Files.createDirectories(outputDir)
-              javac.compile(
-                javaSrcs,
-                config.converter,
-                joptions,
-                CompileOutput(outputDir),
-                Some(outputJar),
-                callback,
-                incToolOptions,
-                config.reporter,
-                log,
-                config.progress
-              )
-              putJavacOutputInJar(outputJar.toFile, outputDir.toFile)
-            case None =>
-              javac.compile(
-                javaSrcs,
-                config.converter,
-                joptions,
-                output,
-                finalJarOutput = None,
-                callback,
-                incToolOptions,
-                config.reporter,
-                log,
-                config.progress
-              )
-          }
-        }
-      }
-    }
+    def compileJava0(): Unit = compileJava(javaSrcs, callback, classfileManager)
 
     /* `Mixed` order defaults to `ScalaThenJava` behaviour.
      * See https://github.com/sbt/zinc/issues/234. */
     if (config.currentSetup.order == JavaThenScala) {
-      compileJava(); compileScala()
+      compileJava0(); compileScala()
     } else {
-      compileScala(); compileJava()
+      compileScala(); compileJava0()
     }
 
     if (javaSrcs.size + scalaSrcs.size > 0) {
@@ -226,9 +234,6 @@ final class MixedAnalyzingCompiler(
       log.info(combined.mkString("Compiling ", " and ", s" to $targets ..."))
     }
   }
-
-  /** Returns true if the file is java. */
-  private[this] def javaOnly(f: VirtualFileRef): Boolean = f.id.endsWith(".java")
 }
 
 /**
@@ -239,6 +244,10 @@ final class MixedAnalyzingCompiler(
  * of cross Java-Scala compilation.
  */
 object MixedAnalyzingCompiler {
+
+  /** Returns true if the file is java. */
+  private[sbt] def javaOnly(f: VirtualFileRef): Boolean = f.id.endsWith(".java")
+
   def makeConfig(
       scalac: xsbti.compile.ScalaCompiler,
       javac: xsbti.compile.JavaCompiler,
@@ -352,24 +361,39 @@ object MixedAnalyzingCompiler {
   /** Returns the search classpath (for dependencies) and a function which can also do so. */
   def searchClasspathAndLookup(
       config: CompileConfiguration
+  ): (Seq[VirtualFile], String => Option[VirtualFile]) =
+    searchClasspathAndLookup(
+      config.converter,
+      config.classpath,
+      config.currentSetup.output,
+      config.currentSetup.options.scalacOptions,
+      config.perClasspathEntryLookup,
+      config.compiler
+    )
+
+  /** Returns the search classpath (for dependencies) and a function which can also do so. */
+  def searchClasspathAndLookup(
+      converter: FileConverter,
+      classpath: Seq[VirtualFile],
+      output: Output,
+      scalacOptions: Array[String],
+      perClasspathEntryLookup: PerClasspathEntryLookup,
+      compiler: xsbti.compile.ScalaCompiler
   ): (Seq[VirtualFile], String => Option[VirtualFile]) = {
-    import config._
-    import currentSetup._
     // If we are compiling straight to jar, as javac does not support this,
     // it will be compiled to a temporary directory (with deterministic name)
     // and then added to the final jar. This temporary directory has to be
     // available for sbt.internal.inc.classfile.Analyze to work correctly.
     val tempJavacOutput =
       JarUtils
-        .getOutputJar(config.currentSetup.output)
+        .getOutputJar(output)
         .map(JarUtils.javacTempOutput)
         .toSeq
         .map(converter.toVirtualFile(_))
     val absClasspath = classpath.map(toAbsolute(_))
     val cArgs =
       new CompilerArguments(compiler.scalaInstance, compiler.classpathOptions)
-    val searchClasspath
-        : Seq[VirtualFile] = explicitBootClasspath(options.scalacOptions, converter) ++
+    val searchClasspath: Seq[VirtualFile] = explicitBootClasspath(scalacOptions, converter) ++
       withBootclasspath(
         cArgs,
         absClasspath,

--- a/zinc/src/sbt-test/source-dependencies/anon-java-scala-class/incOptions.properties
+++ b/zinc/src/sbt-test/source-dependencies/anon-java-scala-class/incOptions.properties
@@ -1,0 +1,1 @@
+pipelining = false

--- a/zinc/src/sbt-test/source-dependencies/anon-java-scala-class/incOptions.properties
+++ b/zinc/src/sbt-test/source-dependencies/anon-java-scala-class/incOptions.properties
@@ -1,1 +1,2 @@
+# turn off pipelining because compileAllJava over-compiles
 pipelining = false

--- a/zinc/src/sbt-test/source-dependencies/less-inter-inv-java/incOptions.properties
+++ b/zinc/src/sbt-test/source-dependencies/less-inter-inv-java/incOptions.properties
@@ -1,0 +1,1 @@
+pipelining = false

--- a/zinc/src/sbt-test/source-dependencies/less-inter-inv-java/incOptions.properties
+++ b/zinc/src/sbt-test/source-dependencies/less-inter-inv-java/incOptions.properties
@@ -1,1 +1,2 @@
+# turn off pipelining because compileAllJava over-compiles
 pipelining = false

--- a/zinc/src/sbt-test/source-dependencies/less-inter-inv-java/test
+++ b/zinc/src/sbt-test/source-dependencies/less-inter-inv-java/test
@@ -6,4 +6,4 @@ $ copy-file changes/A2.java A.java
 # 1 iteration to recompile all descendents and direct dependencies
 # no further iteration, because APIs of directs don't change
 > run
-> checkIterations 1
+> checkIterations 2

--- a/zinc/src/sbt-test/source-dependencies/less-inter-inv-java/test
+++ b/zinc/src/sbt-test/source-dependencies/less-inter-inv-java/test
@@ -6,4 +6,4 @@ $ copy-file changes/A2.java A.java
 # 1 iteration to recompile all descendents and direct dependencies
 # no further iteration, because APIs of directs don't change
 > run
-> checkIterations 2
+> checkIterations 1

--- a/zinc/src/sbt-test/source-dependencies/local-class-inheritance-from-java/incOptions.properties
+++ b/zinc/src/sbt-test/source-dependencies/local-class-inheritance-from-java/incOptions.properties
@@ -1,0 +1,1 @@
+pipelining = false

--- a/zinc/src/sbt-test/source-dependencies/local-class-inheritance-from-java/incOptions.properties
+++ b/zinc/src/sbt-test/source-dependencies/local-class-inheritance-from-java/incOptions.properties
@@ -1,1 +1,2 @@
+# turn off pipelining because compileAllJava over-compiles
 pipelining = false

--- a/zinc/src/sbt-test/source-dependencies/subproject-java/test
+++ b/zinc/src/sbt-test/source-dependencies/subproject-java/test
@@ -1,6 +1,6 @@
 # done this way because last modified times often have ~1s resolution
 > use/compile
-> dep/checkProducts A.java: ${0}/dep/target/classes/A.class
+> dep/checkProducts A.java: ${BASE}/dep/target/classes/A.class
 
 $ sleep 2000
 

--- a/zinc/src/test/resources/sbt/inc/Ext1.scala
+++ b/zinc/src/test/resources/sbt/inc/Ext1.scala
@@ -14,3 +14,7 @@ package test.pkg
 object Ext1 {
   val x = 2
 }
+class Ext1 {
+
+}
+

--- a/zinc/src/test/scala/sbt/inc/BaseCompilerSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/BaseCompilerSpec.scala
@@ -32,6 +32,7 @@ class BaseCompilerSpec extends BridgeProviderSpecification {
         sv,
         scalaInstance(sv, underlying.baseLocation, noLogger),
         getCompilerBridge(underlying.baseLocation, noLogger, sv),
+        pipelining = true,
         log
       )
   }

--- a/zinc/src/test/scala/sbt/inc/BaseCompilerSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/BaseCompilerSpec.scala
@@ -11,7 +11,7 @@
 
 package sbt.inc
 
-import java.nio.file.Path
+import java.nio.file.{ Files, Path }
 import sbt.internal.inc.BridgeProviderSpecification
 import sbt.util.Logger
 
@@ -21,15 +21,27 @@ class BaseCompilerSpec extends BridgeProviderSpecification {
   val maxErrors = 100
   val noLogger = Logger.Null
 
+  def assertExists(p: Path) = assert(Files.exists(p), s"$p does not exist")
+
   implicit class TestProjectSetupMod(underlying: TestProjectSetup) {
     def createCompiler(): TestProjectSetup.CompilerSetup =
+      createCompiler(scalaVersion)
+
+    def createCompiler(sv: String): TestProjectSetup.CompilerSetup =
       underlying.createCompiler(
-        scalaVersion,
-        scalaInstance(scalaVersion, underlying.baseLocation, noLogger),
-        getCompilerBridge(underlying.baseLocation, noLogger, scalaVersion),
+        sv,
+        scalaInstance(sv, underlying.baseLocation, noLogger),
+        getCompilerBridge(underlying.baseLocation, noLogger, sv),
         log
       )
   }
+
+  implicit val compilerSetupHelper: TestProjectSetup.CompilerSetupHelper =
+    new TestProjectSetup.CompilerSetupHelper {
+      def apply(sv: String, setup: TestProjectSetup): TestProjectSetup.CompilerSetup =
+        setup.createCompiler(sv)
+    }
+
   // to avoid rewriting existing tests
   object ProjectSetup {
     def simple(baseLocation: Path, classes: Seq[String]): TestProjectSetup =

--- a/zinc/src/test/scala/sbt/inc/IncrementalCompilerSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/IncrementalCompilerSpec.scala
@@ -67,12 +67,13 @@ class IncrementalCompilerSpec extends BaseCompilerSpec {
 
       val compiler = projectSetup.createCompiler()
       try {
-        val result = compiler.doCompile()
+        compiler.doCompileWithStore()
+        val result1 = compiler.doCompileAllJavaWithStore()
         val expectedOuts = List(projectSetup.defaultClassesDir.resolve("NestedJavaClasses.class"))
         expectedOuts foreach { f =>
           assert(Files.exists(f), s"$f does not exist.")
         }
-        val a = result.analysis match {
+        val a = result1.analysis match {
           case a: Analysis => a
         }
         assert(a.stamps.allSources.nonEmpty)
@@ -86,7 +87,6 @@ class IncrementalCompilerSpec extends BaseCompilerSpec {
     IO.withTemporaryDirectory { tempDir =>
       val sub1Directory = tempDir.toPath / "sub1"
       Files.createDirectories(sub1Directory / "src")
-      Files.createDirectories(sub1Directory / "classes")
       val p1 = VirtualSubproject
         .Builder()
         .baseDirectory(sub1Directory)

--- a/zinc/src/test/scala/sbt/inc/IncrementalCompilerSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/IncrementalCompilerSpec.scala
@@ -82,6 +82,73 @@ class IncrementalCompilerSpec extends BaseCompilerSpec {
     }
   }
 
+  it should "compile all Java code" in {
+    IO.withTemporaryDirectory { tempDir =>
+      val sub1Directory = tempDir.toPath / "sub1"
+      Files.createDirectories(sub1Directory / "src")
+      Files.createDirectories(sub1Directory / "classes")
+      val p1 = VirtualSubproject
+        .Builder()
+        .baseDirectory(sub1Directory)
+        .get
+
+      try {
+        val javaContent =
+          """package example;
+          |
+          |public class A {
+          |}
+          |""".stripMargin
+        val javaFile = StringVirtualFile("src/example/A.java", javaContent)
+        val result = p1.compileAllJava(javaFile)
+        val a = result.analysis match {
+          case a: Analysis => a
+        }
+        assert(a.stamps.allSources.nonEmpty)
+        assertExists(sub1Directory / "classes" / "example" / "A.class")
+      } finally p1.close()
+    }
+  }
+
+  it should "compile all Java code in a mixed project" in {
+    IO.withTemporaryDirectory { tempDir =>
+      val sub1Directory = tempDir.toPath / "sub1"
+      Files.createDirectories(sub1Directory / "src")
+      Files.createDirectories(sub1Directory / "classes")
+      val p1 = VirtualSubproject
+        .Builder()
+        .baseDirectory(sub1Directory)
+        .get
+
+      try {
+        val javaContent =
+          """package example;
+          |
+          |public class A {
+          |}
+          |""".stripMargin
+        val javaFile = StringVirtualFile("src/example/A.java", javaContent)
+
+        val scalaContent =
+          """package example
+          |
+          |class B {
+          |  val a = new A
+          |}
+          |""".stripMargin
+        val scalaFile = StringVirtualFile("src/example/B.scala", scalaContent)
+        val result1 = p1.compile(javaFile, scalaFile)
+        val a1 = result1.analysis.asInstanceOf[Analysis]
+        assert(a1.stamps.allSources.size == 2)
+        // assert(!Files.exists(sub1Directory / "classes" / "example" / "A.class"))
+        val result2 = p1.compileAllJava(javaFile, scalaFile)
+        val a2 = result2.analysis.asInstanceOf[Analysis]
+        assert(a2.stamps.allSources.nonEmpty)
+        assertExists(sub1Directory / "classes" / "example" / "A.class")
+      } finally p1.close()
+    }
+  }
+
   it should "trigger full compilation if extra changes" in {
     IO.withTemporaryDirectory { tempDir =>
       val cacheFile = tempDir / "target" / "inc_compile.zip"

--- a/zinc/src/test/scala/sbt/inc/TestProjectSetup.scala
+++ b/zinc/src/test/scala/sbt/inc/TestProjectSetup.scala
@@ -97,7 +97,13 @@ case class TestProjectSetup(
   def defaultStoreLocation: Path = baseLocation.resolve("inc_data.zip")
   def defaultEarlyStoreLocation: Path = baseLocation.resolve("early_inc_data.zip")
 
-  def createCompiler(sv: String, si: XScalaInstance, compilerBridge: Path, log: ManagedLogger) = {
+  def createCompiler(
+      sv: String,
+      si: XScalaInstance,
+      compilerBridge: Path,
+      pipelining: Boolean,
+      log: ManagedLogger
+  ) = {
     CompilerSetup(
       sv,
       si,
@@ -108,7 +114,7 @@ case class TestProjectSetup(
       allSources.toVector.map(converter.toVirtualFile(_)),
       allClasspath.map(converter.toVirtualFile(_)),
       scalacOptions,
-      IncOptions.of(),
+      IncOptions.of().withPipelining(pipelining),
       analysisForCp,
       defaultStoreLocation,
       defaultEarlyStoreLocation,

--- a/zinc/src/test/scala/sbt/inc/TestProjectSetup.scala
+++ b/zinc/src/test/scala/sbt/inc/TestProjectSetup.scala
@@ -267,6 +267,32 @@ object TestProjectSetup {
       newResult
     }
 
+    def doCompileAllJava(newInputs: Inputs => Inputs = identity): CompileResult = {
+      lastCompiledUnits = Set.empty
+      compiler.compileAllJava(newInputs(in), log)
+    }
+
+    def doCompileAllJavaWithStore(
+        store: AnalysisStore = FileAnalysisStore.getDefault(analysisStoreLocation.toFile),
+        newInputs: Inputs => Inputs = identity
+    ): CompileResult = {
+      val previousResult = store.get().toOption match {
+        case Some(analysisContents) =>
+          val prevAnalysis = analysisContents.getAnalysis
+          val prevSetup = analysisContents.getMiniSetup
+          PreviousResult.of(
+            Optional.of[CompileAnalysis](prevAnalysis),
+            Optional.of[MiniSetup](prevSetup)
+          )
+        case _ =>
+          compiler.emptyPreviousResult
+      }
+      val newResult = doCompileAllJava(in => newInputs(in.withPreviousResult(previousResult)))
+
+      store.set(AnalysisContents.create(newResult.analysis(), newResult.setup()))
+      newResult
+    }
+
     def close(): Unit = sc.classLoaderCache.foreach(_.close())
   }
 
@@ -277,5 +303,67 @@ object TestProjectSetup {
 
     override def definesClass(classpathEntry: VirtualFile): DefinesClass =
       Locate.definesClass(classpathEntry)
+  }
+
+  trait CompilerSetupHelper {
+    def apply(sv: String, setup: TestProjectSetup): CompilerSetup
+  }
+}
+
+object VirtualSubproject {
+  case class Builder(
+      base: Option[Path] = None,
+      projectDeps: List[VirtualSubproject] = Nil,
+      externalDeps: List[Path] = Nil,
+      scalaVersion: String = scala.util.Properties.versionNumberString,
+  ) {
+    def baseDirectory(value: Path): Builder = copy(base = Some(value))
+    def scalaVersion(value: String): Builder = copy(scalaVersion = value)
+    def dependsOn(values: VirtualSubproject*): Builder =
+      copy(projectDeps = this.projectDeps ::: values.toList)
+    def externalDependencies(values: Path*): Builder =
+      copy(externalDeps = this.externalDeps ::: values.toList)
+    // call this get because "build" sounds like we're compiling something
+    def get(implicit ev: TestProjectSetup.CompilerSetupHelper): VirtualSubproject =
+      new VirtualSubproject(base.get, projectDeps, externalDeps, scalaVersion, ev)
+  }
+}
+
+class VirtualSubproject(
+    baseLocation: Path,
+    projectDeps: List[VirtualSubproject],
+    externalDeps: List[Path],
+    scalaVersion: String,
+    helper: TestProjectSetup.CompilerSetupHelper,
+) {
+  val setup = TestProjectSetup.simple(baseLocation, classes = Nil)
+  val cp = setup.earlyOutput :: projectDeps.map(_.setup.defaultClassesDir) ::: externalDeps
+  def p2vf(p: Path) = setup.converter.toVirtualFile(p)
+
+  val analysisForCp = (this :: projectDeps).flatMap { p =>
+    Seq(
+      p2vf(p.setup.defaultClassesDir) -> p.setup.defaultStoreLocation,
+      p2vf(p.setup.earlyOutput) -> p.setup.defaultEarlyStoreLocation,
+    )
+  }.toMap
+
+  val compiler = helper(
+    scalaVersion,
+    setup
+      .copy(analysisForCp = analysisForCp) // need setup's converter to define this, so copy in after
+  ).copy(classpath = cp.map(p2vf)) // TestProjectSetup does weird CP things, so copy this in lat
+
+  def compile(sources: VirtualFile*) = {
+    val vs = sources.toArray
+    compiler.doCompileWithStore(newInputs = in => in.withOptions(in.options.withSources(vs)))
+  }
+
+  def close(): Unit = compiler.close()
+
+  def compileAllJava(sources: VirtualFile*) = {
+    val vs = sources.toArray
+    compiler.doCompileAllJavaWithStore(
+      newInputs = in => in.withOptions(in.options.withSources(vs))
+    )
   }
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/sbt/zinc/pull/744. (This actually makes pipelining usable)

![pipelining](https://user-images.githubusercontent.com/184683/81020232-58f43900-8e36-11ea-8239-3bacb0452a8b.png)

This implements an Analysis-aware `compileAllJava(...)`.

```scala
def compileAllJava(in: Inputs, logger: Logger): CompileResult = ...
```

How this is realized is more complicated than one might expect because we need all the wiring to get AnalysisCallback going to reuse the `Incremental` + `MixedAnalyzingCompiler` harness (This is so the *downstream* subprojects can get the incremental goodness).

**Note**: If incOptions pipelining is enabled, the build tool must call `compileAllJava(in, logger)` after _both_
1. All upstream subproject Scala and Java compilation has completed, and 
2. Scala *whole* `*.class` compilation has completed && hasModified.
