### PR TITLE
Fix #930: Report original problems in SourceInfos

### DIFF
--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/LoggedReporter.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/LoggedReporter.scala
@@ -136,7 +136,7 @@ class LoggedReporter(
       severity,
       InterfaceUtil.jo2o(rendered)
     )
-    allProblems += problem
+    allProblems += problem0
     severity match {
       case Warn | Error =>
         if (!testAndLog(transformedPos, severity)) display(problem)


### PR DESCRIPTION
Fixes #930 

`LoggedReporter.allProblems` return original problems so that the ` AnalysisCallback` can link each position to the corresponding `VirtualFile`