### PR TITLE
Fix WrappedSet.contains

### DIFF
--- a/internal/zinc-core/src/main/scala-2.12/sbt/internal/inc/WrappedSet.scala
+++ b/internal/zinc-core/src/main/scala-2.12/sbt/internal/inc/WrappedSet.scala
@@ -6,7 +6,7 @@ import scala.collection.immutable.Set
 private[inc] class WrappedSet(s: java.util.Set[VirtualFileRef]) extends Set[VirtualFileRef] {
   import scala.collection.JavaConverters._
   def iterator: Iterator[xsbti.VirtualFileRef] = s.asScala.iterator
-  def contains(elem: xsbti.VirtualFileRef): Boolean = s.contains(s)
+  def contains(elem: xsbti.VirtualFileRef): Boolean = s.contains(elem)
 
   def +(elem: xsbti.VirtualFileRef): Set[xsbti.VirtualFileRef] =
     s.asScala.foldLeft(Set(elem)) { case (a, e) => a + e }

--- a/internal/zinc-core/src/main/scala-2.13/sbt/internal/inc/WrappedSet.scala
+++ b/internal/zinc-core/src/main/scala-2.13/sbt/internal/inc/WrappedSet.scala
@@ -6,7 +6,7 @@ import xsbti.VirtualFileRef
 private[inc] class WrappedSet(s: java.util.Set[VirtualFileRef]) extends Set[VirtualFileRef] {
   import scala.jdk.CollectionConverters._
   def iterator: Iterator[VirtualFileRef] = s.asScala.iterator
-  def contains(elem: VirtualFileRef): Boolean = s.contains(s)
+  def contains(elem: VirtualFileRef): Boolean = s.contains(elem)
   def excl(elem: VirtualFileRef): Set[VirtualFileRef] =
     s.asScala.foldLeft(Set.empty[VirtualFileRef]) { case (a, e) => if (e != elem) a + e else a }
   def incl(elem: VirtualFileRef): Set[VirtualFileRef] =


### PR DESCRIPTION
I noticed from code inspection that the contains method of WrappedSet
was not correctly implemented. It doesn't appear that it is called in
zinc but I figured it would still be good to fix in case it ever is. (My
assumption was that only the iterator method of these Sets would be
called since they just hold the source and binary changes between
analysis runs. Avoiding creating an immutable set when when all we
needed was an iterator over the existing data was the reason for the
WrappedSet class in the first place.)