### PR TITLE
Invalidate all sources after transitive step

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
@@ -86,7 +86,12 @@ private[inc] abstract class IncrementalCommon(
       val invalidatedRefs: Set[VirtualFileRef] =
         mapInvalidationsToSources(classesToRecompile, initialChangedSources, sourceRefs, previous)
 
-      val invalidatedSources: Set[VirtualFile] = invalidatedRefs.map(toVf)
+      val invalidatedSources: Set[VirtualFile] = if (cycleNum > options.transitiveStep) {
+        debug(s"reached cycle limit ${options.transitiveStep}; invalidating all sources")
+        allSources
+      } else {
+        invalidatedRefs.map(toVf)
+      }
 
       val pruned = IncrementalCommon
         .pruneClassFilesOfInvalidations(invalidatedSources, previous, classfileManager, converter)


### PR DESCRIPTION
If there are cyclic dependencies in files, it is possible to get in a
loop where we repeatedly recompile the same files. To avoid that, we can
just invalidate all of the sources if the cycle count exceeds the
IncOptions.transitiveStep parameter. This is a blunt tool but is better
than getting stuck in a loop.