### PR TITLE
Make doc work with sbt 1.4.x

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/DelegatingReporter.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/DelegatingReporter.scala
@@ -17,6 +17,7 @@ import java.util.Optional
 import scala.reflect.internal.util.{ FakePos, NoPosition, Position }
 // Left for compatibility
 import Compat._
+import scala.reflect.io.PlainFile
 
 private object DelegatingReporter {
   def apply(settings: scala.tools.nsc.Settings, delegate: xsbti.Reporter): DelegatingReporter =
@@ -89,7 +90,10 @@ private object DelegatingReporter {
 
     def makePosition(pos: Position): xsbti.Position = {
       val src = pos.source
-      val sourcePath = src.file match { case AbstractZincFile(virtualFile) => virtualFile.id }
+      val sourcePath = src.file match {
+        case AbstractZincFile(virtualFile) => virtualFile.id
+        case f: PlainFile                  => f.file.toString
+      }
       val sourceFile = new File(src.file.path)
       val line = pos.line
       val lineContent = pos.lineContent.stripLineEnd

--- a/internal/compiler-bridge/src/main/scala/xsbt/ScaladocBridge.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ScaladocBridge.scala
@@ -30,12 +30,13 @@ private class Runner(
   import scala.tools.nsc.{ doc, Global, reporters }
   import reporters.Reporter
   val docSettings: doc.Settings = new doc.Settings(Log.settingsError(log))
-  val command = new CompilerCommand(args.toList, docSettings)
+  val fullArgs = args.toList ++ sources.map(_.toString)
+  val command = new CompilerCommand(fullArgs, docSettings)
   val reporter = DelegatingReporter(docSettings, delegate)
   def noErrors = !reporter.hasErrors && command.ok
 
   def run(): Unit = {
-    debug(log, "Calling Scaladoc with arguments:\n\t" + args.mkString("\n\t"))
+    debug(log, "Calling Scaladoc with arguments:\n\t" + fullArgs.mkString("\n\t"))
     if (noErrors) {
       import doc._ // 2.8 trunk and Beta1-RC4 have doc.DocFactory.  For other Scala versions, the next line creates forScope.DocFactory
       val processor = new DocFactory(reporter, docSettings)


### PR DESCRIPTION
Scaladoc are not generated with 1.4.0-M2:
https://github.com/sbt/sbt/issues/5798. There seemed to be ~~three~~ two problems:
1. the sources were not actually specified in ScaladocBridge
2. Three was an assumption that the compiler would return only
   AbstractZincFiles in DelegatingReporter.makePosition but, in doc at
   least, it returns scala.reflect.io.PlainFile
3. ~~service loading doesn't seem to work reliably from sbt~~

~~Issues 1 and 2 are straightforward but issue 3 is more tricky. It isn't
clear to me what the assumptions are for service loading and why it
_sometimes_ works from sbt but not always. For example, in the sbt
project, the scripted actions/cross-multi-project successfully loads the
instance of CompilerInterface2 for scala 2.13.1 but not for 2.12.12. It
seems like maybe there is some kind of conflict between the sbt
metabuild loader and the scala instance class loader. At any rate, the
issue can be worked around if we use reflection to load
xsbt.CompilerBridge and xsbt.ScaladocBridge directly rather than
creating a dummy bridge and using reflection on the dummy bridge (at
least that is my interpretation of what the fallback code is doing). If
that fails, we fall back to the dummy bridge as it was before.~~
