### PR TITLE
remove "duplicate compilations" assertion

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Compilations.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Compilations.scala
@@ -36,10 +36,6 @@ object Compilations {
 
 private final class MCompilations(val allCompilations: Seq[Compilation]) extends Compilations {
   // TODO: Sort `allCompilations` chronologically and enforce it in the Zinc API specification
-  assert(
-    { val xs = allCompilations.map(_.getStartTime); xs.distinct.size == xs.size },
-    "Created a Compilations with duplicate compilations"
-  )
 
   def ++(o: Compilations): Compilations = new MCompilations(allCompilations ++ o.allCompilations)
   def add(c: Compilation): Compilations = new MCompilations(allCompilations :+ c)


### PR DESCRIPTION
There was a new assertion introduced in https://github.com/sbt/zinc/pull/800 that there couldn't be more than one compilation with the same start time.

The start time appears to be intended as a millisecond time so it's perfectly possible that more than one can start in the same millisecond.

To further confuse matters, the failure message suggests that the compilation itself is duplicated rather than just the start time, however the start time is not a strong identifier as far as I can see.  So presumably this didn't match the intent at the time of implementation.

In practical terms this is preventing us from updating to sbt 1.4 ( as well as others https://github.com/sbt/sbt/issues/5911 by the looks), as the incremental play compiler seems to randomly trigger this assertion, presumably a race condition depending on compilation speed etc. https://github.com/guardian/support-frontend/pull/2808