### PR TITLE
Fix transitive invalidation looping (reverts cleanup)

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -412,7 +412,6 @@ object Incremental {
             classfileManager,
             output,
             1,
-            pickleJava,
           )
         else {
           val analysis =

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -412,6 +412,7 @@ object Incremental {
             classfileManager,
             output,
             1,
+            pickleJava,
           )
         else {
           val analysis =

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -427,7 +427,7 @@ object Incremental {
               )
             else previous
           if (earlyOutput.isDefined)
-            writeEarlyOut(lookup, progress, earlyOutput, analysis, new java.util.HashSet)
+            writeEarlyOut(lookup, progress, earlyOutput, analysis, new java.util.HashSet, log)
           analysis
         }
     }
@@ -511,13 +511,14 @@ object Incremental {
       progress: Option[CompileProgress],
       earlyOutput: Option[Output],
       analysis: Analysis,
-      knownProducts: java.util.Set[String]
+      knownProducts: java.util.Set[String],
+      log: Logger,
   ) = {
     for {
       earlyO <- earlyOutput
       pickleJar <- jo2o(earlyO.getSingleOutputAsPath)
     } {
-      PickleJar.write(pickleJar, knownProducts)
+      PickleJar.write(pickleJar, knownProducts, log)
       progress.foreach(_.afterEarlyOutput(lookup.shouldDoEarlyOutput(analysis)))
     }
   }
