### PR TITLE
Fix PickleJar to not clobber unmodified pickles

### DIFF
--- a/internal/compiler-interface/src/main/java/xsbti/AnalysisCallback.java
+++ b/internal/compiler-interface/src/main/java/xsbti/AnalysisCallback.java
@@ -16,6 +16,7 @@ import xsbti.api.DependencyContext;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.EnumSet;
+import java.util.Optional;
 
 public interface AnalysisCallback {
 
@@ -257,4 +258,6 @@ public interface AnalysisCallback {
      * Returns true if -Ypickle-java is on.
      */
     boolean isPickleJava();
+
+    Optional<T2<Path, Path>> getPickleJarPair();
 }

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/IndexBasedZipOps.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/IndexBasedZipOps.scala
@@ -165,7 +165,7 @@ abstract class IndexBasedZipOps extends CreateZip {
     setHeaders(centralDir, clearedHeaders)
   }
 
-  private def mergeArchives(target: Path, source: Path): Unit = {
+  def mergeArchives(target: Path, source: Path): Unit = {
     val targetCentralDir = readCentralDir(target)
     val sourceCentralDir = readCentralDir(source)
 

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/PickleJar.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/PickleJar.scala
@@ -19,12 +19,16 @@ import java.nio.file.attribute.BasicFileAttributes
 import scala.reflect.io.RootPath
 
 object PickleJar {
-  def write(pickleOut: Path, knownProducts: java.util.Set[String]): Unit = {
-    if (!Files.exists(pickleOut)) {
-      Files.createDirectories(pickleOut.getParent)
-      Files.createFile(pickleOut)
+  // create an empty JAR file in case the subproject has no classes.
+  def touch(path: Path): Unit = {
+    if (!Files.exists(path)) {
+      Files.createDirectories(path.getParent)
+      RootPath(path, writable = true).close() // create an empty jar
     }
+  }
 
+  def write(pickleOut: Path, knownProducts: java.util.Set[String]): Unit = {
+    touch(pickleOut)
     if (!knownProducts.isEmpty) {
       val pj = RootPath(pickleOut, writable = false) // so it doesn't delete the file
       try Files.walkFileTree(pj.root, deleteUnknowns(knownProducts))

--- a/internal/zinc-testing/src/main/scala/xsbti/TestCallback.scala
+++ b/internal/zinc-testing/src/main/scala/xsbti/TestCallback.scala
@@ -14,6 +14,7 @@ package xsbti
 import java.io.File
 import java.nio.file.Path
 import java.util
+import java.util.Optional
 
 import xsbti.api.{ DependencyContext, ClassLike }
 
@@ -138,6 +139,8 @@ class TestCallback extends AnalysisCallback {
   override def classesInOutputJar(): util.Set[String] = java.util.Collections.emptySet()
 
   override def isPickleJava: Boolean = false
+
+  override def getPickleJarPair = Optional.empty()
 }
 
 object TestCallback {

--- a/zinc/src/sbt-test/source-dependencies/subproject-pipelining-noclobber/build.json
+++ b/zinc/src/sbt-test/source-dependencies/subproject-pipelining-noclobber/build.json
@@ -1,0 +1,15 @@
+{
+  "projects": [
+    {
+      "name": "use",
+      "dependsOn": [
+        "dep"
+      ],
+      "scalaVersion": "2.13.3"
+    },
+    {
+      "name": "dep",
+      "scalaVersion": "2.13.3"
+    }
+  ]
+}

--- a/zinc/src/sbt-test/source-dependencies/subproject-pipelining-noclobber/changes/B.scala
+++ b/zinc/src/sbt-test/source-dependencies/subproject-pipelining-noclobber/changes/B.scala
@@ -1,0 +1,5 @@
+package example
+
+object Main {
+  val y = A.x
+}

--- a/zinc/src/sbt-test/source-dependencies/subproject-pipelining-noclobber/dep/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/subproject-pipelining-noclobber/dep/A.scala
@@ -1,0 +1,5 @@
+package example
+
+object A {
+  val x = 3
+}

--- a/zinc/src/sbt-test/source-dependencies/subproject-pipelining-noclobber/dep/incOptions.properties
+++ b/zinc/src/sbt-test/source-dependencies/subproject-pipelining-noclobber/dep/incOptions.properties
@@ -1,0 +1,1 @@
+pipelining = true

--- a/zinc/src/sbt-test/source-dependencies/subproject-pipelining-noclobber/test
+++ b/zinc/src/sbt-test/source-dependencies/subproject-pipelining-noclobber/test
@@ -1,0 +1,8 @@
+# this compiles A.scala
+> dep/compile
+$ sleep 1000
+
+$ copy-file changes/B.scala dep/B.scala
+
+# this compiles Main.scala that uses A.scala
+> use/compile

--- a/zinc/src/sbt-test/source-dependencies/subproject-pipelining-noclobber/use/Main.scala
+++ b/zinc/src/sbt-test/source-dependencies/subproject-pipelining-noclobber/use/Main.scala
@@ -1,0 +1,3 @@
+package example
+
+class B

--- a/zinc/src/sbt-test/source-dependencies/subproject-pipelining-noclobber/use/incOptions.properties
+++ b/zinc/src/sbt-test/source-dependencies/subproject-pipelining-noclobber/use/incOptions.properties
@@ -1,0 +1,1 @@
+pipelining = true


### PR DESCRIPTION
Found a way to give scalac a unique file and then merge it with the previous one.

Now I just need to find a way to reproduce the original bug in a scripted test - any ideas?  It needs to somehow recognize that, for example, class A was compiled but the pickle jar should've contained the pickle for class B too.