### PR TITLE
Make a number of performance optimizations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -338,6 +338,14 @@ lazy val zincCore = (projectMatrix in internalPath / "zinc-core")
       exclude[ReversedMissingMethodProblem]("xsbti.*"),
       exclude[MissingClassProblem]("xsbti.*"),
     ),
+    libraryDependencies ++= {
+      scalaPartialVersion.value match {
+        case Some((2, major)) if major >= 13 =>
+          List("org.scala-lang.modules" %% "scala-parallel-collections" % "0.2.0")
+        case _ =>
+          List()
+      }
+    },
   )
   .jvmPlatform(scalaVersions = List(scala212, scala213))
   .configure(addBaseSettingsAndTestDeps, addSbtIO, addSbtUtilLogging, addSbtUtilRelation)

--- a/internal/zinc-apiinfo/src/main/scala/xsbt/api/NameHashing.scala
+++ b/internal/zinc-apiinfo/src/main/scala/xsbt/api/NameHashing.scala
@@ -59,11 +59,10 @@ class NameHashing(optimizedSealed: Boolean) {
   ): Array[NameHash] = {
     val includeSealedChildren = !optimizedSealed || useScope == UseScope.PatMatTarget
     val groupedBySimpleName = defs.groupBy(locatedDef => localName(locatedDef.name))
-    val hashes =
-      groupedBySimpleName.mapValues(hashLocatedDefinitions(_, location, includeSealedChildren))
-    hashes.toIterable
-      .map({ case (name: String, hash: Int) => NameHash.of(name, useScope, hash) })
-      .toArray
+    groupedBySimpleName.iterator.map {
+      case (name, value) =>
+        NameHash.of(name, useScope, hashLocatedDefinitions(value, location, includeSealedChildren))
+    }.toArray
   }
 
   private def hashLocatedDefinitions(

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/IndexBasedZipOps.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/IndexBasedZipOps.scala
@@ -55,7 +55,7 @@ abstract class IndexBasedZipOps extends CreateZip {
       if (Files.exists(zipFile)) {
         val centralDir = readCentralDir(zipFile)
         val headers = getHeaders(centralDir)
-        Map(headers.map(header => getFileName(header) -> getLastModifiedTime(header)): _*)
+        headers.iterator.map(header => getFileName(header) -> getLastModifiedTime(header)).toMap
       } else {
         Map.empty
       }

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/JavaAnalyze.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/JavaAnalyze.scala
@@ -192,7 +192,8 @@ private[sbt] object JavaAnalyze {
 
       def readInheritanceDependencies(classes: Seq[Class[_]]) = {
         val api = readAPI(source, classes)
-        api.groupBy(_._1).mapValues(_.map(_._2))
+        // avoid .mapValues(...) because of its viewness (scala/bug#10919)
+        api.groupBy(_._1).iterator.map { case (k, v) => k -> v.map(_._2) }
       }
 
       // Read API of non-local classes and process dependencies by inheritance

--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaders.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaders.scala
@@ -78,7 +78,9 @@ final class ClasspathFilter(parent: ClassLoader, root: ClassLoader, classpath: S
         |  cp = $classpath
         |)""".stripMargin
 
-  private[this] val directories: Seq[Path] = classpath.toSeq.filter(Files.isDirectory(_))
+  private[this] val directories: Seq[Path] = classpath.toSeq.filter { p =>
+    !p.toString.endsWith(".jar") && Files.isDirectory(p)
+  }
   override def loadClass(className: String, resolve: Boolean): Class[_] = {
     val c = super.loadClass(className, resolve)
     if (includeLoader(c.getClassLoader, root) || fromClasspath(c))

--- a/internal/zinc-core/src/main/scala-2.12/sbt/internal/inc/WrappedSet.scala
+++ b/internal/zinc-core/src/main/scala-2.12/sbt/internal/inc/WrappedSet.scala
@@ -1,0 +1,17 @@
+package sbt.internal.inc
+
+import xsbti.VirtualFileRef
+import scala.collection.immutable.Set
+
+private[inc] class WrappedSet(s: java.util.HashSet[VirtualFileRef]) extends Set[VirtualFileRef] {
+  import scala.collection.JavaConverters._
+  def iterator: Iterator[xsbti.VirtualFileRef] = s.asScala.iterator
+  def contains(elem: xsbti.VirtualFileRef): Boolean = s.contains(s)
+
+  def +(elem: xsbti.VirtualFileRef): Set[xsbti.VirtualFileRef] =
+    s.asScala.foldLeft(Set(elem)) { case (a, e) => a + e }
+  def -(elem: xsbti.VirtualFileRef): Set[xsbti.VirtualFileRef] =
+    s.asScala.foldLeft(Set.empty[VirtualFileRef]) {
+      case (a, e) => if (e != elem) a + e else a
+    }
+}

--- a/internal/zinc-core/src/main/scala-2.13/sbt/internal/inc/WrappedSet.scala
+++ b/internal/zinc-core/src/main/scala-2.13/sbt/internal/inc/WrappedSet.scala
@@ -1,0 +1,14 @@
+package sbt.internal.inc
+
+import scala.collection.immutable.Set
+import xsbti.VirtualFileRef
+
+private[inc] class WrappedSet(s: java.util.HashSet[VirtualFileRef]) extends Set[VirtualFileRef] {
+  import scala.jdk.CollectionConverters._
+  def iterator: Iterator[VirtualFileRef] = s.asScala.iterator
+  def contains(elem: VirtualFileRef): Boolean = s.contains(s)
+  def excl(elem: VirtualFileRef): Set[VirtualFileRef] =
+    s.asScala.foldLeft(Set.empty[VirtualFileRef]) { case (a, e) => if (e != elem) a + e else a }
+  def incl(elem: VirtualFileRef): Set[VirtualFileRef] =
+    s.asScala.foldLeft(Set(elem)) { case (a, e) => a + e }
+}

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -896,9 +896,9 @@ private final class AnalysisCallback(
           .map(_._1)
         val analyzedApis = classesInSrc.map(analyzeClass)
         val info = SourceInfos.makeInfo(
-          getOrNil(reporteds.mapValues({ _.asScala.toSeq }).toMap, src),
-          getOrNil(unreporteds.mapValues({ _.asScala.toSeq }).toMap, src),
-          getOrNil(mainClasses.mapValues({ _.asScala.toSeq }).toMap, src)
+          getOrNil(reporteds.iterator.map { case (k, v)   => k -> v.asScala.toSeq }.toMap, src),
+          getOrNil(unreporteds.iterator.map { case (k, v) => k -> v.asScala.toSeq }.toMap, src),
+          getOrNil(mainClasses.iterator.map { case (k, v) => k -> v.asScala.toSeq }.toMap, src)
         )
         val libraries: collection.mutable.Set[VirtualFile] =
           libraryDeps.getOrElse(src, ConcurrentHashMap.newKeySet[VirtualFile]).asScala

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Relations.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Relations.scala
@@ -390,8 +390,8 @@ private case class InternalDependencies(
    */
   def --(classes: Iterable[String]): InternalDependencies = {
     InternalDependencies(
-      dependencies
-        .mapValues(_ -- classes)
+      dependencies.iterator
+        .map { case (k, v) => k -> (v -- classes) }
         .filter(_._2.size > 0)
         .toMap
     )
@@ -434,8 +434,8 @@ private case class ExternalDependencies(
    */
   def --(classNames: Iterable[String]): ExternalDependencies =
     ExternalDependencies(
-      dependencies
-        .mapValues(_ -- classNames)
+      dependencies.iterator
+        .map { case (k, v) => k -> (v -- classNames) }
         .filter(_._2.size > 0)
         .toMap
     )

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -299,7 +299,7 @@ case class ProjectStructure(
       .map(_.toPath)
       .toList
 
-  val stamper = Stamps.timeWrapLibraryStamps(converter)
+  val stamper = Stamps.timeWrapBinaryStamps(converter)
   val cacheFile = baseDirectory / "target" / "inc_compile.zip"
   val fileStore = FileAnalysisStore.binary(cacheFile.toFile)
   val cachedStore = AnalysisStore.cached(fileStore)

--- a/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
@@ -54,7 +54,7 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
     val scalac = compilers.scalac
     val extraOptions = extra.toList.map(_.toScalaTuple)
     val conv = converter.toOption.getOrElse(???)
-    val defaultStampReader = Stamps.timeWrapLibraryStamps(conv)
+    val defaultStampReader = Stamps.timeWrapBinaryStamps(conv)
     compileIncrementally(
       scalac,
       javacChosen,
@@ -109,7 +109,7 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
     val scalac = compilers.scalac
     val extraOptions = extra.toList.map(_.toScalaTuple)
     val conv = converter.toOption.getOrElse(???)
-    val defaultStampReader = Stamps.timeWrapLibraryStamps(conv)
+    val defaultStampReader = Stamps.timeWrapBinaryStamps(conv)
     compileIncrementally(
       scalac,
       javacChosen,

--- a/zinc/src/test/scala/sbt/inc/TestProjectSetup.scala
+++ b/zinc/src/test/scala/sbt/inc/TestProjectSetup.scala
@@ -227,7 +227,7 @@ object TestProjectSetup {
       si.allJars.map(x => converter.toVirtualFile(x.toPath)) ++
       classpath.toVector
 
-    val stamper = Stamps.timeWrapLibraryStamps(converter)
+    val stamper = Stamps.timeWrapBinaryStamps(converter)
 
     val in = compiler.inputs(
       cp.toArray,


### PR DESCRIPTION
I noticed that running https://github.com/eatkins/scala-build-watch-performance with a local sbt build using zinc 1.4.0-M1 was slower than 1.3.10 in turbo mode. Using flamegraphs, I was able to identify to hotspots and optimize them with some relatively straightforward changes. Before these changes, I got the following results with sbt 1.4.0-SNAPSHOT:
 project | min (ms) | max (ms) | median (ms) | total (ms) | cpu % |
:------- | :------: | :------: | :-------: | :--------: | :---: |
sbt-1.4.0-SNAPSHOT (3 source files) | 151 | 263 | 166 | 34787 | 0.2
sbt-1.4.0-SNAPSHOT (5003 source files) | 747 | 1016 | 836 | 103423 | 0.1

After these changes, the performance improved:
 project | min (ms) | max (ms) | median (ms) | total (ms) | cpu % |
:------- | :------: | :------: | :-------: | :--------: | :---: |
sbt-1.4.0-SNAPSHOT (3 source files) | 140 | 346 | 149 | 27990 | 0.2
sbt-1.4.0-SNAPSHOT (5003 source files) | 458 | 574 | 470 | 68228 | 0.2

Note that there is a lot of time spent stamping source files outside of zinc, scalatest and the scala compiler so the zinc overhead was probably about 400ms before these optimizations and 100ms after. 

By comparison, for sbt 1.3.10, I got
 project | min (ms) | max (ms) | median (ms) | total (ms) | cpu % |
:------- | :------: | :------: | :-------: | :--------: | :---: |
sbt-1.3.10-turbo (3 source files) | 119 | 220 | 125 | 25906 | 3.1
sbt-1.3.10-turbo (5003 source files) | 535 | 746 | 558 | 77775 | 3.5

I couldn't quite figure out why sbt 1.4.0-SNAPSHOT was consistently 20ms slower than 1.3.10 in the 3 source file example. It was reproducible in the shell though. I ran sbt with `-Dsbt.task.timings=true` and it appeared that about 10ms of the extra time was in `compileIncremental` and the other 10ms was somewhere that didn't show up in the task timing report.

The variance seemed generally lower after these changes which is probably because I reworked things so that less garbage is generated so GC is probably running less often.

I also just benchmarked running `compile` in the sbt shell in a scenario when we just needed to compile a single source file (`object Foo`) and with the head of origin/develop in zinc, it took about 700ms when there were 5000 other source files and with these zinc changes, it dropped down to 500ms.