### PR TITLE
Prevent overcompilation in mixed projects without pipelining

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -2,6 +2,7 @@ version = 2.1.0-RC1
 maxColumn = 100
 project.git = true
 project.excludeFilters = [ /sbt-test/, /input_sources/, /contraband-scala/ ]
+lineEndings = preserve
 
 # http://docs.scala-lang.org/style/scaladoc.html recommends the JavaDoc style.
 # scala/scala is written that way too https://github.com/scala/scala/blob/v2.12.2/src/library/scala/Predef.scala

--- a/build.sbt
+++ b/build.sbt
@@ -150,6 +150,7 @@ lazy val zincRoot: Project = (project in file("."))
     mimaPreviousArtifacts := Set.empty,
     scriptedBufferLog := true,
     scripted := scriptedTask.evaluated,
+    scripted / watchTriggers += baseDirectory.value.toGlob / "zinc" / "src" / "sbt-test" / **,
     Scripted.scriptedSource := (zinc212 / sourceDirectory).value / "sbt-test",
     Scripted.scriptedCompileToJar := false,
     noPublish,

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/LocalJava.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/LocalJava.scala
@@ -298,6 +298,10 @@ final class LocalJavaCompiler(compiler: javax.tools.JavaCompiler) extends XJavaC
       log.warn(invalidOptions.mkString("\t", ", ", ""))
     }
     val outputOption = CompilerArguments.outputOption(output)
+    output.getSingleOutputAsPath match {
+      case p if p.isPresent => Files.createDirectories(p.get)
+      case _                =>
+    }
 
     val fileManager = {
       if (cleanedOptions.contains("-XDuseOptimizedZip=false")) {

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -339,7 +339,7 @@ object Incremental {
     val (initialInvClasses, initialInvSources0) =
       incremental.invalidateInitial(previous.relations, initialChanges)
 
-    // If there's any compilation at all, invalidate all java sources too, so we have access to their type information.
+    // During pipelining, if there's any compilation at all, invalidate all Java sources too, so the downstream Scala subprojects would have type information via early output (pickle jar).
     val javaSources: Set[VirtualFileRef] = sources.collect {
       case s: VirtualFileRef if s.name.endsWith(".java") => s
     }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -340,17 +340,17 @@ object Incremental {
       incremental.invalidateInitial(previous.relations, initialChanges)
 
     // If there's any compilation at all, invalidate all java sources too, so we have access to their type information.
-    val javaSources: Set[VirtualFileRef] = sources
-      .filter(_.name.endsWith(".java"))
-      .map(_.asInstanceOf[VirtualFileRef])
+    val javaSources: Set[VirtualFileRef] = sources.collect {
+      case s: VirtualFileRef if s.name.endsWith(".java") => s
+    }
     val isPickleJava = currentSetup.options.scalacOptions.contains("-Ypickle-java")
     assert(
       javaSources.isEmpty || !options.pipelining || isPickleJava,
       s"-Ypickle-java must be included into scalacOptions if pipelining is enabled with Java sources"
     )
     val initialInvSources =
-      if (initialInvSources0.nonEmpty) initialInvSources0 ++ javaSources
-      else Set.empty[VirtualFileRef]
+      if (isPickleJava && initialInvSources0.nonEmpty) initialInvSources0 ++ javaSources
+      else initialInvSources0
     if (initialInvClasses.nonEmpty || initialInvSources.nonEmpty) {
       if (initialInvSources == sources)
         incremental.log.debug(s"all ${initialInvSources.size} sources are invalidated")

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -113,9 +113,7 @@ final class MixedAnalyzingCompiler(
       val dir =
         if (d.toString.endsWith(".jar")) d.getParent
         else d
-      if (!Files.exists(dir)) {
-        Files.createDirectories(dir)
-      }
+      Files.createDirectories(dir)
     }
     outputDirs
   }

--- a/zinc/src/sbt-test/source-dependencies/less-inter-inv-java/test
+++ b/zinc/src/sbt-test/source-dependencies/less-inter-inv-java/test
@@ -6,4 +6,4 @@ $ copy-file changes/A2.java A.java
 # 1 iteration to recompile all descendents and direct dependencies
 # no further iteration, because APIs of directs don't change
 > run
-> checkIterations 2
+> checkIterations 3

--- a/zinc/src/sbt-test/source-dependencies/mixed-java-invalidations/changes/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/mixed-java-invalidations/changes/A.scala
@@ -1,0 +1,3 @@
+object A {
+  val x = 1
+}

--- a/zinc/src/sbt-test/source-dependencies/mixed-java-invalidations/changes/B.scala
+++ b/zinc/src/sbt-test/source-dependencies/mixed-java-invalidations/changes/B.scala
@@ -1,0 +1,4 @@
+object B {
+  val foo = new Foo
+  val y = 2
+}

--- a/zinc/src/sbt-test/source-dependencies/mixed-java-invalidations/incOptions.properties
+++ b/zinc/src/sbt-test/source-dependencies/mixed-java-invalidations/incOptions.properties
@@ -1,0 +1,2 @@
+# turn off pipelining because compileAllJava over-compiles
+pipelining = false

--- a/zinc/src/sbt-test/source-dependencies/mixed-java-invalidations/src/main/java/Foo.java
+++ b/zinc/src/sbt-test/source-dependencies/mixed-java-invalidations/src/main/java/Foo.java
@@ -1,0 +1,1 @@
+public class Foo {}

--- a/zinc/src/sbt-test/source-dependencies/mixed-java-invalidations/src/main/scala/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/mixed-java-invalidations/src/main/scala/A.scala
@@ -1,0 +1,1 @@
+object A

--- a/zinc/src/sbt-test/source-dependencies/mixed-java-invalidations/src/main/scala/B.scala
+++ b/zinc/src/sbt-test/source-dependencies/mixed-java-invalidations/src/main/scala/B.scala
@@ -1,0 +1,3 @@
+object B {
+  val foo = new Foo
+}

--- a/zinc/src/sbt-test/source-dependencies/mixed-java-invalidations/test
+++ b/zinc/src/sbt-test/source-dependencies/mixed-java-invalidations/test
@@ -1,0 +1,10 @@
+> compile
+> checkIterations 1
+
+$ copy-file changes/A.scala src/main/scala/A.scala
+> compile
+> checkIterations 2
+
+$ copy-file changes/B.scala src/main/scala/B.scala
+> compile
+> checkIterations 3


### PR DESCRIPTION
The latest zinc will overcompile mixed projects when scala sources have changed but no java sources have. Fixes #867.