@@ -1067,7 +1068,7 @@ private final class AnalysisCallback(
     earlyAnalysisStore.foreach(_.set(AnalysisContents.create(trimmedAnalysis, trimmedSetup)))
 
     mergeUpdates() // must merge updates each cycle or else scalac will clobber it
-    Incremental.writeEarlyOut(lookup, progress, earlyOutput, merged, knownProducts(merged))
+    Incremental.writeEarlyOut(lookup, progress, earlyOutput, merged, knownProducts(merged), log)
   }
 
   private def mergeUpdates() = {

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalNameHashing.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalNameHashing.scala
@@ -90,30 +90,41 @@ private[inc] class IncrementalNameHashingCommon(
       isScalaClass: String => Boolean
   ): Set[String] = {
     val modifiedBinaryClassName = externalAPIChange.modifiedClass
-    log.debug(memberRefInvalidator.invalidationReason(externalAPIChange))
-    log.debug("All member reference dependencies will be considered within this context.")
-    val memberRefInv = memberRefInvalidator.get(_, relations.names, externalAPIChange, isScalaClass)
-
+    val invalidationReason = memberRefInvalidator.invalidationReason(externalAPIChange)
+    log.debug(
+      s"$invalidationReason\nAll member reference dependencies will be considered within this context."
+    )
     // Propagate inheritance dependencies transitively.
     // This differs from normal because we need the initial crossing from externals to classes in this project.
-    val byExternalInheritance = relations.inheritance.external.reverse(modifiedBinaryClassName)
+    val externalInheritanceR = relations.inheritance.external
+    val byExternalInheritance = externalInheritanceR.reverse(modifiedBinaryClassName)
     log.debug(
-      s"Files invalidated by inheriting from (external) $modifiedBinaryClassName: $byExternalInheritance"
+      s"Files invalidated by inheriting from (external) $modifiedBinaryClassName: $byExternalInheritance; now invalidating by inheritance (internally)."
     )
-    log.debug("Now invalidating by inheritance (internally).")
-    val transitiveInheritance = byExternalInheritance.flatMap(invalidateByInheritance(relations, _))
-
+    val transitiveInheritance = byExternalInheritance flatMap { className =>
+      invalidateByInheritance(relations, className)
+    }
     val localInheritance = relations.localInheritance.external.reverse(modifiedBinaryClassName)
+    val memberRefInvalidationInternal = memberRefInvalidator.get(
+      relations.memberRef.internal,
+      relations.names,
+      externalAPIChange,
+      isScalaClass
+    )
+    val memberRefInvalidationExternal = memberRefInvalidator.get(
+      relations.memberRef.external,
+      relations.names,
+      externalAPIChange,
+      isScalaClass
+    )
 
     // Get the member reference dependencies of all classes transitively invalidated by inheritance
     log.debug("Getting direct dependencies of all classes transitively invalidated by inheritance.")
-    val memberRefA = transitiveInheritance.flatMap(memberRefInv(relations.memberRef.internal))
-
+    val memberRefA = transitiveInheritance flatMap memberRefInvalidationInternal
     // Get the classes that depend on externals by member reference.
     // This includes non-inheritance dependencies and is not transitive.
     log.debug(s"Getting classes that directly depend on (external) $modifiedBinaryClassName.")
-    val memberRefB = memberRefInv(relations.memberRef.external)(modifiedBinaryClassName)
-
+    val memberRefB = memberRefInvalidationExternal(modifiedBinaryClassName)
     transitiveInheritance ++ localInheritance ++ memberRefA ++ memberRefB
   }
 
@@ -125,48 +136,70 @@ private[inc] class IncrementalNameHashingCommon(
     transitiveInheritance
   }
 
-  private def invalidateByLocalInheritance(relations: Relations, modified: String): Set[String] = {
-    val localInheritanceDeps = relations.localInheritance.internal.reverse(modified)
-    if (localInheritanceDeps.nonEmpty)
-      log.debug(s"Invalidate by local inheritance: $modified -> $localInheritanceDeps")
-    localInheritanceDeps
-  }
-
   /** @inheritdoc */
   override protected def invalidateClassesInternally(
       relations: Relations,
       change: APIChange,
       isScalaClass: String => Boolean
   ): Set[String] = {
+    def invalidateByLocalInheritance(relations: Relations, modified: String): Set[String] = {
+      val localInheritanceDeps = relations.localInheritance.internal.reverse(modified)
+      if (localInheritanceDeps.nonEmpty)
+        log.debug(s"Invalidate by local inheritance: $modified -> $localInheritanceDeps")
+      localInheritanceDeps
+    }
+
     val modifiedClass = change.modifiedClass
-    val memberRefInv = memberRefInvalidator.get(_, relations.names, change, isScalaClass)
-
     val transitiveInheritance = invalidateByInheritance(relations, modifiedClass)
-    val reason1 = s"The invalidated class names inherit directly or transitively on $modifiedClass."
-    profiler.registerEvent(InheritanceKind, List(modifiedClass), transitiveInheritance, reason1)
+    profiler.registerEvent(
+      InvalidationProfilerUtils.InheritanceKind,
+      List(modifiedClass),
+      transitiveInheritance,
+      s"The invalidated class names inherit directly or transitively on ${modifiedClass}."
+    )
 
-    val localInheritance = transitiveInheritance.flatMap(invalidateByLocalInheritance(relations, _))
-    val reason2 =
-      s"The invalidated class names inherit (via local inheritance) directly or transitively on $modifiedClass."
-    profiler.registerEvent(LocalInheritanceKind, transitiveInheritance, localInheritance, reason2)
+    val localInheritance =
+      transitiveInheritance.flatMap(invalidateByLocalInheritance(relations, _))
+    profiler.registerEvent(
+      InvalidationProfilerUtils.LocalInheritanceKind,
+      transitiveInheritance,
+      localInheritance,
+      s"The invalidated class names inherit (via local inheritance) directly or transitively on ${modifiedClass}."
+    )
 
-    val memberRef = transitiveInheritance.flatMap(memberRefInv(relations.memberRef.internal))
-    val reason3 = s"The invalidated class names refer directly or transitively to $modifiedClass."
-    profiler.registerEvent(MemberReferenceKind, transitiveInheritance, memberRef, reason3)
-
+    val memberRefSrcDeps = relations.memberRef.internal
+    val memberRefInvalidation =
+      memberRefInvalidator.get(memberRefSrcDeps, relations.names, change, isScalaClass)
+    val memberRef = transitiveInheritance flatMap memberRefInvalidation
+    profiler.registerEvent(
+      InvalidationProfilerUtils.MemberReferenceKind,
+      transitiveInheritance,
+      memberRef,
+      s"The invalidated class names refer directly or transitively to ${modifiedClass}."
+    )
     val all = transitiveInheritance ++ localInheritance ++ memberRef
-    log.debug {
+
+    def debugMessage: String = {
       if (all.isEmpty) s"Change $change does not affect any class."
       else {
-        val reason = memberRefInvalidator.invalidationReason(change)
-        def ppxs(s: String, xs: Set[String]) = if (xs.isEmpty) "" else s"$s: $xs"
-        s"""Change $change invalidates ${all.size} classes due to $reason
-           |  > ${ppxs("by transitive inheritance", transitiveInheritance)}
-           |  > ${ppxs("by local inheritance", localInheritance)}
-           |  > ${ppxs("by member reference", memberRef)}
+        val byTransitiveInheritance =
+          if (transitiveInheritance.nonEmpty) s"by transitive inheritance: $transitiveInheritance"
+          else ""
+        val byLocalInheritance =
+          if (localInheritance.nonEmpty) s"by local inheritance: $localInheritance" else ""
+        val byMemberRef =
+          if (memberRef.nonEmpty) s"by member reference: $memberRef" else ""
+
+        s"""Change $change invalidates ${all.size} classes due to ${memberRefInvalidator
+             .invalidationReason(change)}
+           |\t> $byTransitiveInheritance
+           |\t> $byLocalInheritance
+           |\t> $byMemberRef
         """.stripMargin
       }
     }
+
+    log.debug(debugMessage)
     all
   }
 

--- a/zinc/src/sbt-test/source-dependencies/subproject-pipelining-mixed/use/C.java
+++ b/zinc/src/sbt-test/source-dependencies/subproject-pipelining-mixed/use/C.java
@@ -1,0 +1,5 @@
+package example;
+
+public class C {
+  public int hi() { return A.x() + 1; }
+}

--- a/zinc/src/sbt-test/source-dependencies/subproject-pipelining-mixed/use/D.scala
+++ b/zinc/src/sbt-test/source-dependencies/subproject-pipelining-mixed/use/D.scala
@@ -1,0 +1,7 @@
+package example
+
+class D extends C {
+  override def hi(): Int = {
+    super.hi() + 1
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/sbt/zinc/issues/911

This is a rework of #916, reverting #898, on top of https://github.com/sbt/zinc/pull/920.

~In #898, transitive invalidation was refactored incorrectly to have the same `dependsOnClass` function value. This restores that.~

## before

```
sbt:sbtRoot> compile
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] compiling 6 Scala sources and 1 Java source to /private/tmp/sbt/zinc-lm-integration/target/scala-2.12/classes ...
[info] compiling 1 Scala source to /private/tmp/sbt/run/target/scala-2.12/classes ...
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] compiling 1 Scala source to /private/tmp/sbt/testing/target/scala-2.12/classes ...
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] compiling 5 Scala sources to /private/tmp/sbt/main-command/target/scala-2.12/classes ...
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] compiling 5 Scala sources to /private/tmp/sbt/main-actions/target/scala-2.12/classes ...
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] compiling 1 Scala source to /private/tmp/sbt/main-settings/target/scala-2.12/classes ...
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] compiling 9 Scala sources to /private/tmp/sbt/main-settings/target/scala-2.12/classes ...
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] compiling 3 Scala sources to /private/tmp/sbt/main-settings/target/scala-2.12/classes ...
[info] compiling 11 Scala sources to /private/tmp/sbt/main-settings/target/scala-2.12/classes ...
[info] compiling 3 Scala sources to /private/tmp/sbt/main-settings/target/scala-2.12/classes ...
[info] compiling 11 Scala sources to /private/tmp/sbt/main-settings/target/scala-2.12/classes ...
[info] compiling 3 Scala sources to /private/tmp/sbt/main-settings/target/scala-2.12/classes ...
[info] compiling 11 Scala sources to /private/tmp/sbt/main-settings/target/scala-2.12/classes ...
[info] compiling 3 Scala sources to /private/tmp/sbt/main-settings/target/scala-2.12/classes ...
[info] compiling 11 Scala sources to /private/tmp/sbt/main-settings/target/scala-2.12/classes ...
[info] compiling 3 Scala sources to /private/tmp/sbt/main-settings/target/scala-2.12/classes ...
[info] compiling 11 Scala sources to /private/tmp/sbt/main-settings/target/scala-2.12/classes ...
[info] compiling 3 Scala sources to /private/tmp/sbt/main-settings/target/scala-2.12/classes ...
[info] compiling 11 Scala sources to /private/tmp/sbt/main-settings/target/scala-2.12/classes ...
```

## after

```
sbt:sbtRoot> compile
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] compiling 6 Scala sources and 1 Java source to /private/tmp/sbt/zinc-lm-integration/target/scala-2.12/classes ...
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] compiling 1 Scala source to /private/tmp/sbt/testing/target/scala-2.12/classes ...
[info] compiling 5 Scala sources to /private/tmp/sbt/main-command/target/scala-2.12/classes ...
[info] compiling 1 Scala source to /private/tmp/sbt/run/target/scala-2.12/classes ...
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] compiling 5 Scala sources to /private/tmp/sbt/main-actions/target/scala-2.12/classes ...
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] compiling 1 Scala source to /private/tmp/sbt/main-settings/target/scala-2.12/classes ...
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] compiling 10 Scala sources to /private/tmp/sbt/main-settings/target/scala-2.12/classes ...
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] compiling 11 Scala sources to /private/tmp/sbt/main-settings/target/scala-2.12/classes ...
[info] compiling 23 Scala sources to /private/tmp/sbt/main-settings/target/scala-2.12/classes ...
[info] compiling 132 Scala sources and 14 Java sources to /private/tmp/sbt/main/target/scala-2.12/classes ...
[info] compiling 3 Scala sources to /private/tmp/sbt/sbt/target/classes ...
[info] compiling 4 Scala sources to /private/tmp/sbt/scripted-sbt-redux/target/scala-2.12/classes ...
[success] Total time: 29 s, completed Sep 13, 2020 10:14:56 PM
```
