### PR TITLE
Don't auto-invalidate java sources every cycle, take 2

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -412,7 +412,6 @@ object Incremental {
             classfileManager,
             output,
             1,
-            pickleJava,
           )
         else {
           val analysis =

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
@@ -70,11 +70,9 @@ private[inc] abstract class IncrementalCommon(
       classfileManager: XClassFileManager,
       output: Output,
       cycleNum: Int,
-      isPipeline: Boolean,
   ) {
     def toVf(ref: VirtualFileRef): VirtualFile = converter.toVirtualFile(ref)
     def sourceRefs: Set[VirtualFileRef] = allSources.asInstanceOf[Set[VirtualFileRef]]
-    lazy val javaSources: Set[VirtualFileRef] = sourceRefs.filter(_.id.endsWith(".java"))
 
     def hasNext: Boolean = invalidatedClasses.nonEmpty || initialChangedSources.nonEmpty
 
@@ -120,7 +118,7 @@ private[inc] abstract class IncrementalCommon(
       // Return immediate analysis as all sources have been recompiled
       copy(
         if (continue && !handler.isFullCompilation) nextInvalidations else Set.empty,
-        if (continue && !handler.isFullCompilation && isPipeline) javaSources else Set.empty,
+        Set.empty,
         binaryChanges = IncrementalCommon.emptyChanges,
         previous = current,
         cycleNum = cycleNum + 1,
@@ -231,7 +229,6 @@ private[inc] abstract class IncrementalCommon(
       classfileManager: XClassFileManager,
       output: Output,
       cycleNum: Int,
-      isPipeline: Boolean
   ): Analysis = {
     var s = CycleState(
       invalidatedClasses,
@@ -245,7 +242,6 @@ private[inc] abstract class IncrementalCommon(
       classfileManager,
       output,
       cycleNum,
-      isPipeline,
     )
     val it = iterations(s)
     while (it.hasNext) {

--- a/zinc/src/sbt-test/source-dependencies/java-class-invs/app/App.scala
+++ b/zinc/src/sbt-test/source-dependencies/java-class-invs/app/App.scala
@@ -1,0 +1,3 @@
+package pkg
+
+object App extends Std with LibIntf

--- a/zinc/src/sbt-test/source-dependencies/java-class-invs/build.json
+++ b/zinc/src/sbt-test/source-dependencies/java-class-invs/build.json
@@ -1,0 +1,18 @@
+{
+  "projects": [
+    {
+      "name": "app",
+      "dependsOn": [ "std", "lib" ],
+      "scalaVersion": "2.13.3"
+    },
+    {
+      "name": "lib",
+      "dependsOn": [ "std" ],
+      "scalaVersion": "2.13.3"
+    },
+    {
+      "name": "std",
+      "scalaVersion": "2.13.3"
+    }
+  ]
+}

--- a/zinc/src/sbt-test/source-dependencies/java-class-invs/changes/Std.scala
+++ b/zinc/src/sbt-test/source-dependencies/java-class-invs/changes/Std.scala
@@ -1,0 +1,5 @@
+package pkg
+
+trait Std {
+  def x = 1
+}

--- a/zinc/src/sbt-test/source-dependencies/java-class-invs/lib/LibIntf.java
+++ b/zinc/src/sbt-test/source-dependencies/java-class-invs/lib/LibIntf.java
@@ -1,0 +1,3 @@
+package pkg;
+
+interface LibIntf {}

--- a/zinc/src/sbt-test/source-dependencies/java-class-invs/lib/LibUtil.scala
+++ b/zinc/src/sbt-test/source-dependencies/java-class-invs/lib/LibUtil.scala
@@ -1,0 +1,3 @@
+package pkg
+
+class LibUtil extends Std

--- a/zinc/src/sbt-test/source-dependencies/java-class-invs/std/Std.scala
+++ b/zinc/src/sbt-test/source-dependencies/java-class-invs/std/Std.scala
@@ -1,0 +1,3 @@
+package pkg
+
+trait Std

--- a/zinc/src/sbt-test/source-dependencies/java-class-invs/test
+++ b/zinc/src/sbt-test/source-dependencies/java-class-invs/test
@@ -1,0 +1,5 @@
+> app/compile
+
+$ copy-file changes/Std.scala std/Std.scala
+
+> app/compile


### PR DESCRIPTION
This propagates "don't auto-invalidate Java sources in every cycle" (https://github.com/sbt/zinc/pull/899) to pipelining as well.
Note that all Java sources are invalidated in Incremental.scala:
https://github.com/sbt/zinc/blob/21c73c9e6758d27a388d3df70ccbe8f85e6d04e8/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala#L386-L388

I don't think it's necessary to invalidate them for all cycles.