### PR TITLE
Pipelining follow-up

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -446,6 +446,7 @@ lazy val compilerInterface = (projectMatrix in internalPath / "compiler-interfac
       exclude[ReversedMissingMethodProblem]("xsbti.compile.IncrementalCompiler.compile"),
       exclude[ReversedMissingMethodProblem]("xsbti.compile.ScalaInstance.loaderLibraryOnly"),
       exclude[ReversedMissingMethodProblem]("xsbti.compile.ScalaInstance.libraryJars"),
+      exclude[ReversedMissingMethodProblem]("xsbti.compile.IncrementalCompiler.compileAllJava"),
     ),
   )
   .jvmPlatform(autoScalaLibrary = false)

--- a/internal/compiler-interface/src/main/java/xsbti/compile/IncrementalCompiler.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/IncrementalCompiler.java
@@ -183,4 +183,18 @@ public interface IncrementalCompiler {
                           FileConverter converter,
                           ReadStamps stamper,
                           Logger logger);
+
+    /**
+     * Compile all Java sources based on xsbti.compile.Inputs.
+     * Currently this step is necessary to perform pipeline builds.
+     *
+     * @param inputs An instance of {@link Inputs} that collect all the inputs
+     *               required to run the compiler (from sources and classpath,
+     *               to compilation order, previous results, current setup, etc).
+     * @param logger An instance of {@link Logger} that logs Zinc output.
+     *
+     * @return An instance of {@link CompileResult} that holds information
+     * about the results of the compilation.
+     */
+    CompileResult compileAllJava(Inputs inputs, Logger logger);
 }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -361,7 +361,7 @@ object Incremental {
     def notifyEarlyArtifact(): Unit =
       if (options.pipelining)
         progress foreach { p =>
-          p.afterEarlyOutput(hasAnyMacro(previous))
+          p.afterEarlyOutput(!hasAnyMacro(previous))
         } else ()
     val hasModified = initialInvClasses.nonEmpty || initialInvSources.nonEmpty
     val analysis = withClassfileManager(options, converter, output, outputJarContent) {

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/PickleJar.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/PickleJar.scala
@@ -19,10 +19,20 @@ import java.nio.file.attribute.BasicFileAttributes
 import scala.reflect.io.RootPath
 
 object PickleJar {
+  // create an empty JAR file in case the subproject has no classes.
+  def touch(pickleOut: Path): Unit = {
+    if (!Files.exists(pickleOut)) {
+      Files.createDirectories(pickleOut.getParent)
+      Files.createFile(pickleOut)
+    }
+    ()
+  }
   def write(pickleOut: Path, knownProducts: java.util.Set[String]): Path = {
     val pj = RootPath(pickleOut, writable = false) // so it doesn't delete the file
-    try Files.walkFileTree(pj.root, deleteUnknowns(knownProducts))
+    val result = try Files.walkFileTree(pj.root, deleteUnknowns(knownProducts))
     finally pj.close()
+    touch(pickleOut)
+    result
   }
 
   def deleteUnknowns(knownProducts: java.util.Set[String]) = new SimpleFileVisitor[Path] {

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
@@ -392,7 +392,7 @@ private class MStamps(
       products.size,
       sources.size,
       libraries.size
-    ) + " " + sources.toString
+    )
 }
 
 /**

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -761,9 +761,10 @@ case class ProjectStructure(
     }
     val scalacOptions: List[String] =
       (Option(map.get("scalac.options")) match {
-        case Some(x)                    => List(x)
-        case _ if incOptions.pipelining => List("-Ypickle-java")
-        case _                          => Nil
+        case Some(x) => List(x)
+        case _ if incOptions.pipelining =>
+          List("-Ypickle-java", "-Ypickle-write", earlyOutput.toString)
+        case _ => Nil
       }).flatMap(_.toString.split(" +").toList)
     (incOptions, scalacOptions.toArray)
   }

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -53,7 +53,7 @@ import sjsonnew.support.scalajson.unsafe.{ Converter, Parser => JsonParser }
 
 import scala.{ PartialFunction => ?=> }
 import scala.collection.mutable
-import scala.concurrent.{ Await, Future, Promise }
+import scala.concurrent.{ blocking, Await, Future, Promise }
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
 import scala.util.Success
@@ -71,9 +71,13 @@ final case class IncState(
     si: XScalaInstance,
     cs: XCompilers,
     number: Int,
-    compilations: mutable.Map[ProjectStructure, (Future[Analysis], Future[Boolean])]
+    compilations: scala.collection.concurrent.Map[
+      ProjectStructure,
+      (Future[Analysis], Future[Boolean])
+    ] = scala.collection.concurrent.TrieMap.empty
 ) {
-  def inc: IncState = copy(number = number + 1, compilations = mutable.Map.empty)
+  def inc: IncState =
+    copy(number = number + 1, compilations = scala.collection.concurrent.TrieMap.empty)
 }
 
 class IncHandler(directory: Path, cacheDir: Path, scriptedLog: ManagedLogger, compileToJar: Boolean)
@@ -192,7 +196,7 @@ class IncHandler(directory: Path, cacheDir: Path, scriptedLog: ManagedLogger, co
     }
     val analyzingCompiler = scalaCompiler(si, compilerBridge)
     val cs = incrementalCompiler.compilers(si, ClasspathOptionsUtil.boot, None, analyzingCompiler)
-    IncState(si, cs, 0, mutable.Map.empty)
+    IncState(si, cs, 0)
   }
 
   private final val unit = (_: Seq[String]) => ()
@@ -364,7 +368,12 @@ case class ProjectStructure(
       }
     }
 
-  def clean(): Future[Unit] = Future { IO.delete(classesDir.toFile) }
+  def clean(): Future[Unit] =
+    Future {
+      blocking {
+        IO.delete(classesDir.toFile)
+      }
+    }
 
   def checkNumberOfCompilerIterations(i: IncState, expected: Int): Future[Unit] =
     compile(i).map { analysis =>
@@ -496,7 +505,6 @@ case class ProjectStructure(
     }
 
   def compile(i: IncState): Future[Analysis] = startCompilation(i)._1
-  def earlyArtifact(i: IncState): Future[Boolean] = startCompilation(i)._2
 
   def startCompilation(i: IncState): (Future[Analysis], Future[Boolean]) = synchronized {
     def traditionalLookupAnalysis: VirtualFile => Option[CompileAnalysis] = {
@@ -519,9 +527,9 @@ case class ProjectStructure(
       }
       val f1 = dependsOnRef.foldLeft(f0) { (acc, dep) =>
         acc.orElse {
-          case x
-              if (converter.toPath(x).toAbsolutePath == dep.classesDir.toAbsolutePath)
-                || (converter.toPath(x).toAbsolutePath == dep.earlyOutput.toAbsolutePath) =>
+          case x if converter.toPath(x).toAbsolutePath == dep.classesDir.toAbsolutePath =>
+            dep.prev().analysis().toOption
+          case x if converter.toPath(x).toAbsolutePath == dep.earlyOutput.toAbsolutePath =>
             dep.earlyPreviousResult.analysis().toOption
         }
       }
@@ -531,19 +539,35 @@ case class ProjectStructure(
     i.compilations.get(this).getOrElse {
       val notifyEarlyOutput: Promise[Boolean] = Promise[Boolean]()
       if (incOptions.pipelining) {
+        // Initiate compilation
+        val triggerDeps: Map[ProjectStructure, (Future[Analysis], Future[Boolean])] =
+          Map(dependsOnRef map { dep =>
+            dep -> dep.startCompilation(i)
+          }: _*)
+        val wholeDeps = Future.traverse(dependsOnRef) { dep =>
+          triggerDeps(dep)._1.map(_ => dep.output)
+        }
         // future of early outputs
         val earlyDeps: Future[Seq[Path]] = Future.traverse(dependsOnRef) { dep =>
-          dep.earlyArtifact(i).map(success => if (success) dep.earlyOutput else dep.output)
+          triggerDeps(dep)._2 flatMap { success =>
+            if (success) {
+              Future.successful { dep.earlyOutput }
+            } else {
+              triggerDeps(dep)._1.map(_ => dep.output)
+            }
+          }
         }
         val futureScalaAnalysis = earlyDeps.map { internalCp =>
-          doCompile(i, notifyEarlyOutput, internalCp, pipelinedLookupAnalysis, false)
-        }
-        val wholeDeps = Future.traverse(dependsOnRef) { dep =>
-          dep.compile(i).map(_ => dep.output)
+          blocking {
+            scriptedLog.info(s"[$name] internapCp = $internalCp")
+            doCompile(i, notifyEarlyOutput, internalCp, pipelinedLookupAnalysis, false)
+          }
         }
         def futureJavaAnalysis(projectDependencies: Seq[Path], prev: Analysis): Future[Analysis] =
           Future {
-            doCompile(i, notifyEarlyOutput, projectDependencies, pipelinedLookupAnalysis, true)
+            blocking {
+              doCompile(i, notifyEarlyOutput, projectDependencies, pipelinedLookupAnalysis, true)
+            }
           }
 
         // wait for the full compilation from the dependencies
@@ -598,9 +622,9 @@ case class ProjectStructure(
       override def afterEarlyOutput(success: Boolean) = {
         if (success) {
           assert(Files.exists(earlyOutput))
-          scriptedLog.info(s"[progress] early output is done for $name!")
+          scriptedLog.info(s"[$name][progress] early output is done!")
         } else {
-          scriptedLog.info(s"[progress] early output can't be made for $name because macros!")
+          scriptedLog.info(s"[$name][progress] early output can't be made because macros!")
         }
         notifyEarlyOutput.complete(Success(success))
       }
@@ -641,7 +665,7 @@ case class ProjectStructure(
       else incrementalCompiler.compile(in, scriptedLog)
     val analysis = result.analysis match { case a: Analysis => a }
     cachedStore.set(AnalysisContents.create(analysis, result.setup))
-    scriptedLog.info(s"""$name: compilation done: ${sources.toList.mkString(", ")}""")
+    scriptedLog.info(s"""[$name] compilation done: ${sources.toList.mkString(", ")}""")
     analysis
   }
 
@@ -725,7 +749,11 @@ case class ProjectStructure(
     import scala.collection.JavaConverters._
     val map = new java.util.HashMap[String, String]
     properties.asScala foreach { case (k: String, v: String) => map.put(k, v) }
-    val base = IncOptions.of().withPipelining(defaultPipelining)
+    val base = IncOptions
+      .of()
+      .withPipelining(defaultPipelining)
+      .withApiDebug(true)
+    //.withRelationsDebug(true)
     val incOptions = {
       val opts = IncOptionsUtil.fromStringMap(base, map, scriptedLog)
       if (opts.recompileAllFraction() != IncOptions.defaultRecompileAllFraction()) opts

--- a/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
@@ -28,7 +28,7 @@ import xsbti.compile.analysis.ReadStamps
 class IncrementalCompilerImpl extends IncrementalCompiler {
 
   /**
-   * Compile all Java compilation based on xsbti.compile.Inputs.
+   * Compile all Java sources based on xsbti.compile.Inputs.
    *
    * This is a Scala implementation of xsbti.compile.IncrementalCompiler,
    * check the docs for more information on the specification of this method.

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -143,11 +143,10 @@ final class MixedAnalyzingCompiler(
     val isPickleJava = config.currentSetup.order == Mixed && config.incOptions.pipelining && javaSrcs.nonEmpty
 
     val earlyOut = config.earlyOutput.flatMap(_.getSingleOutputAsPath.toOption)
-    val pickleWrite = earlyOut.toList.flatMap { out =>
-      val sbv = scalac.scalaInstance.version.take(4)
-      if (out.toString.endsWith(".jar") && !Files.exists(out))
+    earlyOut foreach { out =>
+      if (out.toString.endsWith(".jar") && !Files.exists(out)) {
         scala.reflect.io.RootPath(out, writable = true).close() // creates an empty jar
-      List("-Ypickle-write", out.toString).filter(_ => sbv == "2.12" || sbv == "2.13")
+      }
     }
 
     // Compile Scala sources.
@@ -162,7 +161,7 @@ final class MixedAnalyzingCompiler(
             config.converter.toVirtualFile(x.toAbsolutePath)
           }) ++ absClasspath
           val arguments =
-            cArgs.makeArguments(Nil, cp, config.currentSetup.options.scalacOptions ++ pickleWrite)
+            cArgs.makeArguments(Nil, cp, config.currentSetup.options.scalacOptions)
           timed("Scala compilation", log) {
             config.compiler.compile(
               sources.toArray,

--- a/zinc/src/test/scala/sbt/inc/TestProjectSetup.scala
+++ b/zinc/src/test/scala/sbt/inc/TestProjectSetup.scala
@@ -229,7 +229,8 @@ object TestProjectSetup {
       sources.toArray,
       output,
       Some(earlyOutput),
-      scalacOptions = (Vector("-Ypickle-java") ++ scalacOptions).toArray,
+      scalacOptions =
+        (Vector("-Ypickle-java", "-Ypickle-write", earlyOutput.toString) ++ scalacOptions).toArray,
       javacOptions = Array(),
       maxErrors,
       sourcePositionMappers = Array(),


### PR DESCRIPTION
1. success needs to be `false` when there is a macro, not other way around.
2. AnalysisLookup should use the traditional one when macro is present.
3. Create an empty JAR as a stand-in for pickle JAR when there are no classes.
4. Attempt to create one compiler bridge at a time to avoid Windows file issue.
5. Add `compileAllJava(...)` to `IncrementalCompiler` interface.