### PR TITLE
Don't auto-invalidate java sources every cycle

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -411,7 +411,8 @@ object Incremental {
             doCompile(compile, callbackBuilder, classfileManager),
             classfileManager,
             output,
-            1
+            1,
+            pickleJava,
           )
         else {
           val analysis =

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
@@ -69,7 +69,8 @@ private[inc] abstract class IncrementalCommon(
       doCompile: CompileCycle,
       classfileManager: XClassFileManager,
       output: Output,
-      cycleNum: Int
+      cycleNum: Int,
+      isPipeline: Boolean,
   ) {
     def toVf(ref: VirtualFileRef): VirtualFile = converter.toVirtualFile(ref)
     def sourceRefs: Set[VirtualFileRef] = allSources.asInstanceOf[Set[VirtualFileRef]]
@@ -119,7 +120,7 @@ private[inc] abstract class IncrementalCommon(
       // Return immediate analysis as all sources have been recompiled
       copy(
         if (continue && !handler.isFullCompilation) nextInvalidations else Set.empty,
-        if (continue && !handler.isFullCompilation) javaSources else Set.empty,
+        if (continue && !handler.isFullCompilation && isPipeline) javaSources else Set.empty,
         binaryChanges = IncrementalCommon.emptyChanges,
         previous = current,
         cycleNum = cycleNum + 1,
@@ -229,7 +230,8 @@ private[inc] abstract class IncrementalCommon(
       doCompile: CompileCycle,
       classfileManager: XClassFileManager,
       output: Output,
-      cycleNum: Int
+      cycleNum: Int,
+      isPipeline: Boolean
   ): Analysis = {
     var s = CycleState(
       invalidatedClasses,
@@ -242,7 +244,8 @@ private[inc] abstract class IncrementalCommon(
       doCompile,
       classfileManager,
       output,
-      cycleNum
+      cycleNum,
+      isPipeline,
     )
     val it = iterations(s)
     while (it.hasNext) {

--- a/zinc/src/sbt-test/source-dependencies/anon-java-scala-class/test
+++ b/zinc/src/sbt-test/source-dependencies/anon-java-scala-class/test
@@ -11,9 +11,9 @@ $ copy-file changes/A2.java A.java
 > checkRecompilations 0 D
 
 # A is explicitly changed
-> checkRecompilations 1
+> checkRecompilations 1 A
 
 # B is recompiled because it depends by inheritance on A
 # C is recompiled because it depends by local inheritance on B but its
 # dependencies (D) are not recompiled
-> checkRecompilations 2 A B C
+> checkRecompilations 2 B C

--- a/zinc/src/sbt-test/source-dependencies/local-class-inheritance-from-java/test
+++ b/zinc/src/sbt-test/source-dependencies/local-class-inheritance-from-java/test
@@ -9,8 +9,8 @@ $ copy-file changes/A2.java A.java
 # on C and C's public interface is not affected by changes to A
 > checkRecompilations 0 D
 # A is explicitly changed
-> checkRecompilations 1
+> checkRecompilations 1 A
 # B is recompiled because it depends by inheritance on A
 # C is recompiled because it depends by local inheritance on B but its
 # dependencies (D) are not recompiled
-> checkRecompilations 2 A B C
+> checkRecompilations 2 B C


### PR DESCRIPTION
With the latest zinc, the second compilation cycle will always
invalidate all of the java sources in a given project resulting in
frequent overcompilation of these sources. This commit stops
automatically invalidating them. The invalidation logic was added in
0504f70454fdbe9db2cba4003c710888f6e31e2a. Two scripted tests needed to
be reverted to their pre-0504f70454fdbe9db2cba4003c710888f6e31e2a state
after this change.