### PR TITLE
Fix match error in DelegatingReporter.scala

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/DelegatingReporter.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/DelegatingReporter.scala
@@ -17,7 +17,7 @@ import java.util.Optional
 import scala.reflect.internal.util.{ FakePos, NoPosition, Position }
 // Left for compatibility
 import Compat._
-import scala.reflect.io.PlainFile
+import scala.reflect.io.AbstractFile
 
 private object DelegatingReporter {
   def apply(settings: scala.tools.nsc.Settings, delegate: xsbti.Reporter): DelegatingReporter =
@@ -92,7 +92,7 @@ private object DelegatingReporter {
       val src = pos.source
       val sourcePath = src.file match {
         case AbstractZincFile(virtualFile) => virtualFile.id
-        case f: PlainFile                  => f.file.toString
+        case af: AbstractFile              => af.path
       }
       val sourceFile = new File(src.file.path)
       val line = pos.line


### PR DESCRIPTION
8b2db7a792f3dbf47d31d6e543b353b4e1a42834 introduced a regression because
it is not always the case that the source passed in to
DelegateReporter.makePosition is an instance of AbstractZincFile.
53bc41acc7d878617f0d8b6f9400d606e8191637 partially fixed this by
handling PlainFile but the proper fix is to handle AbstractFile which is
what was done prior to 8b2db7a792f3dbf47d31d6e543b353b4e1a42834

This was detected by running the community build in the shapeless
project.