### PR TITLE
Fix early output notification

### DIFF
--- a/internal/compiler-interface/src/main/java/xsbti/compile/CompileProgress.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/CompileProgress.java
@@ -27,7 +27,7 @@ public interface CompileProgress {
 	 * @param unitPath The path of the compilation unit. It will be empty
 	 *                 when a Java compiler is reporting the progress.
 	 */
-	void startUnit(String phase, String unitPath);
+	default void startUnit(String phase, String unitPath) {}
 
 	/**
 	 * Advance the progress of the current unit.
@@ -39,7 +39,9 @@ public interface CompileProgress {
 	 *
 	 * @return Whether the user has cancelled compilation or not.
 	 */
-	boolean advance(int current, int total, String prevPhase, String nextPhase);
+	default boolean advance(int current, int total, String prevPhase, String nextPhase) {
+		return true;
+	}
 
 	/**
 	 * Called when early output is created mid-compilation, or
@@ -47,5 +49,5 @@ public interface CompileProgress {
 	 *
 	 * @param success True if output is written; false otherwise.
 	 */
-	void earlyOutputComplete(boolean success);
+	default void afterEarlyOutput(boolean success) {}
 }

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/JarUtils.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/JarUtils.scala
@@ -166,6 +166,9 @@ object JarUtils {
     IndexBasedZipFsOps.listEntries(jar).filter(_.endsWith(".class"))
   }
 
+  /** Lists file entries in jar e.g. sbt/internal/inc/JarUtils.class */
+  def listFiles(jar: Path): Seq[String] = IndexBasedZipFsOps.listEntries(jar.toFile)
+
   /**
    * Removes specified entries from a jar file.
    */

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala
@@ -382,8 +382,4 @@ object AnalyzingCompiler {
     name.endsWith(".scala") || name.endsWith(".java")
 }
 
