### PR TITLE
Improve incremental compilation on multi module project 

### DIFF
--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -229,6 +229,9 @@ class IncHandler(directory: Path, cacheDir: Path, scriptedLog: ManagedLogger, co
     onArgs("checkDependencies") {
       case (p, cls :: dependencies, i) => p.checkDependencies(i, dropRightColon(cls), dependencies)
     },
+    onArgs("checkExists") {
+      case (p, cls :: name :: Nil, i) => p.checkExists(i, dropRightColon(cls), name)
+    },
     noArgs("checkSame") { case (p, i)   => p.checkSame(i) },
     onArgs("run") { case (p, params, i) => p.run(i, params) },
     noArgs("package") { case (p, i)     => p.packageBin(i) },
@@ -479,6 +482,12 @@ case class ProjectStructure(
         assert(expected == actual, s"Expected $expected dependencies, got $actual")
 
       assertDependencies(expected.toSet, classDeps(className))
+      ()
+    }
+
+  def checkExists(i: IncState, className: String, name: String): Future[Unit] =
+    compile(i).map { analysis =>
+      assert(analysis.apis.externalAPI(className).nameHashes().exists(_.name() == name))
       ()
     }
 

--- a/zinc/src/sbt-test/source-dependencies/subproject-api-update/build.json
+++ b/zinc/src/sbt-test/source-dependencies/subproject-api-update/build.json
@@ -1,0 +1,15 @@
+{
+  "projects": [
+    {
+      "name": "root",
+      "dependsOn": [
+        "core"
+      ],
+      "scalaVersion": "2.13.3"
+    },
+    {
+      "name": "core",
+      "scalaVersion": "2.13.3"
+    }
+  ]
+}

--- a/zinc/src/sbt-test/source-dependencies/subproject-api-update/build.sbt
+++ b/zinc/src/sbt-test/source-dependencies/subproject-api-update/build.sbt
@@ -1,0 +1,1 @@
+//ThisBuild / logLevel         := Level.Debug

--- a/zinc/src/sbt-test/source-dependencies/subproject-api-update/changes/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/subproject-api-update/changes/A.scala
@@ -1,0 +1,5 @@
+package core
+
+class A {
+  protected val b: String = "A"
+}

--- a/zinc/src/sbt-test/source-dependencies/subproject-api-update/core/src/main/scala/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/subproject-api-update/core/src/main/scala/A.scala
@@ -1,0 +1,5 @@
+package core
+
+class A {
+  protected val a: String = "A"
+}

--- a/zinc/src/sbt-test/source-dependencies/subproject-api-update/root/src/main/scala/Hello.scala
+++ b/zinc/src/sbt-test/source-dependencies/subproject-api-update/root/src/main/scala/Hello.scala
@@ -1,0 +1,5 @@
+package example
+
+import core.A
+
+object Hello

--- a/zinc/src/sbt-test/source-dependencies/subproject-api-update/test
+++ b/zinc/src/sbt-test/source-dependencies/subproject-api-update/test
@@ -1,0 +1,5 @@
+> checkExists core.A a
+
+$ copy-file changes/A.scala core/src/main/scala/A.scala
+
+> checkExists core.A b


### PR DESCRIPTION
Fixes #810

Consider a multimodule build with subproject `core` and subproject `app` where `app` depends on `core`. When there are source code changes on `core` that does NOT cause invalidations on `app` then the current `Analysis` is not updated to include the subproject ("external") changes. Subsequent incremental compilations keep considering the changes despite nothing changing.

The fix is to update the Analysis file with the external changes even if there are no invalidations in the current module.

**Note**: In other words, this change would in some cases introduce changes to `Analysis` file when the output JAR itself would be identical.