### PR TITLE
Add ScalaInstance.loaderCompilerOnly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -467,6 +467,8 @@ lazy val compilerInterface = (projectMatrix in internalPath / "compiler-interfac
       exclude[ReversedMissingMethodProblem]("xsbti.compile.ScalaInstance.loaderLibraryOnly"),
       exclude[ReversedMissingMethodProblem]("xsbti.compile.ScalaInstance.libraryJars"),
       exclude[ReversedMissingMethodProblem]("xsbti.compile.IncrementalCompiler.compileAllJava"),
+      exclude[ReversedMissingMethodProblem]("xsbti.compile.ScalaInstance.loaderCompilerOnly"),
+      exclude[ReversedMissingMethodProblem]("xsbti.compile.ScalaInstance.compilerJars"),
     ),
   )
   .jvmPlatform(autoScalaLibrary = false)

--- a/internal/compiler-interface/src/main/java/xsbti/compile/ScalaInstance.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/ScalaInstance.java
@@ -35,6 +35,13 @@ public interface ScalaInstance {
 	/** A class loader providing access to the classes and resources in all the jars of this Scala instance. */
 	ClassLoader loader();
 
+	/** A class loader providing access to the classes and resources in the compiler jar of this Scala instance.
+	 * In Scala 2, `loaderCompilerOnly` and `loader` are not different.
+	 * But in Scala 3, `loader` contains the `scala3doc` jar and all its dependencies, that are not contained in
+	 * `loaderCompilerOnly`
+	 * */
+	ClassLoader loaderCompilerOnly();
+
 	/** A class loader providing access to the classes and resources in the library jars of this Scala instance. */
 	ClassLoader loaderLibraryOnly();
 
@@ -48,7 +55,11 @@ public interface ScalaInstance {
 	}
 
 	/** Classpath entry that stores the Scala compiler classes. */
-	File compilerJar();
+	File[] compilerJars();
+
+	/** @deprecated Use `compilerJars` instead (since 1.5.0). */
+	@Deprecated
+	default File compilerJar() { return compilerJars()[0]; }
 
 	/** All the jars except `libraryJars` and `compilerJar`. */
 	File[] otherJars();

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala
@@ -88,7 +88,7 @@ final class CompilerArguments(
    */
   def finishClasspath(classpath: Seq[Path]): Seq[Path] = {
     val filteredClasspath = filterLibrary(classpath)
-    val extraCompiler = include(cpOptions.compiler, scalaInstance.compilerJar.toPath)
+    val extraCompiler = include(cpOptions.compiler, scalaInstance.compilerJars.map(_.toPath): _*)
     val otherJars = scalaInstance.otherJars.toList.map(_.toPath)
     val extraClasspath = include(cpOptions.extra, otherJars: _*)
     filteredClasspath ++ extraCompiler ++ extraClasspath

--- a/zinc/src/test/scala/sbt/inc/ConstantBridgeProvider.scala
+++ b/zinc/src/test/scala/sbt/inc/ConstantBridgeProvider.scala
@@ -41,11 +41,19 @@ final class ConstantBridgeProvider(bridges: List[ScalaBridge], tempDir: Path)
     val jars = bridgeOrBoom(scalaVersion).jars.toArray
     assert(jars.forall(_.exists), "One or more jar(s) in the Scala instance do not exist.")
     val libraryJar = jars.find(_.getName.contains("scala-library")).get
-    val compilerJar = jars.find(_.getName.contains("scala-compiler")).get
     val loaderLibraryOnly = ClasspathUtil.toLoader(Seq(libraryJar.toPath))
     val missingJars = jars.filter(_ != libraryJar)
     val loader = ClasspathUtil.toLoader(missingJars.map(_.toPath), loaderLibraryOnly)
-    new ScalaInstance(scalaVersion, loader, loaderLibraryOnly, libraryJar, compilerJar, jars, None)
+    new ScalaInstance(
+      scalaVersion,
+      loader,
+      loader,
+      loaderLibraryOnly,
+      Array(libraryJar),
+      compilerJars = jars,
+      jars,
+      None
+    )
   }
 
   private def bridgeOrBoom(scalaVersion: String) = {


### PR DESCRIPTION
Part of https://github.com/sbt/sbt/issues/6080

Distinguish between the compiler class loader and the full class loader, that contains `scala3doc`.

Use the full class loader only for compiling the doc.