-private[this] object IgnoreProgress extends CompileProgress {
-  override def startUnit(phase: String, unitPath: String): Unit = ()
-  override def advance(current: Int, total: Int, prevPhase: String, nextPhase: String) = true
-  override def earlyOutputComplete(success: Boolean) = ()
-}
+private[this] object IgnoreProgress extends CompileProgress

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -361,7 +361,7 @@ object Incremental {
     def notifyEarlyArtifact(): Unit =
       if (options.pipelining)
         progress foreach { p =>
-          p.earlyOutputComplete(hasAnyMacro(previous))
+          p.afterEarlyOutput(hasAnyMacro(previous))
         } else ()
     val hasModified = initialInvClasses.nonEmpty || initialInvSources.nonEmpty
     val analysis = withClassfileManager(options, converter, output, outputJarContent) {
@@ -819,7 +819,7 @@ private final class AnalysisCallback(
     def notifyEarlyArifactFailure(): Unit =
       if (!writtenEarlyArtifacts) {
         progress foreach { p =>
-          p.earlyOutputComplete(false)
+          p.afterEarlyOutput(false)
         }
       }
     outputJarContent.scalacRunCompleted()
@@ -1040,7 +1040,7 @@ private final class AnalysisCallback(
       PickleJar.write(pickleJarPath, ps)
     }
     progress foreach { p =>
-      p.earlyOutputComplete(true)
+      p.afterEarlyOutput(true)
     }
   }
 }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/PickleJar.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/PickleJar.scala
@@ -19,13 +19,13 @@ import java.nio.file.attribute.BasicFileAttributes
 import scala.reflect.io.RootPath
 
 object PickleJar {
-  def write(pickleOut: Path, knownProducts: Set[String]): Path = {
+  def write(pickleOut: Path, knownProducts: java.util.Set[String]): Path = {
     val pj = RootPath(pickleOut, writable = false) // so it doesn't delete the file
     try Files.walkFileTree(pj.root, deleteUnknowns(knownProducts))
     finally pj.close()
   }
 
-  def deleteUnknowns(knownProducts: Set[String]) = new SimpleFileVisitor[Path] {
+  def deleteUnknowns(knownProducts: java.util.Set[String]) = new SimpleFileVisitor[Path] {
     override def visitFile(path: Path, attrs: BasicFileAttributes): FileVisitResult = {
       val ps = path.toString
       if (ps.endsWith(".sig")) {

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -598,6 +598,7 @@ case class ProjectStructure(
       override def advance(current: Int, total: Int, prevPhase: String, nextPhase: String) = true
       override def earlyOutputComplete(success: Boolean) = {
         if (success) {
+          assert(Files.exists(earlyOutput))
           scriptedLog.info(s"[progress] early output is done for $name!")
         } else {
           scriptedLog.info(s"[progress] early output can't be made for $name because macros!")

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -595,8 +595,7 @@ case class ProjectStructure(
       override def startUnit(phase: String, unitPath: String): Unit = {
         // scriptedLog.debug(s"[zinc] start $phase $unitPath")
       }
-      override def advance(current: Int, total: Int, prevPhase: String, nextPhase: String) = true
-      override def earlyOutputComplete(success: Boolean) = {
+      override def afterEarlyOutput(success: Boolean) = {
         if (success) {
           assert(Files.exists(earlyOutput))
           scriptedLog.info(s"[progress] early output is done for $name!")

--- a/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
@@ -469,7 +469,7 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
         extra
       )
       def prevResult = CompileResult.of(prev, config.currentSetup, false)
-      if (skip) prevResult
+      if (skip && !incrementalOptions.pipelining) prevResult
       else if (recompileAllJava) {
         if (javaSrcs.isEmpty) prevResult
         else {

--- a/zinc/src/sbt-test/source-dependencies/subproject-pipelining/changes/B2.scala
+++ b/zinc/src/sbt-test/source-dependencies/subproject-pipelining/changes/B2.scala
@@ -2,4 +2,5 @@ package example
 
 object B {
   val y = A.x
+  val z = 1
 }

--- a/zinc/src/sbt-test/source-dependencies/subproject-pipelining/changes/Break.scala
+++ b/zinc/src/sbt-test/source-dependencies/subproject-pipelining/changes/Break.scala
@@ -1,1 +1,3 @@
+package example
+
 object Break

--- a/zinc/src/sbt-test/source-dependencies/subproject-pipelining/dep/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/subproject-pipelining/dep/A.scala
@@ -1,3 +1,5 @@
+package example
+
 object A {
   val x = 3
 }

--- a/zinc/src/sbt-test/source-dependencies/subproject-pipelining/test
+++ b/zinc/src/sbt-test/source-dependencies/subproject-pipelining/test
@@ -1,6 +1,12 @@
 # done this way because last modified times often have ~1s resolution
 > use/compile
-$ sleep 2000
+$ sleep 1000
+
+# This tests no-op compilation of dep
+$ copy-file changes/B2.scala use/B.scala
+> use/compile
+$ sleep 1000
 
 $ copy-file changes/Break.scala dep/A.scala
 -> use/compile
+

--- a/zinc/src/test/scala/sbt/inc/TestProjectSetup.scala
+++ b/zinc/src/test/scala/sbt/inc/TestProjectSetup.scala
@@ -199,14 +199,9 @@ object TestProjectSetup {
 
     var lastCompiledUnits: Set[String] = Set.empty
     val progress = new CompileProgress {
-      override def advance(
-          current: Int,
-          total: Int,
-          prevPhaseName: String,
-          nextPhaseName: String
-      ): Boolean = true
-      override def startUnit(phase: String, unitPath: String): Unit = lastCompiledUnits += unitPath
-      override def earlyOutputComplete(success: Boolean): Unit = ()
+      override def startUnit(phase: String, unitPath: String): Unit = {
+        lastCompiledUnits += unitPath
+      }
     }
 
     val setup = compiler.setup(


### PR DESCRIPTION
Fixes https://github.com/sbt/zinc/issues/847

This fixes the no-op case.

<s>
This fixes 2 related bugs.

First is that prior to this change, early notification could have triggered multiple times in `AnalysisCallback#getCycleResultOnce`. This fixes that by moving that to `CycleState#completeCycles`, which is called only for the final cycle.
</s>
