### PR TITLE
Prepare DualLoader for Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -597,6 +597,11 @@ lazy val zincClasspath = (projectMatrix in internalPath / "zinc-classpath")
         "sbt.internal.inc.classpath.NativeCopyConfig.*"
       ),
       exclude[IncompatibleMethTypeProblem]("sbt.internal.inc.classpath.NativeCopyConfig.*"),
+      exclude[MissingTypesProblem]("sbt.internal.inc.classpath.DualLoader"),
+      exclude[DirectMissingMethodProblem]("sbt.internal.inc.classpath.DualLoader.this"),
+      exclude[IncompatibleMethTypeProblem]("sbt.internal.inc.classpath.DualLoader.this"),
+      exclude[MissingClassProblem]("sbt.internal.inc.classpath.DifferentLoaders"),
+      exclude[MissingClassProblem]("sbt.internal.inc.classpath.NullLoader")
     ),
   )
   .jvmPlatform(scalaVersions = scala212_213)

--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/DualLoader.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/DualLoader.scala
@@ -14,116 +14,42 @@ package internal
 package inc
 package classpath
 
-import java.net.URL
-import java.util.Enumeration
-import java.util.Collections
-
-/** A class loader that always fails to load classes and resources. */
-final class NullLoader extends ClassLoader {
-  override final def loadClass(className: String, resolve: Boolean): Class[_] =
-    throw new ClassNotFoundException("No classes can be loaded from the null loader")
-  override def getResource(name: String): URL = null
-  override def getResources(name: String): Enumeration[URL] =
-    Collections.enumeration(Collections.emptyList())
-  override def toString = "NullLoader"
-}
-
-/** Exception thrown when `loaderA` and `loaderB` load a different Class for the same name. */
-class DifferentLoaders(message: String, val loaderA: ClassLoader, val loaderB: ClassLoader)
-    extends ClassNotFoundException(message)
+import java.net.{ URL, URLClassLoader }
+import java.util
 
 /**
- * A ClassLoader with two parents `parentA` and `parentB`.  The predicates direct lookups towards one parent or the other.
+ * A [[DualLoader]] is an `URLClassLoader`` that also contains a dual `ClassLoader`
+ * The `dual` loader preempts `super` on some class or resource lookups.
  *
- * If `aOnlyClasses` returns `true` for a class name, class lookup delegates to `parentA` only.
- * Otherwise, if `bOnlyClasses` returns `true` for a class name, class lookup delegates to `parentB` only.
- * If both `aOnlyClasses` and `bOnlyClasses` are `false` for a given class name, both class loaders must load the same Class or
- * a [[DifferentLoaders]] exception is thrown.
+ * If `isDualClass` returns `true` for a class name, class lookup delegates to `dual`.
+ * Otherwise class lookup is performed by `super`.
  *
- * If `aOnlyResources` is `true` for a resource path, lookup delegates to `parentA` only.
- * Otherwise, if `bOnlyResources` is `true` for a resource path, lookup delegates to `parentB` only.
- * If neither are `true` for a resource path and either `parentA` or `parentB` return a valid URL, that valid URL is returned.
+ * If `isDualResource` is `true` for a resource path, lookup delegates to `dual` only.
+ * Otherwise resource lookup is performed by `super`.
  */
 class DualLoader(
-    parentA: ClassLoader,
-    aOnlyClasses: String => Boolean,
-    aOnlyResources: String => Boolean,
-    parentB: ClassLoader,
-    bOnlyClasses: String => Boolean,
-    bOnlyResources: String => Boolean
-) extends ClassLoader(new NullLoader) {
-  def this(
-      parentA: ClassLoader,
-      aOnly: String => Boolean,
-      parentB: ClassLoader,
-      bOnly: String => Boolean
-  ) =
-    this(parentA, aOnly, aOnly, parentB, bOnly, bOnly)
-  override final def loadClass(className: String, resolve: Boolean): Class[_] = {
-    val c =
-      if (aOnlyClasses(className))
-        parentA.loadClass(className)
-      else if (bOnlyClasses(className))
-        parentB.loadClass(className)
-      else {
-        val classA = parentA.loadClass(className)
-        val classB = parentB.loadClass(className)
-        if (classA.getClassLoader eq classB.getClassLoader)
-          classA
-        else
-          throw new DifferentLoaders(
-            "Parent class loaders returned different classes for '" + className + "'",
-            classA.getClassLoader,
-            classB.getClassLoader
-          )
-      }
-    if (resolve)
-      resolveClass(c)
-    c
+    urls: Array[URL],
+    dual: ClassLoader,
+    isDualClass: String => Boolean,
+    isDualResource: String => Boolean
+) extends URLClassLoader(urls, null) {
+  override def loadClass(name: String, resolve: Boolean): Class[_] = {
+    if (isDualClass(name)) {
+      val c = dual.loadClass(name)
+      if (resolve) resolveClass(c)
+      c
+    } else super.loadClass(name, resolve)
   }
+
   override def getResource(name: String): URL = {
-    if (aOnlyResources(name))
-      parentA.getResource(name)
-    else if (bOnlyResources(name))
-      parentB.getResource(name)
-    else {
-      val urlA = parentA.getResource(name)
-      val urlB = parentB.getResource(name)
-      if (urlA eq null)
-        urlB
-      else
-        urlA
-    }
-  }
-  override def getResources(name: String): Enumeration[URL] = {
-    if (aOnlyResources(name))
-      parentA.getResources(name)
-    else if (bOnlyResources(name))
-      parentB.getResources(name)
-    else {
-      val urlsA = parentA.getResources(name)
-      val urlsB = parentB.getResources(name)
-      if (!urlsA.hasMoreElements)
-        urlsB
-      else if (!urlsB.hasMoreElements)
-        urlsA
-      else
-        new DualEnumeration(urlsA, urlsB)
-    }
+    if (isDualResource(name)) dual.getResource(name)
+    else super.getResource(name)
   }
 
-  override def toString = s"DualLoader(a = $parentA, b = $parentB)"
-}
-
-/** Concatenates `a` and `b` into a single `Enumeration`.*/
-final class DualEnumeration[T](a: Enumeration[T], b: Enumeration[T]) extends Enumeration[T] {
-  // invariant: current.hasMoreElements or current eq b
-  private[this] var current = if (a.hasMoreElements) a else b
-  def hasMoreElements = current.hasMoreElements
-  def nextElement = {
-    val element = current.nextElement
-    if (!current.hasMoreElements)
-      current = b
-    element
+  override def getResources(name: String): util.Enumeration[URL] = {
+    if (isDualResource(name)) dual.getResources(name)
+    else super.getResources(name)
   }
+
+  override def toString = s"DualLoader(urls = $urls, dual = $dual)"
 }

--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/RawURL.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/RawURL.scala
@@ -75,3 +75,16 @@ trait FixedResources extends ClassLoader {
     }
   }
 }
