### PR TITLE
fix ScalaInstance constructor

### DIFF
--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/ScalaInstance.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/ScalaInstance.scala
@@ -58,8 +58,8 @@ final class ScalaInstance(
       loader,
       loaderLibraryOnly,
       Array(libraryJar),
-      allJars,
-      Array.empty,
+      compilerJars = allJars,
+      allJars = allJars,
       explicitActual
     )
   }


### PR DESCRIPTION
Fix #972 