### PR TITLE
Only check if library changed if its stamp changed

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
@@ -821,7 +821,7 @@ object IncrementalCommon {
       }
 
       if (skipClasspathLookup) compareStamps(binaryFile, binaryFile)
-      else isLibraryChanged(binaryFile)
+      else compareStamps(binaryFile, binaryFile) && isLibraryChanged(binaryFile)
     }
   }
 


### PR DESCRIPTION
The isLibraryChanged method is fairly expensive and we can bypass it if
the stamps haven't changed. In sbt 1.4.0, the stamps are time wrapped
file hashes and since libraries change fairly rarely, we rarely have to
evaluate the hash and even less frequently have to inspect the file
contents.

This changed reduced the time to run `test` by about 15ms in a very
simple project that only had a few libraries. I could imagine the
improvement being more substantial for projects with a heavy dependency
graph.