### PR TITLE
Include pickle JAR (aka early output) to classpath

### DIFF
--- a/internal/compiler-interface/src/main/java/xsbti/AnalysisCallback.java
+++ b/internal/compiler-interface/src/main/java/xsbti/AnalysisCallback.java
@@ -260,4 +260,6 @@ public interface AnalysisCallback {
     boolean isPickleJava();
 
     Optional<T2<Path, Path>> getPickleJarPair();
+
+    int cycleNum();
 }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -82,6 +82,10 @@ object Incremental {
      * @return true when the compilation cycle is compiling all the sources; false, otherwise.
      */
     def isFullCompilation: Boolean
+
+    /** The counter of incremental compiler cycles.
+     */
+    def cycleNum: Int
   }
 
   sealed trait CompileCycle {
@@ -659,6 +663,11 @@ private final class AnalysisCallback(
   }
 
   override def getPickleJarPair = pickleJarPair.map { case (p1, p2) => t2((p1, p2)) }.toOptional
+  override def cycleNum: Int =
+    incHandlerOpt match {
+      case Some(handler) => handler.cycleNum
+      case _             => 1
+    }
 
   override def startSource(source: File): Unit = startSource(converter.toVirtualFile(source.toPath))
   override def startSource(source: VirtualFile): Unit = {

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
@@ -70,7 +70,7 @@ private[inc] abstract class IncrementalCommon(
       classfileManager: XClassFileManager,
       output: Output,
       cycleNum: Int,
-  ) {
+  ) { self =>
     def toVf(ref: VirtualFileRef): VirtualFile = converter.toVirtualFile(ref)
     def sourceRefs: Set[VirtualFileRef] = allSources.asInstanceOf[Set[VirtualFileRef]]
 
@@ -138,6 +138,7 @@ private[inc] abstract class IncrementalCommon(
         classesToRecompile: Set[String],
         registerCycle: (Set[String], APIChanges, Set[String], Boolean) => Unit
     ) extends IncrementalCallback(classFileManager) {
+      override val cycleNum: Int = self.cycleNum
       override val isFullCompilation: Boolean = allSources.subsetOf(invalidatedSources)
       override val previousAnalysisPruned: Analysis = pruned
 

--- a/internal/zinc-testing/src/main/scala/xsbti/TestCallback.scala
+++ b/internal/zinc-testing/src/main/scala/xsbti/TestCallback.scala
@@ -141,6 +141,8 @@ class TestCallback extends AnalysisCallback {
   override def isPickleJava: Boolean = false
 
   override def getPickleJarPair = Optional.empty()
+
+  override def cycleNum: Int = 1
 }
 
 object TestCallback {

--- a/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
@@ -545,8 +545,18 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
           previousAnalysis
           // Return an empty analysis if values of extra have changed
         } else if (!equivPairs.equiv(previous.extra, currentSetup.extra)) {
+          log.info(
+            InterfaceUtil.toSupplier(
+              s"detected compileIncSetup.extra change: from ${previous.extra.toList} to ${currentSetup.extra.toList}"
+            )
+          )
           Analysis.empty
         } else {
+          log.debug(
+            InterfaceUtil.toSupplier(
+              s"detected compileIncSetup chage: from ${previous} to ${currentSetup}"
+            )
+          )
           Incremental.prune(srcsSet, previousAnalysis, output, outputJarContent, converter)
         }
       case None =>

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -158,9 +158,17 @@ final class MixedAnalyzingCompiler(
             if (config.currentSetup.order == Mixed) incSrc
             else scalaSrcs
 
+          // include outputted pickle jar into the classpath since this would contain
+          // pickles for Java sources that are not included into cycle 2 onwards
+          val pickleJarAsClasspath: Option[VirtualFile] = pickleJarPair match {
+            case Some((originalJar, _)) =>
+              if (callback.cycleNum > 1) Some(config.converter.toVirtualFile(originalJar))
+              else None
+            case _ => None
+          }
           val cp0: Vector[VirtualFile] = (extraClasspath.toVector map { x =>
             config.converter.toVirtualFile(x.toAbsolutePath)
-          }) ++ absClasspath.toVector
+          }) ++ absClasspath.toVector ++ pickleJarAsClasspath.toVector
           val cp =
             if (scalaSrcs.isEmpty && pickleJava) {
               // we are invoking Scala compiler just for the sake of generating pickles for Java, which


### PR DESCRIPTION
Fixes #918

Similar to the way output is included into classpath to implement incremental compilation, this includes the outputted pickle JAR to the compilation after cycleNum > 1. This allows signatures of Java classes to be available during Scala compilation without including Java sources into every cycle.

## before

```
sbt:sbtRoot> utilScripted/clean
sbt:sbtRoot> utilScripted/compile
sbt:sbtRoot> utilScripted/compile
[error] ${BASE}/internal/util-scripted/src/main/scala/sbt/internal/scripted/HandlersProvider.scala:11:27: not found: type ScriptConfig
[error]   def getHandlers(config: ScriptConfig): Map[Char, StatementHandler]
[error]                           ^
[error] ${BASE}/internal/util-scripted/src/main/scala/sbt/internal/scripted/ScriptedTests.scala:146:30: not found: type ScriptConfig
[error]       val scriptConfig = new ScriptConfig(label, testDirectory, log)
[error]                              ^
[error] two errors found
```

## after

```
sbt:sbtRoot> utilScripted/clean
sbt:sbtRoot> utilScripted/compile
sbt:sbtRoot> utilScripted/compile
[info] compiling 9 Scala sources to /private/tmp/sbt/core-macros/target/scala-2.12/classes ...
[info] compiling 1 Java source to /private/tmp/sbt/internal/util-scripted/target/scala-2.12/classes ...
[info] [sig files written]
[info] compiling 2 Scala sources to /private/tmp/sbt/internal/util-scripted/target/scala-2.12/classes ...
[info] [sig files written]
```
