### PR TITLE
Use toIterator instead of toStream

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
@@ -41,7 +41,8 @@ sealed abstract class CallbackGlobal(
     output match {
       case single: SingleOutput => List(single.getOutputDirectoryAsPath)
       // Use Stream instead of List because Analyzer maps intensively over the directories
-      case multi: MultipleOutput => multi.getOutputGroups.toStream map (_.getOutputDirectoryAsPath)
+      case multi: MultipleOutput =>
+        multi.getOutputGroups.toIterator.map(_.getOutputDirectoryAsPath).toSeq
     }
   }
 

--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaders.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaders.scala
@@ -191,9 +191,10 @@ trait NativeCopyLoader extends ClassLoader {
 
   private[this] def findLibrary0(name: String): String = {
     val mappedName = System.mapLibraryName(name)
-    val explicit = explicitLibraries.filter(_.getFileName.toString == mappedName).toStream
-    val search = searchPaths.toStream flatMap relativeLibrary(mappedName)
-    (explicit ++ search).headOption.map(copy).orNull
+    val explicit = explicitLibraries.toIterator.filter(_.getFileName.toString == mappedName)
+    val search = searchPaths.toIterator flatMap relativeLibrary(mappedName)
+    val combined = explicit ++ search
+    if (combined.hasNext) copy(combined.next) else null
   }
   private[this] def relativeLibrary(mappedName: String)(base: Path): Seq[Path] = {
     val f = base.resolve(mappedName)


### PR DESCRIPTION
Historically Streams have not performed nearly as well as Iterator. I'm
not sure how relevant that is the case for the latest versions of scala
but there were a number of places where it was easy to switch from
Streams to Iterators so this commit does just that. There is very little
expressivity loss in the switch from Iterator to Stream.

From a performance perspective, I have been testing the zinc overhead in
a small project by looping 100 iterations of no-op Test / compile. While
not a scientific benchmark by any means, I pretty consistently found
zinc to run about 10% faster (~63ms average after this change compared
to ~70 ms before).