### PR TITLE
Fixes full recompilation after reboot by fixing Modifier access

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -283,6 +283,9 @@ lazy val zincPersist = (projectMatrix in internalPath / "zinc-persist")
       exclude[IncompatibleMethTypeProblem]("xsbti.*"),
       exclude[ReversedMissingMethodProblem]("xsbti.*"),
       exclude[IncompatibleTemplateDefProblem]("sbt.internal.inc.schema.*"),
+      exclude[MissingClassProblem]("xsbti.api.InternalApiProxy$"),
+      exclude[MissingClassProblem]("xsbti.api.InternalApiProxy$Modifiers$"),
+      exclude[MissingClassProblem]("xsbti.api.InternalApiProxy")
     ),
   )
   .jvmPlatform(scalaVersions = scala212_213)

--- a/internal/compiler-interface/src/main/java/xsbti/api/Modifiers.java
+++ b/internal/compiler-interface/src/main/java/xsbti/api/Modifiers.java
@@ -56,7 +56,7 @@ public final class Modifiers implements java.io.Serializable
 	 * This method is not part of the public API and it may be removed at any point.
 	 * @param flags An instance of byte encoding the modifiers.
 	 */
-	protected Modifiers(byte flags) {
+	private Modifiers(byte flags) {
 		this.flags = flags;
 	}
 

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/binary/converters/InternalApiProxy.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/binary/converters/InternalApiProxy.scala
@@ -9,20 +9,24 @@
  * additional information regarding copyright ownership.
  */
 
-package xsbti.api
+package sbt.internal.inc.binary.converters
 
 /**
  * Defines a proxy to the Java compiler interface to create different utils.
  *
  * This proxy is required for an efficient deserialization of the analysis files.
- * It exposes implementation details and uses protected methods to create new
- * instances of other classes.
+ * It exposes implementation details and uses reflection methods to access private
+ * constructors.
  *
- * Even though this proxy is public, Do not depend on it, it has no binary compatibility
+ * This proxy is not public, Do not depend on it, it has no binary compatibility
  * guarantee and can be broken in any minor release.
  */
 object InternalApiProxy {
   object Modifiers {
-    def apply(flags: Int): Modifiers = new Modifiers(flags.toByte)
+    def apply(flags: Int): xsbti.api.Modifiers = {
+      val constructor = classOf[xsbti.api.Modifiers].getDeclaredConstructor(java.lang.Byte.TYPE)
+      constructor.setAccessible(true)
+      constructor.newInstance(flags.toByte: java.lang.Byte)
+    }
   }
 }

--- a/internal/zinc-persist/src/test/scala/sbt/inc/binary/converter/InternalApiProxySpecification.scala
+++ b/internal/zinc-persist/src/test/scala/sbt/inc/binary/converter/InternalApiProxySpecification.scala
@@ -1,0 +1,19 @@
+package sbt.inc.binary.converter
+
+import org.scalatest.funsuite.AnyFunSuite
+import sbt.internal.inc.binary.converters.InternalApiProxy
+
+class InternalApiProxySpecification extends AnyFunSuite {
+  test("should create Modifiers from tags") {
+    val modifiers = InternalApiProxy.Modifiers(0)
+    assert(!modifiers.isAbstract)
+    assert(!modifiers.isFinal)
+    assert(!modifiers.isImplicit)
+    assert(!modifiers.isLazy)
+    assert(!modifiers.isMacro)
+    assert(!modifiers.isOverride)
+    assert(!modifiers.isSealed)
+    assert(!modifiers.isSuperAccessor)
+  }
+
+}


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/6209

The problem is `InternalApiProxy` cannot access the `protected` constructor in `Modifiers` because it is not declared in the same **run-time** package. It is in the same package but it is not created by the same class loader (see [jvm spec](https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-5.html#jvms-5.4.4)). This causes runtime errors when parsing the `api_companions.bin`:
```
tried to access method xsbti.api.Modifiers.<init>(B)V from class xsbti.api.InternalApiProxy$Modifiers$
```

The solution I propose is to make `protected Modifiers(byte tag)` private and to use reflection to access it in `InternalApiProxy`. Thus it is clear that we are intentionally accessing the internals of `Modifiers`. Also I've added a test to make it a bit more robust.
  