### PR TITLE
Drop pruning in compileAllJava

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/SourceInfo.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/SourceInfo.scala
@@ -30,28 +30,73 @@ object SourceInfos {
   def of(m: Map[VirtualFileRef, SourceInfo]): SourceInfos = new MSourceInfos(m)
 
   val emptyInfo: SourceInfo = makeInfo(Nil, Nil, Nil)
+
   def makeInfo(
       reported: Seq[Problem],
       unreported: Seq[Problem],
       mainClasses: Seq[String]
   ): SourceInfo =
     new UnderlyingSourceInfo(reported, unreported, mainClasses)
+
   def merge(infos: Traversable[SourceInfos]): SourceInfos =
     infos.foldLeft(SourceInfos.empty)(_ ++ _)
+
+  def merge1(info1: SourceInfo, info2: SourceInfo) = {
+    makeInfo(
+      mergeProblems(info1.getReportedProblems, info2.getReportedProblems),
+      mergeProblems(info1.getUnreportedProblems, info2.getUnreportedProblems),
+      (info1.getMainClasses ++ info2.getMainClasses).distinct,
+    )
+  }
+
+  def mergeProblems(ps1: Seq[Problem], ps2: Seq[Problem]) = {
+    distinctBy(ps1 ++ ps2)(problemKey)
+  }
+
+  // Seq#distinctBy is 2.13+ only
+  def distinctBy[A, B](xs: Seq[A])(f: A => B) = xs.groupBy(f).map(_._2.head).toSeq
+
+  def problemKey(p: Problem) = {
+    (
+      p.category,
+      p.severity.ordinal,
+      p.message,
+      p.position.sourcePath.orElse(""),
+      p.position.offset.orElse(0),
+      p.position.startOffset.orElse(0),
+      p.position.endOffset.orElse(0)
+    )
+  }
 }
 
 private final class MSourceInfos(val allInfos: Map[VirtualFileRef, SourceInfo])
     extends SourceInfos {
-  def ++(o: SourceInfos) = new MSourceInfos(allInfos ++ o.allInfos)
-  def --(sources: Iterable[VirtualFileRef]) = new MSourceInfos(allInfos -- sources)
-  def groupBy[K](f: VirtualFileRef => K): Map[K, SourceInfos] =
-    allInfos groupBy (x => f(x._1)) map { x =>
-      (x._1, new MSourceInfos(x._2))
+
+  def ++(o: SourceInfos) = {
+    var infos = new scala.collection.immutable.HashMap[VirtualFileRef, SourceInfo]
+    (allInfos.keySet ++ o.allInfos.keySet).foreach { file =>
+      val lhs = allInfos.getOrElse(file, null)
+      val rhs = o.allInfos.getOrElse(file, null)
+      val res = if (lhs == null) rhs else if (rhs == null) lhs else SourceInfos.merge1(lhs, rhs)
+      infos = infos.updated(file, res)
     }
-  def add(file: VirtualFileRef, info: SourceInfo) = new MSourceInfos(allInfos + ((file, info)))
+    new MSourceInfos(infos)
+  }
+
+  def --(sources: Iterable[VirtualFileRef]) = new MSourceInfos(allInfos -- sources)
+
+  def groupBy[K](f: VirtualFileRef => K): Map[K, SourceInfos] =
+    allInfos.groupBy(x => f(x._1)).map(x => (x._1, new MSourceInfos(x._2)))
+
+  def add(file: VirtualFileRef, info: SourceInfo) = {
+    val info0 = allInfos.getOrElse(file, null)
+    val infos = allInfos.updated(file, if (info0 == null) info else SourceInfos.merge1(info0, info))
+    new MSourceInfos(infos)
+  }
 
   override def get(file: VirtualFileRef): SourceInfo =
     allInfos.getOrElse(file, SourceInfos.emptyInfo)
+
   override def getAllSourceInfos: java.util.Map[VirtualFileRef, SourceInfo] = {
     import scala.collection.JavaConverters.mapAsJavaMapConverter
     mapAsJavaMapConverter(allInfos).asJava


### PR DESCRIPTION
I couldn't find or guess why compileAllJava pruned its previous
analysis, so I removed it and found only "apiinfo/main-discovery"
failed.  That turned out to be because SourceInfos merging was removing
previously found main classes, so I tweaked that.  I reused the logic
for when to prune the analysis anyways (changes in setup).