### PR TITLE
Let the build tools configure -Ypickle-write flag

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -343,11 +343,16 @@ object Incremental {
     val javaSources: Set[VirtualFileRef] = sources.collect {
       case s: VirtualFileRef if s.name.endsWith(".java") => s
     }
+    val isPickleWrite = currentSetup.options.scalacOptions.contains("-Ypickle-write")
+    if (!isPickleWrite && options.pipelining) {
+      log.warn(s"-Ypickle-write should be included into scalacOptions if pipelining is enabled")
+    }
     val isPickleJava = currentSetup.options.scalacOptions.contains("-Ypickle-java")
-    assert(
-      javaSources.isEmpty || !options.pipelining || isPickleJava,
-      s"-Ypickle-java must be included into scalacOptions if pipelining is enabled with Java sources"
-    )
+    if (javaSources.nonEmpty && options.pipelining && !isPickleJava) {
+      log.warn(
+        s"-Ypickle-java should be included into scalacOptions if pipelining is enabled with Java sources"
+      )
+    }
     val initialInvSources =
       if (isPickleJava && initialInvSources0.nonEmpty) initialInvSources0 ++ javaSources
       else initialInvSources0

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -761,9 +761,10 @@ case class ProjectStructure(
     }
     val scalacOptions: List[String] =
       (Option(map.get("scalac.options")) match {
-        case Some(x)                    => List(x)
-        case _ if incOptions.pipelining => List("-Ypickle-java")
-        case _                          => Nil
+        case Some(x) => List(x)
+        case _ if incOptions.pipelining =>
+          List("-Ypickle-java", "-Ypickle-write", earlyOutput.toString)
+        case _ => Nil
       }).flatMap(_.toString.split(" +").toList)
     (incOptions, scalacOptions.toArray)
   }

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -141,11 +141,10 @@ final class MixedAnalyzingCompiler(
     val isPickleJava = config.currentSetup.order == Mixed && config.incOptions.pipelining && javaSrcs.nonEmpty
 
     val earlyOut = config.earlyOutput.flatMap(_.getSingleOutputAsPath.toOption)
-    val pickleWrite = earlyOut.toList.flatMap { out =>
-      val sbv = scalac.scalaInstance.version.take(4)
-      if (out.toString.endsWith(".jar") && !Files.exists(out))
+    earlyOut foreach { out =>
+      if (out.toString.endsWith(".jar") && !Files.exists(out)) {
         scala.reflect.io.RootPath(out, writable = true).close() // creates an empty jar
-      List("-Ypickle-write", out.toString).filter(_ => sbv == "2.12" || sbv == "2.13")
+      }
     }
 
     // Compile Scala sources.
@@ -160,7 +159,7 @@ final class MixedAnalyzingCompiler(
             x.toAbsolutePath
           }) ++ absClasspath.map(config.converter.toPath)
           val arguments =
-            cArgs.makeArguments(Nil, cp, config.currentSetup.options.scalacOptions ++ pickleWrite)
+            cArgs.makeArguments(Nil, cp, config.currentSetup.options.scalacOptions)
           timed("Scala compilation", log) {
             config.compiler.compile(
               sources.toArray,

--- a/zinc/src/test/scala/sbt/inc/TestProjectSetup.scala
+++ b/zinc/src/test/scala/sbt/inc/TestProjectSetup.scala
@@ -229,7 +229,8 @@ object TestProjectSetup {
       sources.toArray,
       output,
       Some(earlyOutput),
-      scalacOptions = (Vector("-Ypickle-java") ++ scalacOptions).toArray,
+      scalacOptions =
+        (Vector("-Ypickle-java", "-Ypickle-write", earlyOutput.toString) ++ scalacOptions).toArray,
       javacOptions = Array(),
       maxErrors,
       sourcePositionMappers = Array(),


### PR DESCRIPTION
Ref https://github.com/sbt/zinc/pull/855 / https://github.com/sbt/zinc/pull/860

This reverts commit af29a4aedc10e1755833ce33b274d58fbd12ce6d.

As a general policy, Zinc should avoid adding Scalac flags to the build, and let build tools handle it.

https://github.com/sbt/zinc/pull/821 introduced `-Ypickle-write` flag, which I now realize is not great. It's an experimental flag that's not existed in earlier version of 2.12.x or 2.13.x, and its status may change over time. When I started using it with sbt, I saw log message of sig files written even when pipelining wasn't enabled.

I'm happy to see pipelining become available to all build tools, but it's a feature that still requires careful coordination with the build tool anyway (esp in terms of calling `compileAllJava`), so adding this I don't think adds to much of convenience. Note `-Ypickle-java` is not added by default.