### PR TITLE
Made AnalysisCallback thread-safe again. Re sbt/sbt#6198

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -16,6 +16,7 @@ package inc
 import java.io.File
 import java.nio.file.{ Files, Path, Paths }
 import java.util.{ EnumSet, UUID }
+import java.util.concurrent.atomic.{ AtomicBoolean }
 import sbt.internal.inc.Analysis.{ LocalProduct, NonLocalProduct }
 import sbt.internal.inc.JavaInterfaceUtil.EnrichOption
 import sbt.util.{ InterfaceUtil, Level, Logger }
@@ -649,7 +650,7 @@ private final class AnalysisCallback(
 
   // Results of invalidation calculations (including whether to continue cycles) - the analysis at this point is
   // not useful and so isn't included.
-  private[this] var invalidationResults: Option[CompileCycleResult] = None
+  @volatile private[this] var invalidationResults: Option[CompileCycleResult] = None
 
   private def add[A, B](map: TrieMap[A, ConcurrentSet[B]], a: A, b: B): Unit = {
     map.getOrElseUpdate(a, ConcurrentHashMap.newKeySet[B]()).add(b)
@@ -866,25 +867,30 @@ private final class AnalysisCallback(
 
   override def enabled(): Boolean = options.enabled
 
-  private[this] var gotten: Boolean = false
+  private[this] val gotten: AtomicBoolean = new AtomicBoolean(false)
   def getCycleResultOnce: CompileCycleResult = {
-    assert(!gotten, "can't call AnalysisCallback#getCycleResultOnce more than once")
-    val incHandler = incHandlerOpt.getOrElse(sys.error("incHandler was expected"))
-    gotten = true
-    // Not continuing & nothing was written, so notify it ain't gonna happen
-    def notifyNoEarlyOut() = if (!writtenEarlyArtifacts) progress.foreach(_.afterEarlyOutput(false))
-    outputJarContent.scalacRunCompleted()
-    if (earlyOutput.isDefined) {
-      val early = incHandler.previousAnalysisPruned
-      invalidationResults match {
-        case None if lookup.shouldDoEarlyOutput(early)    => writeEarlyArtifacts(early)
-        case None | Some(CompileCycleResult(false, _, _)) => notifyNoEarlyOut()
-        case _                                            =>
+    if (gotten.compareAndSet(false, true)) {
+      val incHandler = incHandlerOpt.getOrElse(sys.error("incHandler was expected"))
+      // Not continuing & nothing was written, so notify it ain't gonna happen
+      def notifyNoEarlyOut() =
+        if (!writtenEarlyArtifacts) progress.foreach(_.afterEarlyOutput(false))
+      outputJarContent.scalacRunCompleted()
+      if (earlyOutput.isDefined) {
+        val early = incHandler.previousAnalysisPruned
+        invalidationResults match {
+          case None if lookup.shouldDoEarlyOutput(early)    => writeEarlyArtifacts(early)
+          case None | Some(CompileCycleResult(false, _, _)) => notifyNoEarlyOut()
+          case _                                            =>
+        }
+        if (!writtenEarlyArtifacts) // writing implies the updates merge has happened
+          mergeUpdates() // must merge updates each cycle or else scalac will clobber it
       }
-      if (!writtenEarlyArtifacts) // writing implies the updates merge has happened
-        mergeUpdates() // must merge updates each cycle or else scalac will clobber it
+      incHandler.completeCycle(invalidationResults, getAnalysis)
+    } else {
+      throw new IllegalStateException(
+        "can't call AnalysisCallback#getCycleResultOnce more than once"
+      )
     }
-    incHandler.completeCycle(invalidationResults, getAnalysis)
   }
 
   private def getAnalysis: Analysis = {
@@ -1051,7 +1057,7 @@ private final class AnalysisCallback(
     outputJarContent.get().asJava
   }
 
-  private[this] var writtenEarlyArtifacts: Boolean = false
+  @volatile private[this] var writtenEarlyArtifacts: Boolean = false
 
   private def writeEarlyArtifacts(merged: Analysis): Unit = {
     writtenEarlyArtifacts = true


### PR DESCRIPTION
For the parallel Hydra Scala compiler to work with sbt and zinc, it's paramount
that the AnalysisCallback is thread-safe. The bulk of the work was done in
sbt/zinc#410, but the changes introduced to support pipelined compilation were
not thread-safe, hence could potentially break compilation via Hydra.

There are three categories of concurrency hazards that are fixed:

* Memory visibility issues (`@volatile` helps with this)
* Compiler/JVM optimizations leading to instructions re-ordering (`@volatile
  prevents this from happening in the sections of interest)
* Race conditions due to concurrent read/write (`AtomicBoolean` CAS heals this)

Mind that instead of `@volatile`, it was perfectly fine to use
`AtomicReference`/`AtomicBoolean`, but I opted for `@volatile` in the places
where CAS were not required. The rationale is to apply KISS.

I've tested this by building a local sbt with zinc produced out of this PR, and tested Hydra compilation in sbt 1.4 works. I don't believe there is a need for testing performance. The reason is that the performance impact of this PR is so irrelevant that is essentially impossible to observe.