### PR TITLE
Throw UnprintableException to suppress stack trace

### DIFF
--- a/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
@@ -331,7 +331,8 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
     try {
       compilerRun
     } catch {
-      case e: xsbti.CompileFailed  => throw e // just ignore
+      case e: xsbti.CompileFailed =>
+        throw new sbt.internal.inc.CompileFailed(e.arguments, e.toString, e.problems) // just ignore
       case e: CompileFailed        => throw e // just ignore
       case e: InterruptedException => throw e // just ignore
       case e: Throwable =>


### PR DESCRIPTION
In sbt 1.4.x, compilation failures print a noisy stack trace because
InterfaceCompileFailed does not inherit FeedbackProvidedException. To
fix this, we can rethrow an sbt.internal.inc.CompileFailed, which does
inherit FeedbackProvidedException.

Ref: https://github.com/sbt/sbt/issues/6002