### PR TITLE
Don't be lazy about ensuring output

### DIFF
--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -102,7 +102,8 @@ final class MixedAnalyzingCompiler(
     else ()
   }
 
-  lazy val ensureOutput = {
+  // We had this as lazy val, but that caused issues https://github.com/sbt/sbt/issues/5951
+  def ensureOutput = {
     val output = config.currentSetup.output
     val outputDirs = outputDirectories(output)
     outputDirs.foreach { d =>


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/issues/5951

Looks like during the compilation the output directory can be wiped out?