### PR TITLE
Catch xsbt.CompileFailed

### DIFF
--- a/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
@@ -331,6 +331,7 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
     try {
       compilerRun
     } catch {
+      case e: xsbti.CompileFailed  => throw e // just ignore
       case e: CompileFailed        => throw e // just ignore
       case e: InterruptedException => throw e // just ignore
       case e: Throwable =>


### PR DESCRIPTION
sbt with the latest zinc was printing very noisy stack traces when
compilation failed because zinc was treating xsbti.CompileFailed (which
is what InterfaceCompileFailed inherits from) as an unexpected error and
printing a stack trace.