### PR TITLE
[1.4.x] Don't initialize symbols before finding classfile

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/Dependency.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/Dependency.scala
@@ -175,7 +175,7 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile with 
               isSyntheticCoreClass(targetSymbol)
           )
           if (!noByteCode) {
-            classFile(targetSymbol.initialize) match {
+            classFile(targetSymbol) match {
               case Some((at, binaryClassName)) =>
                 // Associated file is set, so we know which classpath entry it came from
                 processExternalDependency(binaryClassName, at)


### PR DESCRIPTION
This is a backport of https://github.com/sbt/zinc/pull/950

Previously, we would complete symbols before trying to find the
associated classfile. This is problematic for symbols where we don't
have the classfile (for instance, when compiling with Pants'
`strict_deps` enabled).

This initialization was introduced in #758, to workaround a scalac bug
where the associated classfile of a symbol wouldn't be set before the
symbol is completed. This bug has been fixed in Scala 2.12.12 and later
(see scala/scalac#8889).

Fixes #949