### PR TITLE
Add AuxiliaryClassFiles in IncOptions

### DIFF
--- a/internal/compiler-interface/src/main/contraband-java/xsbti/compile/IncOptions.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/compile/IncOptions.java
@@ -30,6 +30,9 @@ public final class IncOptions implements java.io.Serializable {
     public static java.util.Optional<ClassFileManagerType> defaultClassFileManagerType() {
         return java.util.Optional.empty();
     }
+    public static xsbti.compile.AuxiliaryClassFiles[] defaultAuxiliaryClassFiles() {
+        return new xsbti.compile.AuxiliaryClassFiles[0];
+    }
     public static java.util.Optional<Boolean> defaultRecompileOnMacroDef() {
         return java.util.Optional.empty();
     }
@@ -130,6 +133,18 @@ public final class IncOptions implements java.io.Serializable {
     public static IncOptions of(int _transitiveStep, double _recompileAllFraction, boolean _relationsDebug, boolean _apiDebug, int _apiDiffContextSize, java.io.File _apiDumpDirectory, xsbti.compile.ClassFileManagerType _classfileManagerType, boolean _useCustomizedFileManager, boolean _recompileOnMacroDef, boolean _useOptimizedSealed, boolean _storeApis, boolean _enabled, java.util.Map<String, String> _extra, boolean _logRecompileOnMacro, xsbti.compile.ExternalHooks _externalHooks, String[] _ignoredScalacOptions, boolean _strictMode, boolean _allowMachinePath, boolean _pipelining) {
         return new IncOptions(_transitiveStep, _recompileAllFraction, _relationsDebug, _apiDebug, _apiDiffContextSize, _apiDumpDirectory, _classfileManagerType, _useCustomizedFileManager, _recompileOnMacroDef, _useOptimizedSealed, _storeApis, _enabled, _extra, _logRecompileOnMacro, _externalHooks, _ignoredScalacOptions, _strictMode, _allowMachinePath, _pipelining);
     }
+    public static IncOptions create(int _transitiveStep, double _recompileAllFraction, boolean _relationsDebug, boolean _apiDebug, int _apiDiffContextSize, java.util.Optional<java.io.File> _apiDumpDirectory, java.util.Optional<xsbti.compile.ClassFileManagerType> _classfileManagerType, xsbti.compile.AuxiliaryClassFiles[] _auxiliaryClassFiles, boolean _useCustomizedFileManager, java.util.Optional<Boolean> _recompileOnMacroDef, boolean _useOptimizedSealed, boolean _storeApis, boolean _enabled, java.util.Map<String, String> _extra, boolean _logRecompileOnMacro, xsbti.compile.ExternalHooks _externalHooks, String[] _ignoredScalacOptions, boolean _strictMode, boolean _allowMachinePath, boolean _pipelining) {
+        return new IncOptions(_transitiveStep, _recompileAllFraction, _relationsDebug, _apiDebug, _apiDiffContextSize, _apiDumpDirectory, _classfileManagerType, _auxiliaryClassFiles, _useCustomizedFileManager, _recompileOnMacroDef, _useOptimizedSealed, _storeApis, _enabled, _extra, _logRecompileOnMacro, _externalHooks, _ignoredScalacOptions, _strictMode, _allowMachinePath, _pipelining);
+    }
+    public static IncOptions of(int _transitiveStep, double _recompileAllFraction, boolean _relationsDebug, boolean _apiDebug, int _apiDiffContextSize, java.util.Optional<java.io.File> _apiDumpDirectory, java.util.Optional<xsbti.compile.ClassFileManagerType> _classfileManagerType, xsbti.compile.AuxiliaryClassFiles[] _auxiliaryClassFiles, boolean _useCustomizedFileManager, java.util.Optional<Boolean> _recompileOnMacroDef, boolean _useOptimizedSealed, boolean _storeApis, boolean _enabled, java.util.Map<String, String> _extra, boolean _logRecompileOnMacro, xsbti.compile.ExternalHooks _externalHooks, String[] _ignoredScalacOptions, boolean _strictMode, boolean _allowMachinePath, boolean _pipelining) {
+        return new IncOptions(_transitiveStep, _recompileAllFraction, _relationsDebug, _apiDebug, _apiDiffContextSize, _apiDumpDirectory, _classfileManagerType, _auxiliaryClassFiles, _useCustomizedFileManager, _recompileOnMacroDef, _useOptimizedSealed, _storeApis, _enabled, _extra, _logRecompileOnMacro, _externalHooks, _ignoredScalacOptions, _strictMode, _allowMachinePath, _pipelining);
+    }
+    public static IncOptions create(int _transitiveStep, double _recompileAllFraction, boolean _relationsDebug, boolean _apiDebug, int _apiDiffContextSize, java.io.File _apiDumpDirectory, xsbti.compile.ClassFileManagerType _classfileManagerType, xsbti.compile.AuxiliaryClassFiles[] _auxiliaryClassFiles, boolean _useCustomizedFileManager, boolean _recompileOnMacroDef, boolean _useOptimizedSealed, boolean _storeApis, boolean _enabled, java.util.Map<String, String> _extra, boolean _logRecompileOnMacro, xsbti.compile.ExternalHooks _externalHooks, String[] _ignoredScalacOptions, boolean _strictMode, boolean _allowMachinePath, boolean _pipelining) {
+        return new IncOptions(_transitiveStep, _recompileAllFraction, _relationsDebug, _apiDebug, _apiDiffContextSize, _apiDumpDirectory, _classfileManagerType, _auxiliaryClassFiles, _useCustomizedFileManager, _recompileOnMacroDef, _useOptimizedSealed, _storeApis, _enabled, _extra, _logRecompileOnMacro, _externalHooks, _ignoredScalacOptions, _strictMode, _allowMachinePath, _pipelining);
+    }
+    public static IncOptions of(int _transitiveStep, double _recompileAllFraction, boolean _relationsDebug, boolean _apiDebug, int _apiDiffContextSize, java.io.File _apiDumpDirectory, xsbti.compile.ClassFileManagerType _classfileManagerType, xsbti.compile.AuxiliaryClassFiles[] _auxiliaryClassFiles, boolean _useCustomizedFileManager, boolean _recompileOnMacroDef, boolean _useOptimizedSealed, boolean _storeApis, boolean _enabled, java.util.Map<String, String> _extra, boolean _logRecompileOnMacro, xsbti.compile.ExternalHooks _externalHooks, String[] _ignoredScalacOptions, boolean _strictMode, boolean _allowMachinePath, boolean _pipelining) {
+        return new IncOptions(_transitiveStep, _recompileAllFraction, _relationsDebug, _apiDebug, _apiDiffContextSize, _apiDumpDirectory, _classfileManagerType, _auxiliaryClassFiles, _useCustomizedFileManager, _recompileOnMacroDef, _useOptimizedSealed, _storeApis, _enabled, _extra, _logRecompileOnMacro, _externalHooks, _ignoredScalacOptions, _strictMode, _allowMachinePath, _pipelining);
+    }
     private int transitiveStep;
     private double recompileAllFraction;
     private boolean relationsDebug;
@@ -137,6 +152,7 @@ public final class IncOptions implements java.io.Serializable {
     private int apiDiffContextSize;
     private java.util.Optional<java.io.File> apiDumpDirectory;
     private java.util.Optional<xsbti.compile.ClassFileManagerType> classfileManagerType;
+    private xsbti.compile.AuxiliaryClassFiles[] auxiliaryClassFiles;
     private boolean useCustomizedFileManager;
     private java.util.Optional<Boolean> recompileOnMacroDef;
     private boolean useOptimizedSealed;
@@ -158,6 +174,7 @@ public final class IncOptions implements java.io.Serializable {
         apiDiffContextSize = xsbti.compile.IncOptions.defaultApiDiffContextSize();
         apiDumpDirectory = xsbti.compile.IncOptions.defaultApiDumpDirectory();
         classfileManagerType = xsbti.compile.IncOptions.defaultClassFileManagerType();
+        auxiliaryClassFiles = xsbti.compile.IncOptions.defaultAuxiliaryClassFiles();
         useCustomizedFileManager = xsbti.compile.IncOptions.defaultUseCustomizedFileManager();
         recompileOnMacroDef = xsbti.compile.IncOptions.defaultRecompileOnMacroDef();
         useOptimizedSealed = xsbti.compile.IncOptions.defaultUseOptimizedSealed();
@@ -180,6 +197,7 @@ public final class IncOptions implements java.io.Serializable {
         apiDiffContextSize = _apiDiffContextSize;
         apiDumpDirectory = _apiDumpDirectory;
         classfileManagerType = _classfileManagerType;
+        auxiliaryClassFiles = xsbti.compile.IncOptions.defaultAuxiliaryClassFiles();
         useCustomizedFileManager = _useCustomizedFileManager;
         recompileOnMacroDef = _recompileOnMacroDef;
         useOptimizedSealed = _useOptimizedSealed;
@@ -202,6 +220,7 @@ public final class IncOptions implements java.io.Serializable {
         apiDiffContextSize = _apiDiffContextSize;
         apiDumpDirectory = java.util.Optional.<java.io.File>ofNullable(_apiDumpDirectory);
         classfileManagerType = java.util.Optional.<xsbti.compile.ClassFileManagerType>ofNullable(_classfileManagerType);
+        auxiliaryClassFiles = xsbti.compile.IncOptions.defaultAuxiliaryClassFiles();
         useCustomizedFileManager = _useCustomizedFileManager;
         recompileOnMacroDef = java.util.Optional.<Boolean>ofNullable(_recompileOnMacroDef);
         useOptimizedSealed = _useOptimizedSealed;
@@ -224,6 +243,7 @@ public final class IncOptions implements java.io.Serializable {
         apiDiffContextSize = _apiDiffContextSize;
         apiDumpDirectory = _apiDumpDirectory;
         classfileManagerType = _classfileManagerType;
+        auxiliaryClassFiles = xsbti.compile.IncOptions.defaultAuxiliaryClassFiles();
         useCustomizedFileManager = _useCustomizedFileManager;
         recompileOnMacroDef = _recompileOnMacroDef;
         useOptimizedSealed = _useOptimizedSealed;
@@ -246,6 +266,7 @@ public final class IncOptions implements java.io.Serializable {
         apiDiffContextSize = _apiDiffContextSize;
         apiDumpDirectory = java.util.Optional.<java.io.File>ofNullable(_apiDumpDirectory);
         classfileManagerType = java.util.Optional.<xsbti.compile.ClassFileManagerType>ofNullable(_classfileManagerType);
+        auxiliaryClassFiles = xsbti.compile.IncOptions.defaultAuxiliaryClassFiles();
         useCustomizedFileManager = _useCustomizedFileManager;
         recompileOnMacroDef = java.util.Optional.<Boolean>ofNullable(_recompileOnMacroDef);
         useOptimizedSealed = _useOptimizedSealed;
@@ -268,6 +289,7 @@ public final class IncOptions implements java.io.Serializable {
         apiDiffContextSize = _apiDiffContextSize;
         apiDumpDirectory = _apiDumpDirectory;
         classfileManagerType = _classfileManagerType;
+        auxiliaryClassFiles = xsbti.compile.IncOptions.defaultAuxiliaryClassFiles();
         useCustomizedFileManager = _useCustomizedFileManager;
         recompileOnMacroDef = _recompileOnMacroDef;
         useOptimizedSealed = _useOptimizedSealed;
@@ -290,6 +312,7 @@ public final class IncOptions implements java.io.Serializable {
         apiDiffContextSize = _apiDiffContextSize;
         apiDumpDirectory = java.util.Optional.<java.io.File>ofNullable(_apiDumpDirectory);
         classfileManagerType = java.util.Optional.<xsbti.compile.ClassFileManagerType>ofNullable(_classfileManagerType);
+        auxiliaryClassFiles = xsbti.compile.IncOptions.defaultAuxiliaryClassFiles();
         useCustomizedFileManager = _useCustomizedFileManager;
         recompileOnMacroDef = java.util.Optional.<Boolean>ofNullable(_recompileOnMacroDef);
         useOptimizedSealed = _useOptimizedSealed;
@@ -312,6 +335,7 @@ public final class IncOptions implements java.io.Serializable {
         apiDiffContextSize = _apiDiffContextSize;
         apiDumpDirectory = _apiDumpDirectory;
         classfileManagerType = _classfileManagerType;
+        auxiliaryClassFiles = xsbti.compile.IncOptions.defaultAuxiliaryClassFiles();
         useCustomizedFileManager = _useCustomizedFileManager;
         recompileOnMacroDef = _recompileOnMacroDef;
         useOptimizedSealed = _useOptimizedSealed;
@@ -334,6 +358,53 @@ public final class IncOptions implements java.io.Serializable {
         apiDiffContextSize = _apiDiffContextSize;
         apiDumpDirectory = java.util.Optional.<java.io.File>ofNullable(_apiDumpDirectory);
         classfileManagerType = java.util.Optional.<xsbti.compile.ClassFileManagerType>ofNullable(_classfileManagerType);
+        auxiliaryClassFiles = xsbti.compile.IncOptions.defaultAuxiliaryClassFiles();
+        useCustomizedFileManager = _useCustomizedFileManager;
+        recompileOnMacroDef = java.util.Optional.<Boolean>ofNullable(_recompileOnMacroDef);
+        useOptimizedSealed = _useOptimizedSealed;
+        storeApis = _storeApis;
+        enabled = _enabled;
+        extra = _extra;
+        logRecompileOnMacro = _logRecompileOnMacro;
+        externalHooks = _externalHooks;
+        ignoredScalacOptions = _ignoredScalacOptions;
+        strictMode = _strictMode;
+        allowMachinePath = _allowMachinePath;
+        pipelining = _pipelining;
+    }
+    protected IncOptions(int _transitiveStep, double _recompileAllFraction, boolean _relationsDebug, boolean _apiDebug, int _apiDiffContextSize, java.util.Optional<java.io.File> _apiDumpDirectory, java.util.Optional<xsbti.compile.ClassFileManagerType> _classfileManagerType, xsbti.compile.AuxiliaryClassFiles[] _auxiliaryClassFiles, boolean _useCustomizedFileManager, java.util.Optional<Boolean> _recompileOnMacroDef, boolean _useOptimizedSealed, boolean _storeApis, boolean _enabled, java.util.Map<String, String> _extra, boolean _logRecompileOnMacro, xsbti.compile.ExternalHooks _externalHooks, String[] _ignoredScalacOptions, boolean _strictMode, boolean _allowMachinePath, boolean _pipelining) {
+        super();
+        transitiveStep = _transitiveStep;
+        recompileAllFraction = _recompileAllFraction;
+        relationsDebug = _relationsDebug;
+        apiDebug = _apiDebug;
+        apiDiffContextSize = _apiDiffContextSize;
+        apiDumpDirectory = _apiDumpDirectory;
+        classfileManagerType = _classfileManagerType;
+        auxiliaryClassFiles = _auxiliaryClassFiles;
+        useCustomizedFileManager = _useCustomizedFileManager;
+        recompileOnMacroDef = _recompileOnMacroDef;
+        useOptimizedSealed = _useOptimizedSealed;
+        storeApis = _storeApis;
+        enabled = _enabled;
+        extra = _extra;
+        logRecompileOnMacro = _logRecompileOnMacro;
+        externalHooks = _externalHooks;
+        ignoredScalacOptions = _ignoredScalacOptions;
+        strictMode = _strictMode;
+        allowMachinePath = _allowMachinePath;
+        pipelining = _pipelining;
+    }
+    protected IncOptions(int _transitiveStep, double _recompileAllFraction, boolean _relationsDebug, boolean _apiDebug, int _apiDiffContextSize, java.io.File _apiDumpDirectory, xsbti.compile.ClassFileManagerType _classfileManagerType, xsbti.compile.AuxiliaryClassFiles[] _auxiliaryClassFiles, boolean _useCustomizedFileManager, boolean _recompileOnMacroDef, boolean _useOptimizedSealed, boolean _storeApis, boolean _enabled, java.util.Map<String, String> _extra, boolean _logRecompileOnMacro, xsbti.compile.ExternalHooks _externalHooks, String[] _ignoredScalacOptions, boolean _strictMode, boolean _allowMachinePath, boolean _pipelining) {
+        super();
+        transitiveStep = _transitiveStep;
+        recompileAllFraction = _recompileAllFraction;
+        relationsDebug = _relationsDebug;
+        apiDebug = _apiDebug;
+        apiDiffContextSize = _apiDiffContextSize;
+        apiDumpDirectory = java.util.Optional.<java.io.File>ofNullable(_apiDumpDirectory);
+        classfileManagerType = java.util.Optional.<xsbti.compile.ClassFileManagerType>ofNullable(_classfileManagerType);
+        auxiliaryClassFiles = _auxiliaryClassFiles;
         useCustomizedFileManager = _useCustomizedFileManager;
         recompileOnMacroDef = java.util.Optional.<Boolean>ofNullable(_recompileOnMacroDef);
         useOptimizedSealed = _useOptimizedSealed;
@@ -389,6 +460,10 @@ public final class IncOptions implements java.io.Serializable {
     /** ClassfileManager that will handle class file deletion and addition during a single incremental compilation run. */
     public java.util.Optional<xsbti.compile.ClassFileManagerType> classfileManagerType() {
         return this.classfileManagerType;
+    }
+    /** Associate each class file with corresponding files (eg. .tasty files) that must be managed by the ClassfileManager. */
+    public xsbti.compile.AuxiliaryClassFiles[] auxiliaryClassFiles() {
+        return this.auxiliaryClassFiles;
     }
     /**
      * Option to turn on customized file manager that tracks generated class files for transactional rollbacks.
@@ -463,70 +538,73 @@ public final class IncOptions implements java.io.Serializable {
         return this.pipelining;
     }
     public IncOptions withTransitiveStep(int transitiveStep) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
     }
     public IncOptions withRecompileAllFraction(double recompileAllFraction) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
     }
     public IncOptions withRelationsDebug(boolean relationsDebug) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
     }
     public IncOptions withApiDebug(boolean apiDebug) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
     }
     public IncOptions withApiDiffContextSize(int apiDiffContextSize) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
     }
     public IncOptions withApiDumpDirectory(java.util.Optional<java.io.File> apiDumpDirectory) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
     }
     public IncOptions withApiDumpDirectory(java.io.File apiDumpDirectory) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, java.util.Optional.<java.io.File>ofNullable(apiDumpDirectory), classfileManagerType, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, java.util.Optional.<java.io.File>ofNullable(apiDumpDirectory), classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
     }
     public IncOptions withClassfileManagerType(java.util.Optional<xsbti.compile.ClassFileManagerType> classfileManagerType) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
     }
     public IncOptions withClassfileManagerType(xsbti.compile.ClassFileManagerType classfileManagerType) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, java.util.Optional.<xsbti.compile.ClassFileManagerType>ofNullable(classfileManagerType), useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, java.util.Optional.<xsbti.compile.ClassFileManagerType>ofNullable(classfileManagerType), auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+    }
+    public IncOptions withAuxiliaryClassFiles(xsbti.compile.AuxiliaryClassFiles[] auxiliaryClassFiles) {
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
     }
     public IncOptions withUseCustomizedFileManager(boolean useCustomizedFileManager) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
     }
     public IncOptions withRecompileOnMacroDef(java.util.Optional<Boolean> recompileOnMacroDef) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
     }
     public IncOptions withRecompileOnMacroDef(boolean recompileOnMacroDef) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, useCustomizedFileManager, java.util.Optional.<Boolean>ofNullable(recompileOnMacroDef), useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, java.util.Optional.<Boolean>ofNullable(recompileOnMacroDef), useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
     }
     public IncOptions withUseOptimizedSealed(boolean useOptimizedSealed) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
     }
     public IncOptions withStoreApis(boolean storeApis) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
     }
     public IncOptions withEnabled(boolean enabled) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
     }
     public IncOptions withExtra(java.util.Map<String, String> extra) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
     }
     public IncOptions withLogRecompileOnMacro(boolean logRecompileOnMacro) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
     }
     public IncOptions withExternalHooks(xsbti.compile.ExternalHooks externalHooks) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
     }
     public IncOptions withIgnoredScalacOptions(String[] ignoredScalacOptions) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
     }
     public IncOptions withStrictMode(boolean strictMode) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
     }
     public IncOptions withAllowMachinePath(boolean allowMachinePath) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
     }
     public IncOptions withPipelining(boolean pipelining) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
     }
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -535,13 +613,13 @@ public final class IncOptions implements java.io.Serializable {
             return false;
         } else {
             IncOptions o = (IncOptions)obj;
-            return (this.transitiveStep() == o.transitiveStep()) && (this.recompileAllFraction() == o.recompileAllFraction()) && (this.relationsDebug() == o.relationsDebug()) && (this.apiDebug() == o.apiDebug()) && (this.apiDiffContextSize() == o.apiDiffContextSize()) && this.apiDumpDirectory().equals(o.apiDumpDirectory()) && this.classfileManagerType().equals(o.classfileManagerType()) && (this.useCustomizedFileManager() == o.useCustomizedFileManager()) && this.recompileOnMacroDef().equals(o.recompileOnMacroDef()) && (this.useOptimizedSealed() == o.useOptimizedSealed()) && (this.storeApis() == o.storeApis()) && (this.enabled() == o.enabled()) && this.extra().equals(o.extra()) && (this.logRecompileOnMacro() == o.logRecompileOnMacro()) && this.externalHooks().equals(o.externalHooks()) && java.util.Arrays.deepEquals(this.ignoredScalacOptions(), o.ignoredScalacOptions()) && (this.strictMode() == o.strictMode()) && (this.allowMachinePath() == o.allowMachinePath()) && (this.pipelining() == o.pipelining());
+            return (this.transitiveStep() == o.transitiveStep()) && (this.recompileAllFraction() == o.recompileAllFraction()) && (this.relationsDebug() == o.relationsDebug()) && (this.apiDebug() == o.apiDebug()) && (this.apiDiffContextSize() == o.apiDiffContextSize()) && this.apiDumpDirectory().equals(o.apiDumpDirectory()) && this.classfileManagerType().equals(o.classfileManagerType()) && java.util.Arrays.deepEquals(this.auxiliaryClassFiles(), o.auxiliaryClassFiles()) && (this.useCustomizedFileManager() == o.useCustomizedFileManager()) && this.recompileOnMacroDef().equals(o.recompileOnMacroDef()) && (this.useOptimizedSealed() == o.useOptimizedSealed()) && (this.storeApis() == o.storeApis()) && (this.enabled() == o.enabled()) && this.extra().equals(o.extra()) && (this.logRecompileOnMacro() == o.logRecompileOnMacro()) && this.externalHooks().equals(o.externalHooks()) && java.util.Arrays.deepEquals(this.ignoredScalacOptions(), o.ignoredScalacOptions()) && (this.strictMode() == o.strictMode()) && (this.allowMachinePath() == o.allowMachinePath()) && (this.pipelining() == o.pipelining());
         }
     }
     public int hashCode() {
-        return 37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.compile.IncOptions".hashCode()) + Integer.valueOf(transitiveStep()).hashCode()) + Double.valueOf(recompileAllFraction()).hashCode()) + Boolean.valueOf(relationsDebug()).hashCode()) + Boolean.valueOf(apiDebug()).hashCode()) + Integer.valueOf(apiDiffContextSize()).hashCode()) + apiDumpDirectory().hashCode()) + classfileManagerType().hashCode()) + Boolean.valueOf(useCustomizedFileManager()).hashCode()) + recompileOnMacroDef().hashCode()) + Boolean.valueOf(useOptimizedSealed()).hashCode()) + Boolean.valueOf(storeApis()).hashCode()) + Boolean.valueOf(enabled()).hashCode()) + extra().hashCode()) + Boolean.valueOf(logRecompileOnMacro()).hashCode()) + externalHooks().hashCode()) + java.util.Arrays.deepHashCode(ignoredScalacOptions())) + Boolean.valueOf(strictMode()).hashCode()) + Boolean.valueOf(allowMachinePath()).hashCode()) + Boolean.valueOf(pipelining()).hashCode());
+        return 37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.compile.IncOptions".hashCode()) + Integer.valueOf(transitiveStep()).hashCode()) + Double.valueOf(recompileAllFraction()).hashCode()) + Boolean.valueOf(relationsDebug()).hashCode()) + Boolean.valueOf(apiDebug()).hashCode()) + Integer.valueOf(apiDiffContextSize()).hashCode()) + apiDumpDirectory().hashCode()) + classfileManagerType().hashCode()) + java.util.Arrays.deepHashCode(auxiliaryClassFiles())) + Boolean.valueOf(useCustomizedFileManager()).hashCode()) + recompileOnMacroDef().hashCode()) + Boolean.valueOf(useOptimizedSealed()).hashCode()) + Boolean.valueOf(storeApis()).hashCode()) + Boolean.valueOf(enabled()).hashCode()) + extra().hashCode()) + Boolean.valueOf(logRecompileOnMacro()).hashCode()) + externalHooks().hashCode()) + java.util.Arrays.deepHashCode(ignoredScalacOptions())) + Boolean.valueOf(strictMode()).hashCode()) + Boolean.valueOf(allowMachinePath()).hashCode()) + Boolean.valueOf(pipelining()).hashCode());
     }
     public String toString() {
-        return "IncOptions("  + "transitiveStep: " + transitiveStep() + ", " + "recompileAllFraction: " + recompileAllFraction() + ", " + "relationsDebug: " + relationsDebug() + ", " + "apiDebug: " + apiDebug() + ", " + "apiDiffContextSize: " + apiDiffContextSize() + ", " + "apiDumpDirectory: " + apiDumpDirectory() + ", " + "classfileManagerType: " + classfileManagerType() + ", " + "useCustomizedFileManager: " + useCustomizedFileManager() + ", " + "recompileOnMacroDef: " + recompileOnMacroDef() + ", " + "useOptimizedSealed: " + useOptimizedSealed() + ", " + "storeApis: " + storeApis() + ", " + "enabled: " + enabled() + ", " + "extra: " + extra() + ", " + "logRecompileOnMacro: " + logRecompileOnMacro() + ", " + "externalHooks: " + externalHooks() + ", " + "ignoredScalacOptions: " + ignoredScalacOptions() + ", " + "strictMode: " + strictMode() + ", " + "allowMachinePath: " + allowMachinePath() + ", " + "pipelining: " + pipelining() + ")";
+        return "IncOptions("  + "transitiveStep: " + transitiveStep() + ", " + "recompileAllFraction: " + recompileAllFraction() + ", " + "relationsDebug: " + relationsDebug() + ", " + "apiDebug: " + apiDebug() + ", " + "apiDiffContextSize: " + apiDiffContextSize() + ", " + "apiDumpDirectory: " + apiDumpDirectory() + ", " + "classfileManagerType: " + classfileManagerType() + ", " + "auxiliaryClassFiles: " + auxiliaryClassFiles() + ", " + "useCustomizedFileManager: " + useCustomizedFileManager() + ", " + "recompileOnMacroDef: " + recompileOnMacroDef() + ", " + "useOptimizedSealed: " + useOptimizedSealed() + ", " + "storeApis: " + storeApis() + ", " + "enabled: " + enabled() + ", " + "extra: " + extra() + ", " + "logRecompileOnMacro: " + logRecompileOnMacro() + ", " + "externalHooks: " + externalHooks() + ", " + "ignoredScalacOptions: " + ignoredScalacOptions() + ", " + "strictMode: " + strictMode() + ", " + "allowMachinePath: " + allowMachinePath() + ", " + "pipelining: " + pipelining() + ")";
     }
 }

--- a/internal/compiler-interface/src/main/contraband/incremental.contra
+++ b/internal/compiler-interface/src/main/contraband/incremental.contra
@@ -41,6 +41,10 @@ type IncOptions {
   classfileManagerType: xsbti.compile.ClassFileManagerType = raw"xsbti.compile.IncOptions.defaultClassFileManagerType()"
   @since("0.1.0")
 
+  ## Associate each class file with corresponding files (eg. .tasty files) that must be managed by the ClassfileManager.
+  auxiliaryClassFiles: [xsbti.compile.AuxiliaryClassFiles] = raw"xsbti.compile.IncOptions.defaultAuxiliaryClassFiles()"
+  @since("1.5.0")
+
   ## Option to turn on customized file manager that tracks generated class files for transactional rollbacks.
   ## Using customized file manager may conflict with some libraries, this option allows user to decide
   ## whether to use.
@@ -121,6 +125,9 @@ type IncOptions {
   #x }
   #x public static java.util.Optional<ClassFileManagerType> defaultClassFileManagerType() {
   #x     return java.util.Optional.empty();
+  #x }
+  #x public static xsbti.compile.AuxiliaryClassFiles[] defaultAuxiliaryClassFiles() {
+  #x     return new xsbti.compile.AuxiliaryClassFiles[0];
   #x }
   #x public static java.util.Optional<Boolean> defaultRecompileOnMacroDef() {
   #x     return java.util.Optional.empty();

--- a/internal/compiler-interface/src/main/java/xsbti/compile/AuxiliaryClassFiles.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/AuxiliaryClassFiles.java
@@ -1,0 +1,16 @@
+package xsbti.compile;
+
+import java.nio.file.Path;
+
+/**
+ * Interface that associates a class file with other corresponding produced
+ * files, for instance `.tasty` files or `.sjsir` files.
+ *
+ * This class is meant to be used inside the [[ClassFileManager]] to manage
+ * auxiliary files.
+ *
+ * ClassFileManagers are forgiving on auxiliary files that do not exist.
+ */
+public interface AuxiliaryClassFiles {
+    Path[] associatedFiles(Path classFile);
+}

--- a/internal/zinc-benchmarks/src/test/scala/xsbt/BenchmarkBase.scala
+++ b/internal/zinc-benchmarks/src/test/scala/xsbt/BenchmarkBase.scala
@@ -13,12 +13,13 @@ package xsbt
 
 import net.openhft.affinity.AffinityLock
 import org.openjdk.jmh.annotations._
+
 import java.io.File
 import sbt.inc.{ CompilerSetup, ProjectSetup }
 import sbt.internal.inc.BridgeProviderSpecification
 import sbt.util.Logger
-
 import xsbt.ZincBenchmark.CompilationInfo
+import xsbti.compile.IncOptions
 
 @State(Scope.Benchmark)
 class BenchmarkBase extends BridgeProviderSpecification {
@@ -61,8 +62,8 @@ class BenchmarkBase extends BridgeProviderSpecification {
     val scalaVersion = ZincBenchmark.scalaVersion
     val bridge = getCompilerBridge(_dir.toPath, noLogger, scalaVersion)
     val si = scalaInstance(scalaVersion, _dir.toPath, noLogger)
-    val pipelining = false
-    _compilerSetup = _setup.createCompiler(scalaVersion, si, bridge, pipelining, log)
+    val options = IncOptions.of()
+    _compilerSetup = _setup.createCompiler(scalaVersion, si, bridge, options, log)
     printCompilationDetails()
   }
 

--- a/internal/zinc-core/src/main/java/xsbti/compile/AuxiliaryClassFileExtension.java
+++ b/internal/zinc-core/src/main/java/xsbti/compile/AuxiliaryClassFileExtension.java
@@ -1,0 +1,25 @@
+package xsbti.compile;
+
+import java.nio.file.Path;
+
+public class AuxiliaryClassFileExtension implements AuxiliaryClassFiles {
+    private final String dotExtension;
+
+    public AuxiliaryClassFileExtension(String extension) {
+        this.dotExtension = "." + extension;
+    }
+
+    @Override
+    public Path[] associatedFiles(Path classFile) {
+        // not all class files must have a corresponding auxiliary file
+        // we strongly assume that ClassFileManager is forgiving on files that do not exist.
+        String fileName = classFile.getFileName().toString();
+        if (fileName.endsWith(".class")) {
+            String prefix = fileName.substring(0, fileName.length() - 6);
+            Path auxiliaryFile = classFile.resolveSibling(prefix + dotExtension);
+            return new Path[] { auxiliaryFile };
+        } else  {
+            return new Path[0];
+        }
+    }
+}

--- a/internal/zinc-core/src/main/java/xsbti/compile/ClassFileManagerUtil.java
+++ b/internal/zinc-core/src/main/java/xsbti/compile/ClassFileManagerUtil.java
@@ -26,17 +26,19 @@ public final class ClassFileManagerUtil {
      * @return A classfile manager implementation.
      */
     public static ClassFileManager getDefaultClassFileManager(ClassFileManagerType classFileManagerType) {
-        return sbt.internal.inc.ClassFileManager.getDefaultClassFileManager(Optional.of(classFileManagerType));
+        return sbt.internal.inc.ClassFileManager.getDefaultClassFileManager(
+                Optional.of(classFileManagerType), new AuxiliaryClassFiles[0]);
     }
 
     /**
      * Get the default classfile manager implementation for a given classfile manager type,
      * extracted from an instance of {@link IncOptions}.
      *
-     * @param classFileManagerType The classfile manager type.
+     * @param incOptions The Incremental compiler options.
      * @return A classfile manager implementation.
      */
     public static ClassFileManager getDefaultClassFileManager(IncOptions incOptions) {
-        return sbt.internal.inc.ClassFileManager.getDefaultClassFileManager(incOptions.classfileManagerType());
+        return sbt.internal.inc.ClassFileManager.getDefaultClassFileManager(
+                incOptions.classfileManagerType(), incOptions.auxiliaryClassFiles());
     }
 }

--- a/internal/zinc-core/src/main/java/xsbti/compile/ScalaJSFiles.java
+++ b/internal/zinc-core/src/main/java/xsbti/compile/ScalaJSFiles.java
@@ -1,0 +1,17 @@
+package xsbti.compile;
+
+/**
+ * Can be added to `IncOptions.auxiliaryClassFiles` so that the sjsir files
+ * produced by the Scala.js compiler are managed by the ClassFileManager.
+ */
+public class ScalaJSFiles extends AuxiliaryClassFileExtension {
+    private static final ScalaJSFiles _instance = new ScalaJSFiles();
+
+    public static ScalaJSFiles instance() {
+        return _instance;
+    }
+
+    private ScalaJSFiles() {
+        super("sjsir");
+    }
+}

--- a/internal/zinc-core/src/main/java/xsbti/compile/ScalaNativeFiles.java
+++ b/internal/zinc-core/src/main/java/xsbti/compile/ScalaNativeFiles.java
@@ -1,0 +1,17 @@
+package xsbti.compile;
+
+/**
+ * Can be added to `IncOptions.auxiliaryClassFiles` so that the nir files
+ * produced by the Scala Native compiler are managed by the ClassFileManager.
+ */
+public class ScalaNativeFiles extends AuxiliaryClassFileExtension {
+    private static final ScalaNativeFiles _instance = new ScalaNativeFiles();
+
+    public static ScalaNativeFiles instance() {
+        return _instance;
+    }
+
+    private ScalaNativeFiles() {
+        super("nir");
+    }
+}

--- a/internal/zinc-core/src/main/java/xsbti/compile/TastyFiles.java
+++ b/internal/zinc-core/src/main/java/xsbti/compile/TastyFiles.java
@@ -1,0 +1,17 @@
+package xsbti.compile;
+
+/**
+ * Can be added to `IncOptions.auxiliaryClassFiles` so that the TASTy files are
+ * managed by the ClassFileManager.
+ */
+public class TastyFiles extends AuxiliaryClassFileExtension {
+    private static final TastyFiles _instance = new TastyFiles();
+
+    public static TastyFiles instance() {
+        return _instance;
+    }
+
+    private TastyFiles() {
+        super("tasty");
+    }
+}

--- a/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
@@ -549,10 +549,24 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
         } else if (!equivPairs.equiv(previous.extra, currentSetup.extra)) {
           Analysis.empty
         } else {
-          Incremental.prune(srcsSet, previousAnalysis, output, outputJarContent, converter)
+          Incremental.prune(
+            srcsSet,
+            previousAnalysis,
+            output,
+            outputJarContent,
+            converter,
+            incOptions
+          )
         }
       case None =>
-        Incremental.prune(srcsSet, previousAnalysis, output, outputJarContent, converter)
+        Incremental.prune(
+          srcsSet,
+          previousAnalysis,
+          output,
+          outputJarContent,
+          converter,
+          incOptions
+        )
     }
 
     // Run the incremental compilation

--- a/zinc/src/test/scala/sbt/inc/AuxiliaryClassFilesSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/AuxiliaryClassFilesSpec.scala
@@ -1,0 +1,29 @@
+package sbt.inc
+
+import sbt.io.IO
+import xsbti.compile.AuxiliaryClassFiles
+
+import java.nio.file.Path
+
+class AuxiliaryClassFilesSpec extends BaseCompilerSpec {
+  it should "allow client to add define their own auxiliary class files" in {
+    IO.withTemporaryDirectory { tempDir =>
+      val setup = ProjectSetup.simple(tempDir.toPath, SourceFiles.Foo :: Nil)
+      var callbackCalled = 0
+      val myAuxiliaryFiles = new AuxiliaryClassFiles {
+        override def associatedFiles(classFile: Path): Array[Path] = {
+          callbackCalled += 1
+          Array()
+        }
+      }
+
+      val compiler =
+        setup.createCompiler(incOptions = incOptions.withAuxiliaryClassFiles(Array(myAuxiliaryFiles)))
+
+      try compiler.doCompile()
+      finally compiler.close()
+
+      callbackCalled.shouldEqual(3)
+    }
+  }
+}

--- a/zinc/src/test/scala/sbt/inc/BaseCompilerSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/BaseCompilerSpec.scala
@@ -14,19 +14,22 @@ package sbt.inc
 import java.nio.file.{ Files, Path }
 import sbt.internal.inc.BridgeProviderSpecification
 import sbt.util.Logger
+import xsbti.compile.IncOptions
 
 class BaseCompilerSpec extends BridgeProviderSpecification {
-  val scalaVersion = scala.util.Properties.versionNumberString
+  val scalaVersion: String = scala.util.Properties.versionNumberString
+
+  val incOptions: IncOptions = IncOptions.of().withPipelining(true)
 
   def assertExists(p: Path) = assert(Files.exists(p), s"$p does not exist")
 
   implicit class ProjectSetupOps(setup: ProjectSetup) {
-    def createCompiler(): CompilerSetup = createCompiler(scalaVersion)
+    def createCompiler(): CompilerSetup = setup.createCompiler(scalaVersion, incOptions)
 
-    def createCompiler(sv: String): CompilerSetup = {
+    private def createCompiler(sv: String, incOptions: IncOptions): CompilerSetup = {
       val si = scalaInstance(sv, setup.baseDir, Logger.Null)
       val bridge = getCompilerBridge(setup.baseDir, Logger.Null, sv)
-      setup.createCompiler(sv, si, bridge, true, log)
+      setup.createCompiler(sv, si, bridge, incOptions, log)
     }
   }
 }

--- a/zinc/src/test/scala/sbt/inc/ClassFileManagerHookSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/ClassFileManagerHookSpec.scala
@@ -14,7 +14,6 @@ package sbt.inc
 import java.io.File
 import sbt.io.IO
 import xsbti.compile.ClassFileManager
-import xsbti.compile.IncOptions
 
 class ClassFileManagerHookSpec extends BaseCompilerSpec {
   it should "allow client to add their own class file manager" in {
@@ -36,12 +35,11 @@ class ClassFileManagerHookSpec extends BaseCompilerSpec {
         }
       }
 
-      val incOptions = IncOptions.of()
       val newExternalHooks =
         incOptions.externalHooks.withExternalClassFileManager(myClassFileManager)
+      val options = incOptions.withExternalHooks(newExternalHooks)
 
-      val compiler =
-        setup.createCompiler().copy(incOptions = incOptions.withExternalHooks(newExternalHooks))
+      val compiler = setup.createCompiler().copy(incOptions = options)
       try compiler.doCompile()
       finally compiler.close()
 

--- a/zinc/src/test/scala/sbt/inc/IncrementalCompilerSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/IncrementalCompilerSpec.scala
@@ -11,10 +11,11 @@
 
 package sbt.inc
 
-import xsbti.compile.{ AnalysisStore, CompileAnalysis, DefaultExternalHooks }
 import sbt.internal.inc._
 import sbt.io.IO.{ withTemporaryDirectory => withTmpDir }
 import sbt.io.syntax._
+import xsbti.compile.{ AnalysisStore, CompileAnalysis, DefaultExternalHooks }
+
 import java.util.Optional
 
 class IncrementalCompilerSpec extends BaseCompilerSpec {

--- a/zinc/src/test/scala/sbt/inc/TestProjectSetup.scala
+++ b/zinc/src/test/scala/sbt/inc/TestProjectSetup.scala
@@ -162,7 +162,7 @@ case class ProjectSetup(
     outputToJar: Boolean = false,
     subproject: String = "unnamed",
     scalacOptions: Seq[String] = Nil,
-    overrideCp: Option[Seq[Path]] = None, // to avoid "fromResource"
+    overrideCp: Option[Seq[Path]] = None // to avoid "fromResource"
 ) {
   def baseDir = proj.baseDir
   def converter = proj.converter
@@ -209,7 +209,7 @@ case class ProjectSetup(
       sv: String,
       si: XScalaInstance,
       compilerBridge: Path,
-      pipelining: Boolean,
+      options: IncOptions,
       log: ManagedLogger,
   ): CompilerSetup = {
     CompilerSetup(
@@ -222,7 +222,7 @@ case class ProjectSetup(
       allSources.toVector.map(converter.toVirtualFile(_)),
       allClasspath.map(converter.toVirtualFile(_)),
       scalacOptions,
-      IncOptions.of().withPipelining(pipelining),
+      options,
       analysisForCp,
       analysisPath,
       earlyAnalysisPath,


### PR DESCRIPTION
Fixes #579 

Add an `AuxiliaryClassFiles` member in `IncOptions` so that the `ClassFileManager` manages the files that are associated to class files. This will be used for Scala 3 (`.tasty` files), for Scala.js (`.sjsir` files) and for Scala Native (`.nir` files).

The `auxiliaryClassFiles` member in `IncOptions` is an array so that we can manage several type of files at the same time (for instance `.tasty` and `.sjsir` files). Its default value is an empty array because Scala 2 and Java don't need any.

The implementation for `.tasty` files is provided so that it can already be reused by sbt (https://github.com/sbt/sbt/issues/6080) and also by Mill and Bloop.