### PR TITLE
Auto-invalidate Java sources in every cycle during pipelining

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -412,7 +412,6 @@ object Incremental {
             classfileManager,
             output,
             1,
-            pickleJava,
           )
         else {
           val analysis =

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -412,6 +412,7 @@ object Incremental {
             classfileManager,
             output,
             1,
+            pickleJava,
           )
         else {
           val analysis =

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -427,7 +427,7 @@ object Incremental {
               )
             else previous
           if (earlyOutput.isDefined)
-            writeEarlyOut(lookup, progress, earlyOutput, analysis, new java.util.HashSet)
+            writeEarlyOut(lookup, progress, earlyOutput, analysis, new java.util.HashSet, log)
           analysis
         }
     }
@@ -511,13 +511,14 @@ object Incremental {
       progress: Option[CompileProgress],
       earlyOutput: Option[Output],
       analysis: Analysis,
-      knownProducts: java.util.Set[String]
+      knownProducts: java.util.Set[String],
+      log: Logger,
   ) = {
     for {
       earlyO <- earlyOutput
       pickleJar <- jo2o(earlyO.getSingleOutputAsPath)
     } {
-      PickleJar.write(pickleJar, knownProducts)
+      PickleJar.write(pickleJar, knownProducts, log)
       progress.foreach(_.afterEarlyOutput(lookup.shouldDoEarlyOutput(analysis)))
     }
   }
@@ -1067,7 +1068,7 @@ private final class AnalysisCallback(
     earlyAnalysisStore.foreach(_.set(AnalysisContents.create(trimmedAnalysis, trimmedSetup)))
 
     mergeUpdates() // must merge updates each cycle or else scalac will clobber it
-    Incremental.writeEarlyOut(lookup, progress, earlyOutput, merged, knownProducts(merged))
+    Incremental.writeEarlyOut(lookup, progress, earlyOutput, merged, knownProducts(merged), log)
   }
 
   private def mergeUpdates() = {

--- a/zinc/src/sbt-test/source-dependencies/subproject-pipelining-mixed/use/C.java
+++ b/zinc/src/sbt-test/source-dependencies/subproject-pipelining-mixed/use/C.java
@@ -1,0 +1,5 @@
+package example;
+
+public class C {
+  public int hi() { return A.x() + 1; }
+}

--- a/zinc/src/sbt-test/source-dependencies/subproject-pipelining-mixed/use/D.scala
+++ b/zinc/src/sbt-test/source-dependencies/subproject-pipelining-mixed/use/D.scala
@@ -1,0 +1,7 @@
+package example
+
+class D extends C {
+  override def hi(): Int = {
+    super.hi() + 1
+  }
+}


### PR DESCRIPTION
Fixes #918

This reverts #912 and re-invalidates all Java sources in every cycle during pipelining.
This also adds a minor fix and use `options.pipelining` (this module is pipelining) instead of `isPickleJava` (this module is providing pickle JAR), and adds a comment explaining why we do this.

## before

```
sbt:sbtRoot> utilScripted/clean
sbt:sbtRoot> utilScripted/compile
sbt:sbtRoot> utilScripted/compile
[error] ${BASE}/internal/util-scripted/src/main/scala/sbt/internal/scripted/HandlersProvider.scala:11:27: not found: type ScriptConfig
[error]   def getHandlers(config: ScriptConfig): Map[Char, StatementHandler]
[error]                           ^
[error] ${BASE}/internal/util-scripted/src/main/scala/sbt/internal/scripted/ScriptedTests.scala:146:30: not found: type ScriptConfig
[error]       val scriptConfig = new ScriptConfig(label, testDirectory, log)
[error]                              ^
[error] two errors found
```

## after

```
sbt:sbtRoot> utilScripted/clean
sbt:sbtRoot> utilScripted/compile
sbt:sbtRoot> utilScripted/compile
[info] compiling 9 Scala sources to /private/tmp/sbt/core-macros/target/scala-2.12/classes ...
[info] compiling 1 Java source to /private/tmp/sbt/internal/util-scripted/target/scala-2.12/classes ...
[info] [sig files written]
[info] compiling 2 Scala sources and 1 Java source to /private/tmp/sbt/internal/util-scripted/target/scala-2.12/classes ...
[info] [sig files written]
```