+
+/** Concatenates `a` and `b` into a single `Enumeration`.*/
+final class DualEnumeration[T](a: Enumeration[T], b: Enumeration[T]) extends Enumeration[T] {
+  // invariant: current.hasMoreElements or current eq b
+  private[this] var current = if (a.hasMoreElements) a else b
+  def hasMoreElements = current.hasMoreElements
+  def nextElement = {
+    val element = current.nextElement
+    if (!current.hasMoreElements)
+      current = b
+    element
+  }
+}


### PR DESCRIPTION
Change the implementation of `DualLoader` to fix the `LinkageError` exception that occurs in the Scala 3 compiler when the `xsbti.*` classes are loaded. The problem is that those classes are loaded by two different `ClassLoaders`: the sbt loader and the scala instance loader. See https://github.com/lampepfl/dotty/blob/master/sbt-bridge/src/xsbt/CompilerClassLoader.java for more details about the origin of the problem.

In the fixed implementation, the compiler classes are loaded by the `DualLoader` itself, which extends `URLClassLoader`, so that the subsequent `xsbti.*` classes can be loaded by the underlying `dual` loader which is the sbt loader. 

This fix is needed to implement the new `CompilerInterface2` in the Scala 3 compiler bridge.

### Caching and Performance

@smarter said
> The changes to DualLoader need to be carefully inspected since ClassLoader are always tricky business and the way they are cached in sbt/zinc is also quite intricate (and if classloader caching doesn't work right, it might still work but slow things done as the JIT ends up recompiling the same classes again and again, it helps to run the JVM with -verbose:class to verify that multiple calls to compile for example do not end up reloading the same compiler classes multiple times.)

The cache is not affected here: instances of `DualLoader` are still indexed by the list of jars in the scala instance + the bridge jar.

The thing that could be problematic here is that we do not rely on `scalaInstance.loader` anymore but we build a new `URLClassLoader` containing `scalaInstance.allJars`.

### Regarding Binary Compatibility

I modified the  `DualLoader` constructor but, since it is in the internal package, it should rarely impact a downstream project. There are at least 2 breakage:
- in a deprecated method of sbt that can easily be fixed by merging sbt/sbt#6172
- in the ugly piece of code in `sbt-dotty` that casts and hacks the ClassLoader. This fix is replacement of this hack.

I found no usage of `DualLoader` in Bloop nor Mill.

Also I removed `DifferentLoaders` and `NullLoader` because I found no usage in Zinc, sbt, Bloop and Mill. 
