### PR TITLE
Make xsbt.CompilerInterface class name configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ please check the [CONTRIBUTING guide](CONTRIBUTING.md).
 
 This software is released under the following [LICENSE](LICENSE).
 
+### Note to compiler bridge authors
+
+The compiler bridge classes are loaded using [java.util.ServiceLoader](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html). In other words, the class implementing `xsbti.compile.CompilerInterface2` must be mentioned in a file named: `/META-INF/services/xsbti.compile.CompilerInterface2`.
+
 ## Acknowledgements
 
 | Logo | Acknowledgement |

--- a/build.sbt
+++ b/build.sbt
@@ -223,7 +223,7 @@ lazy val zincTesting = (projectMatrix in internalPath / "zinc-testing")
     name := "zinc Testing",
     baseSettings,
     noPublish,
-    libraryDependencies ++= Seq(scalaCheck, scalatest, junit, sjsonnewScalaJson.value)
+    libraryDependencies ++= Seq(scalaCheck, scalatest, junit, verify, sjsonnewScalaJson.value)
   )
   .jvmPlatform(scalaVersions = List(scala212, scala213))
   .configure(addSbtIO, addSbtUtilLogging)
@@ -442,6 +442,7 @@ lazy val compilerInterface = (projectMatrix in internalPath / "compiler-interfac
       // This is a breaking change
       exclude[Problem]("xsbti.compile.CompileOptions.*"),
       exclude[Problem]("xsbti.compile.CompileProgress.*"),
+      exclude[Problem]("xsbti.InteractiveConsoleFactory.createConsole"),
       // new API points
       exclude[DirectMissingMethodProblem]("xsbti.compile.IncrementalCompiler.compile"),
       exclude[ReversedMissingMethodProblem]("xsbti.compile.IncrementalCompiler.compile"),

--- a/internal/compiler-bridge-test/src/test/scala/sbt/internal/inc/BasicBridgeSpec.scala
+++ b/internal/compiler-bridge-test/src/test/scala/sbt/internal/inc/BasicBridgeSpec.scala
@@ -1,0 +1,39 @@
+package sbt
+package internal
+package inc
+
+import verify._
+import sbt.io.IO.withTemporaryDirectory
+import sbt.io.syntax._
+
+/** This is a basic test for compiler bridge, mostly wrapped as
+ * AnalyzingCompiler.
+ */
+object BasicBridgeSpec
+    extends BasicTestSuite
+    with BridgeProviderTestkit
+    with CompilingSpecification {
+
+  test("A compiler bridge should compile") {
+    withTemporaryDirectory { tempDir =>
+      compileSrcs(tempDir.toPath, "object Foo")
+      val t = tempDir / "target" / "Foo$.class"
+      assert(t.exists)
+    }
+  }
+
+  test("A compiler bridge should run doc") {
+    withTemporaryDirectory { tempDir =>
+      doc(tempDir.toPath)(List())
+      val t = tempDir / "target" / "index.html"
+      /// println((tempDir / "target").listFiles.toList)
+      assert(t.exists)
+    }
+  }
+
+  test("A compiler bridge should run console") {
+    withTemporaryDirectory { tempDir =>
+      console(tempDir.toPath)(":q")
+    }
+  }
+}

--- a/internal/compiler-bridge-test/src/test/scala/sbt/internal/inc/ClassNameSpecification.scala
+++ b/internal/compiler-bridge-test/src/test/scala/sbt/internal/inc/ClassNameSpecification.scala
@@ -5,7 +5,10 @@ package inc
 import java.io.File
 import org.scalactic.source.Position
 
-class ClassNameSpecification extends CompilingSpecification {
+class ClassNameSpecification
+    extends UnitSpec
+    with CompilingSpecification
+    with BridgeProviderTestkit {
 
   "ClassName" should "create correct binary names for top level object" in {
     expectBinaryClassNames("object A", Set("A" -> "A", "A" -> "A$"))

--- a/internal/compiler-bridge-test/src/test/scala/sbt/internal/inc/DependencySpecification.scala
+++ b/internal/compiler-bridge-test/src/test/scala/sbt/internal/inc/DependencySpecification.scala
@@ -4,7 +4,10 @@ package inc
 
 import xsbti.TestCallback.ExtractedClassDependencies
 
-class DependencySpecification extends CompilingSpecification {
+class DependencySpecification
+    extends UnitSpec
+    with CompilingSpecification
+    with BridgeProviderTestkit {
 
   "Dependency phase" should "extract class dependencies from public members" in {
     val classDependencies = extractClassDependenciesPublic

--- a/internal/compiler-bridge-test/src/test/scala/sbt/internal/inc/ExtractAPISpecification.scala
+++ b/internal/compiler-bridge-test/src/test/scala/sbt/internal/inc/ExtractAPISpecification.scala
@@ -5,7 +5,10 @@ package inc
 import xsbti.api._
 import xsbt.api.SameAPI
 
-class ExtractAPISpecification extends CompilingSpecification {
+class ExtractAPISpecification
+    extends UnitSpec
+    with CompilingSpecification
+    with BridgeProviderTestkit {
 
   "ExtractAPI" should "give stable names to members of existential types in method signatures" in stableExistentialNames()
 

--- a/internal/compiler-bridge-test/src/test/scala/sbt/internal/inc/ExtractUsedNamesPerformanceSpecification.scala
+++ b/internal/compiler-bridge-test/src/test/scala/sbt/internal/inc/ExtractUsedNamesPerformanceSpecification.scala
@@ -11,7 +11,9 @@ import java.nio.file.Paths
 import org.scalatest.DiagrammedAssertions
 
 class ExtractUsedNamesPerformanceSpecification
-    extends CompilingSpecification
+    extends UnitSpec
+    with CompilingSpecification
+    with BridgeProviderTestkit
     with DiagrammedAssertions {
   private def initFileSystem(uri: URI): Option[FileSystem] = {
     try Option(FileSystems.getFileSystem(uri))

--- a/internal/compiler-bridge-test/src/test/scala/sbt/internal/inc/ExtractUsedNamesSpecification.scala
+++ b/internal/compiler-bridge-test/src/test/scala/sbt/internal/inc/ExtractUsedNamesSpecification.scala
@@ -4,7 +4,11 @@ package inc
 
 import org.scalatest.DiagrammedAssertions
 
-class ExtractUsedNamesSpecification extends CompilingSpecification with DiagrammedAssertions {
+class ExtractUsedNamesSpecification
+    extends UnitSpec
+    with CompilingSpecification
+    with BridgeProviderTestkit
+    with DiagrammedAssertions {
 
   "Used names extraction" should "extract imported name" in {
     val src = """package a { class A }

--- a/internal/compiler-bridge/src/main/resources/META-INF/services/xsbti.InteractiveConsoleFactory
+++ b/internal/compiler-bridge/src/main/resources/META-INF/services/xsbti.InteractiveConsoleFactory
@@ -1,0 +1,1 @@
+xsbt.InteractiveConsoleBridgeFactory

--- a/internal/compiler-bridge/src/main/resources/META-INF/services/xsbti.compile.CompilerInterface2
+++ b/internal/compiler-bridge/src/main/resources/META-INF/services/xsbti.compile.CompilerInterface2
@@ -1,0 +1,1 @@
+xsbt.CompilerBridge

--- a/internal/compiler-bridge/src/main/resources/META-INF/services/xsbti.compile.ConsoleInterface1
+++ b/internal/compiler-bridge/src/main/resources/META-INF/services/xsbti.compile.ConsoleInterface1
@@ -1,0 +1,1 @@
+xsbt.ConsoleBridge

--- a/internal/compiler-bridge/src/main/resources/META-INF/services/xsbti.compile.ScaladocInterface2
+++ b/internal/compiler-bridge/src/main/resources/META-INF/services/xsbti.compile.ScaladocInterface2
@@ -1,0 +1,1 @@
+xsbt.ScaladocBridge

--- a/internal/compiler-bridge/src/main/scala/xsbt/CompilerBridge.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CompilerBridge.scala
@@ -22,7 +22,7 @@ import java.io.File
 /**
  * This is the entry point for the compiler bridge (implementation of CompilerInterface)
  */
-final class CompilerInterface extends CompilerInterface2 {
+final class CompilerBridge extends xsbti.compile.CompilerInterface2 {
   override def run(
       sources: Array[VirtualFile],
       changes: DependencyChanges,

--- a/internal/compiler-bridge/src/main/scala/xsbt/InteractiveConsoleFactoryBridge.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/InteractiveConsoleFactoryBridge.scala
@@ -11,21 +11,22 @@
 
 package xsbt
 
+import java.util.Optional
 import xsbti.Logger
 
-class InteractiveConsoleFactory extends xsbti.InteractiveConsoleFactory {
+class InteractiveConsoleBridgeFactory extends xsbti.InteractiveConsoleFactory {
   def createConsole(
       args: Array[String],
       bootClasspathString: String,
       classpathString: String,
       initialCommands: String,
       cleanupCommands: String,
-      loader: ClassLoader,
+      loader: Optional[ClassLoader],
       bindNames: Array[String],
       bindValues: Array[AnyRef],
       log: Logger
   ): xsbti.InteractiveConsoleInterface =
-    new InteractiveConsoleInterface(
+    new InteractiveConsoleBridge(
       args,
       bootClasspathString,
       classpathString,

--- a/internal/compiler-bridge/src/main/scala/xsbt/InteractiveConsoleInterface.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/InteractiveConsoleInterface.scala
@@ -12,6 +12,7 @@
 package xsbt
 
 import java.io.{ PrintWriter, StringWriter }
+import java.util.Optional
 
 import scala.tools.nsc.interpreter.IMain
 import scala.tools.nsc.{ GenericRunnerCommand, Settings }
@@ -21,13 +22,14 @@ import xsbti.Logger
 import Compat._
 import InteractiveConsoleHelper._
 
-class InteractiveConsoleInterface(
+// See InteractiveConsoleBridgeFactory
+class InteractiveConsoleBridge(
     args: Array[String],
     bootClasspathString: String,
     classpathString: String,
     initialCommands: String,
     cleanupCommands: String,
-    loader: ClassLoader,
+    loader: Optional[ClassLoader],
     bindNames: Array[String],
     bindValues: Array[AnyRef],
     log: Logger

--- a/internal/compiler-bridge/src/main/scala/xsbt/ScaladocBridge.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ScaladocBridge.scala
@@ -15,7 +15,7 @@ import xsbti.{ Logger, VirtualFile }
 import scala.reflect.io.AbstractFile
 import Log.debug
 
-class ScaladocInterface extends xsbti.compile.ScaladocInterface2 {
+class ScaladocBridge extends xsbti.compile.ScaladocInterface2 {
   def run(sources: Array[VirtualFile], args: Array[String], log: Logger, delegate: xsbti.Reporter) =
     (new Runner(sources, args, log, delegate)).run
 }

--- a/internal/compiler-bridge/src/main/scala_2.11-12/xsbt/ConsoleBridge.scala
+++ b/internal/compiler-bridge/src/main/scala_2.11-12/xsbt/ConsoleBridge.scala
@@ -16,8 +16,8 @@ import scala.tools.nsc.interpreter.{ ILoop, IMain, InteractiveReader, NamedParam
 import scala.tools.nsc.reporters.Reporter
 import scala.tools.nsc.{ GenericRunnerCommand, Settings }
 
-class ConsoleInterface {
-  def commandArguments(
+class ConsoleBridge extends xsbti.compile.ConsoleInterface1 {
+  override def commandArguments(
       args: Array[String],
       bootClasspathString: String,
       classpathString: String,
@@ -25,7 +25,7 @@ class ConsoleInterface {
   ): Array[String] =
     MakeSettings.sync(args, bootClasspathString, classpathString, log).recreateArgs.toArray[String]
 
-  def run(
+  override def run(
       args: Array[String],
       bootClasspathString: String,
       classpathString: String,
@@ -33,7 +33,7 @@ class ConsoleInterface {
       cleanupCommands: String,
       loader: ClassLoader,
       bindNames: Array[String],
-      bindValues: Array[Any],
+      bindValues: Array[AnyRef],
       log: Logger
   ): Unit = {
     lazy val interpreterSettings = MakeSettings.sync(args.toList, log)
@@ -53,7 +53,6 @@ class ConsoleInterface {
             override protected def newCompiler(settings: Settings, reporter: Reporter) =
               super.newCompiler(compilerSettings, reporter)
           }
-          intp.setContextClassLoader()
         } else
           super.createInterpreter()
 

--- a/internal/compiler-interface/src/main/java/xsbti/InteractiveConsoleFactory.java
+++ b/internal/compiler-interface/src/main/java/xsbti/InteractiveConsoleFactory.java
@@ -11,6 +11,11 @@
 
 package xsbti;
 
+import java.util.Optional;
+
+/** Interface for running console interactively.
+ * An implementation is loaded using java.util.ServiceLoader.
+ */
 public interface InteractiveConsoleFactory {
   InteractiveConsoleInterface createConsole(
       String[] args,
@@ -18,7 +23,7 @@ public interface InteractiveConsoleFactory {
       String classpathString,
       String initialCommands,
       String cleanupCommands,
-      ClassLoader loader,
+      Optional<ClassLoader> loader,
       String[] bindNames,
       Object[] bindValues,
       Logger log

--- a/internal/compiler-interface/src/main/java/xsbti/compile/CompilerInterface2.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/CompilerInterface2.java
@@ -16,6 +16,9 @@ import xsbti.Logger;
 import xsbti.Reporter;
 import xsbti.VirtualFile;
 
+/** Interface for running compilation.
+ * An implementation is loaded using java.util.ServiceLoader.
+ */
 public interface CompilerInterface2 {
   void run(
     VirtualFile[] sources,

--- a/internal/compiler-interface/src/main/java/xsbti/compile/ConsoleInterface1.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/ConsoleInterface1.java
@@ -14,7 +14,9 @@ package xsbti.compile;
 import xsbti.Logger;
 import xsbti.Reporter;
 
-/** Console Interface as of Zinc 1.2.0. */
+/** Console Interface as of Zinc 1.2.0.
+ * An implementation is loaded using java.util.ServiceLoader.
+ */
 public interface ConsoleInterface1 {
   void run(
       String[] args,

--- a/internal/compiler-interface/src/main/java/xsbti/compile/ScaladocInterface1.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/ScaladocInterface1.java
@@ -14,8 +14,9 @@ package xsbti.compile;
 import xsbti.Logger;
 import xsbti.Reporter;
 
-/** Scaladoc Interface as of Zinc 1.2.0. */
+/** Scaladoc Interface as of Zinc 1.2.0.
+ * An implementation is loaded using java.util.ServiceLoader.
+ */
 public interface ScaladocInterface1 {
   void run(String[] args, Logger log, Reporter delegate);
 }
-

--- a/internal/compiler-interface/src/main/java/xsbti/compile/ScaladocInterface2.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/ScaladocInterface2.java
@@ -15,8 +15,9 @@ import xsbti.Logger;
 import xsbti.Reporter;
 import xsbti.VirtualFile;
 
-/** Scaladoc Interface as of Zinc 1.4.0. */
+/** Scaladoc Interface as of Zinc 1.4.0.
+ * An implementation is loaded using java.util.ServiceLoader.
+ */
 public interface ScaladocInterface2 {
   void run(VirtualFile[] sources, String[] args, Logger log, Reporter delegate);
 }
-

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/StringVirtualFile.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/StringVirtualFile.scala
@@ -9,11 +9,12 @@
  * additional information regarding copyright ownership.
  */
 
-package sbt.inc
+package sbt
+package internal
+package inc
 
 import java.io.{ ByteArrayInputStream, InputStream }
 
-import sbt.internal.inc.HashUtil
 import xsbti.{ BasicVirtualFileRef, VirtualFile }
 
 case class StringVirtualFile(path: String, content: String)

--- a/internal/zinc-testing/src/main/scala/sbt/internal/inc/AbstractBridgeProviderTestkit.scala
+++ b/internal/zinc-testing/src/main/scala/sbt/internal/inc/AbstractBridgeProviderTestkit.scala
@@ -15,7 +15,7 @@ import java.nio.file.{ Files, FileAlreadyExistsException, Path, StandardCopyOpti
 import sbt.util.Logger
 import xsbti.compile.CompilerBridgeProvider
 
-trait AbstractBridgeProviderTestkit {
+trait AbstractBridgeProviderTestkit extends LogTestkit {
   def getZincProvider(targetDir: Path, log: Logger): CompilerBridgeProvider
 
   def getCompilerBridge(targetDir: Path, log: Logger, scalaVersion: String): Path =

--- a/internal/zinc-testing/src/main/scala/sbt/internal/inc/UnitSpec.scala
+++ b/internal/zinc-testing/src/main/scala/sbt/internal/inc/UnitSpec.scala
@@ -18,7 +18,9 @@ import sbt.util.{ LogExchange, Level }
 import sbt.internal.util.{ ManagedLogger, ConsoleOut, MainAppender }
 import java.util.concurrent.atomic.AtomicInteger
 
-abstract class UnitSpec extends FlatSpec with Matchers {
+abstract class UnitSpec extends FlatSpec with Matchers with LogTestkit {}
+
+trait LogTestkit {
   def logLevel: Level.Value = Level.Warn
   lazy val log: ManagedLogger = UnitSpec.newLogger(logLevel)
 }

--- a/zinc/src/test/scala/sbt/inc/OutputSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/OutputSpec.scala
@@ -14,7 +14,7 @@ package sbt.inc
 import java.io.File
 import java.nio.file.Files
 import sbt.io.IO.{ withTemporaryDirectory => withTmpDir }
-import sbt.internal.inc.JarUtils
+import sbt.internal.inc.{ StringVirtualFile, JarUtils }
 
 class OutputSpec extends BaseCompilerSpec {
   //override val logLevel = sbt.util.Level.Debug

--- a/zinc/src/test/scala/sbt/internal/inc/BridgeProviderSpecification.scala
+++ b/zinc/src/test/scala/sbt/internal/inc/BridgeProviderSpecification.scala
@@ -16,8 +16,10 @@ import sbt.inc.{ ScalaBridge, ConstantBridgeProvider }
 import sbt.util.Logger
 import xsbti.compile.CompilerBridgeProvider
 
-class BridgeProviderSpecification extends UnitSpec with AbstractBridgeProviderTestkit {
-  val bridges: List[ScalaBridge] = {
+class BridgeProviderSpecification extends UnitSpec with BridgeProviderTestkit {}
+
+trait BridgeProviderTestkit extends AbstractBridgeProviderTestkit {
+  lazy val bridges: List[ScalaBridge] = {
     import sbt.internal.inc.ZincBuildInfo._
     val compilerBridge210 = ScalaBridge(scalaVersion210, scalaJars210.toList, classDirectory210)
     val compilerBridge211 = ScalaBridge(scalaVersion211, scalaJars211.toList, classDirectory211)


### PR DESCRIPTION
Fixes https://github.com/sbt/zinc/issues/831

This is a future proofing step for the compiler bridge. As suggested by Guillaume this introduces an indirection using `java.util.ServiceLoader` so the class name of the compiler interface implementation can be configured.