### PR TITLE
Distinguish between using pipelining vs exporting pipelining (earlyOutput)

### DIFF
--- a/internal/compiler-interface/src/main/contraband-java/xsbti/compile/IncOptions.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/compile/IncOptions.java
@@ -451,7 +451,14 @@ public final class IncOptions implements java.io.Serializable {
     public boolean allowMachinePath() {
         return this.allowMachinePath;
     }
-    /** Enables build pipelining at the module level. */
+    /**
+     * Enabled when build pipelining is used for this subproject.
+     * The consumption of early output (pickle JAR) is dependent on the Scala version,
+     * so this flag in Zinc effectively means skip Javac invocation.
+     * 
+     * Note that contribution to pipelining by exporting early output is signaled by
+     * setting an earlyOutput in CompileOptions.
+     */
     public boolean pipelining() {
         return this.pipelining;
     }

--- a/internal/compiler-interface/src/main/contraband/incremental.contra
+++ b/internal/compiler-interface/src/main/contraband/incremental.contra
@@ -92,7 +92,12 @@ type IncOptions {
   allowMachinePath: Boolean! = raw"xsbti.compile.IncOptions.defaultAllowMachinePath()"
   @since("1.4.0")
 
-  ## Enables build pipelining at the module level.
+  ## Enabled when build pipelining is used for this subproject.
+  ## The consumption of early output (pickle JAR) is dependent on the Scala version,
+  ## so this flag in Zinc effectively means skip Javac invocation.
+  ##
+  ## Note that contribution to pipelining by exporting early output is signaled by
+  ## setting an earlyOutput in CompileOptions.
   pipelining: Boolean! = raw"xsbti.compile.IncOptions.defaultPipelining()"
   @since("1.4.0")
 

--- a/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
@@ -470,7 +470,7 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
         extra
       )
       def prevResult = CompileResult.of(prev, config.currentSetup, false)
-      if (skip && !incrementalOptions.pipelining) prevResult
+      if (skip && earlyOutput.isEmpty) prevResult
       else if (recompileAllJava) {
         if (javaSrcs.isEmpty) prevResult
         else {

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -251,7 +251,7 @@ final class MixedAnalyzingCompiler(
     val combined = scalaMsg ++ javaMsg
     if (combined.nonEmpty) {
       val targets = outputDirs.map(_.toAbsolutePath).mkString(",")
-      log.info(combined.mkString("Compiling ", " and ", s" to $targets ..."))
+      log.info(combined.mkString("compiling ", " and ", s" to $targets ..."))
     }
   }
 }

--- a/zinc/src/sbt-test/source-dependencies/subproject-pipelining-optout/build.json
+++ b/zinc/src/sbt-test/source-dependencies/subproject-pipelining-optout/build.json
@@ -1,0 +1,15 @@
+{
+  "projects": [
+    {
+      "name": "use",
+      "dependsOn": [
+        "dep"
+      ],
+      "scalaVersion": "2.13.3"
+    },
+    {
+      "name": "dep",
+      "scalaVersion": "2.13.3"
+    }
+  ]
+}

--- a/zinc/src/sbt-test/source-dependencies/subproject-pipelining-optout/changes/B2.scala
+++ b/zinc/src/sbt-test/source-dependencies/subproject-pipelining-optout/changes/B2.scala
@@ -1,0 +1,6 @@
+package example
+
+object B {
+  val y = A.x
+  val z = 1
+}

--- a/zinc/src/sbt-test/source-dependencies/subproject-pipelining-optout/changes/Break.scala
+++ b/zinc/src/sbt-test/source-dependencies/subproject-pipelining-optout/changes/Break.scala
@@ -1,0 +1,3 @@
+package example
+
+object Break

--- a/zinc/src/sbt-test/source-dependencies/subproject-pipelining-optout/dep/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/subproject-pipelining-optout/dep/A.scala
@@ -1,0 +1,5 @@
+package example
+
+object A {
+  val x = 3
+}

--- a/zinc/src/sbt-test/source-dependencies/subproject-pipelining-optout/dep/incOptions.properties
+++ b/zinc/src/sbt-test/source-dependencies/subproject-pipelining-optout/dep/incOptions.properties
@@ -1,0 +1,1 @@
+pipelining = false

--- a/zinc/src/sbt-test/source-dependencies/subproject-pipelining-optout/test
+++ b/zinc/src/sbt-test/source-dependencies/subproject-pipelining-optout/test
@@ -1,0 +1,10 @@
+# done this way because last modified times often have ~1s resolution
+> use/compile
+
+# This tests no-op compilation of dep
+$ copy-file changes/B2.scala use/B.scala
+> use/compile
+
+$ copy-file changes/Break.scala dep/A.scala
+-> use/compile
+

--- a/zinc/src/sbt-test/source-dependencies/subproject-pipelining-optout/use/B.scala
+++ b/zinc/src/sbt-test/source-dependencies/subproject-pipelining-optout/use/B.scala
@@ -1,0 +1,5 @@
+package example
+
+object B {
+  val y = A.x
+}

--- a/zinc/src/sbt-test/source-dependencies/subproject-pipelining-optout/use/incOptions.properties
+++ b/zinc/src/sbt-test/source-dependencies/subproject-pipelining-optout/use/incOptions.properties
@@ -1,0 +1,1 @@
+pipelining = true

--- a/zinc/src/sbt-test/source-dependencies/trait-trait-211/mirtest/incOptions.properties
+++ b/zinc/src/sbt-test/source-dependencies/trait-trait-211/mirtest/incOptions.properties
@@ -1,2 +1,3 @@
+pipelining = false
 relationsDebug = true
 scalac.options = -deprecation


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/issues/5754

Prior to this change, I was conflating the use of pipelining/early-output with making pipelining/early-output available with a single flag: `incOptions.pipelining`. This distinguishes between the two. Making the early output available is now signaled using a non-empty early output setting. On the other hand, `incOptions.pipelining` now effectively just means "skip javac invocation."

In a complicated subprojects, it's useful to be able to opt-out of pipelining behavior for select subprojects without blocking all of its downstream subprojects. With this change and some adjustment in sbt/sbt, I can now dog food pipelining with sbt/sbt.