### PR TITLE
Fix overcompilation with scalac -release by dummy mapping ct.sym entries

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/MappedVirtualFile.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/MappedVirtualFile.scala
@@ -58,8 +58,12 @@ class MappedFileConverter(rootPaths: Map[String, Path], allowMachinePath: Boolea
       case Some((key, rootPath)) =>
         MappedVirtualFile(s"$${$key}/${rootPath.relativize(path)}".replace('\\', '/'), rootPaths)
       case _ =>
+        def isCtSym =
+          path.getFileSystem
+            .provider()
+            .getScheme == "jar" && path.getFileSystem.toString.endsWith("ct.sym")
         def isJrt = path.getFileSystem.provider().getScheme == "jrt"
-        if (isJrt || path.getFileName.toString == "rt.jar")
+        if (isJrt || path.getFileName.toString == "rt.jar" || isCtSym)
           DummyVirtualFile("rt.jar", path)
         else if (allowMachinePath) MappedVirtualFile(s"$path".replace('\\', '/'), rootPaths)
         else sys.error(s"$path cannot be mapped using the root paths $rootPaths")

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/MappedVirtualFile.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/MappedVirtualFile.scala
@@ -58,12 +58,11 @@ class MappedFileConverter(rootPaths: Map[String, Path], allowMachinePath: Boolea
       case Some((key, rootPath)) =>
         MappedVirtualFile(s"$${$key}/${rootPath.relativize(path)}".replace('\\', '/'), rootPaths)
       case _ =>
-        path match {
-          case p if p.toUri.getScheme == "jrt"         => DummyVirtualFile("rt.jar", p)
-          case p if p.getFileName.toString == "rt.jar" => DummyVirtualFile("rt.jar", p)
-          case p if allowMachinePath                   => MappedVirtualFile(s"$p".replace('\\', '/'), rootPaths)
-          case p                                       => sys.error(s"$p cannot be mapped using the root paths $rootPaths")
-        }
+        def isJrt = path.getFileSystem.provider().getScheme == "jrt"
+        if (isJrt || path.getFileName.toString == "rt.jar")
+          DummyVirtualFile("rt.jar", path)
+        else if (allowMachinePath) MappedVirtualFile(s"$path".replace('\\', '/'), rootPaths)
+        else sys.error(s"$path cannot be mapped using the root paths $rootPaths")
     }
   }
 }


### PR DESCRIPTION
Manually tested with https://github.com/retronym/zinc-bug-release-flag. I can't figure out how to make the test framework a) simulate multiple SBT sessions (ie reload state from disk) or b) conditionally run the new test only on JDK 9+.

Before:

```
> sbt clean compile && echo "==== ROUND 2 ====" && sbt compile 'last compileIncremental'
[info] welcome to sbt 1.5.3 (AdoptOpenJDK Java 11.0.11)
[info] loading project definition from /Users/jz/code/zinc-bug-release-flag/project
[info] loading settings for project zinc-bug-release-flag from build.sbt ...
[info] set current project to zinc-bug-release-flag (in build file:/Users/jz/code/zinc-bug-release-flag/)
[info] Executing in batch mode. For better performance use sbt's shell
[success] Total time: 0 s, completed 2 Jun. 2021, 11:22:39 am
[info] compiling 1 Scala source to /Users/jz/code/zinc-bug-release-flag/target/scala-2.12/classes ...
[info] Non-compiled module 'compiler-bridge_2.12' for Scala 2.12.14. Compiling...
[info]   Compilation completed in 5.956s.
[success] Total time: 7 s, completed 2 Jun. 2021, 11:22:46 am
==== ROUND 2 ====
[info] welcome to sbt 1.5.3 (AdoptOpenJDK Java 11.0.11)
[info] loading project definition from /Users/jz/code/zinc-bug-release-flag/project
[info] loading settings for project zinc-bug-release-flag from build.sbt ...
[info] set current project to zinc-bug-release-flag (in build file:/Users/jz/code/zinc-bug-release-flag/)
[info] Executing in batch mode. For better performance use sbt's shell
[info] compiling 1 Scala source to /Users/jz/code/zinc-bug-release-flag/target/scala-2.12/classes ...
[success] Total time: 3 s, completed 2 Jun. 2021, 11:22:53 am
[debug] [zinc] IncrementalCompile -----------
```

After:

```
> rm -rf /Users/jz/.sbt/boot/scala-2.12.14/org.scala-sbt/sbt/1.5.4-SNAPSHOT && sbt --sbt-version 1.5.4-SNAPSHOT clean compile && echo "==== ROUND 2 ====" && sbt  --sbt-version 1.5.4-SNAPSHOT compile 'last compileIncremental'
[info] [launcher] getting org.scala-sbt sbt 1.5.4-SNAPSHOT  (this may take some time)...
[info] welcome to sbt 1.5.4-SNAPSHOT (N/A Java 15.0.2)
[info] loading project definition from /Users/jz/code/zinc-bug-release-flag/project
[info] loading settings for project zinc-bug-release-flag from build.sbt ...
[info] set current project to zinc-bug-release-flag (in build file:/Users/jz/code/zinc-bug-release-flag/)
[info] Executing in batch mode. For better performance use sbt's shell
[success] Total time: 0 s, completed 2 Jun 2021, 1:40:47 pm
[info] compiling 1 Scala source to /Users/jz/code/zinc-bug-release-flag/target/scala-2.12/classes ...
[success] Total time: 2 s, completed 2 Jun 2021, 1:40:50 pm
==== ROUND 2 ====
[info] welcome to sbt 1.5.4-SNAPSHOT (N/A Java 15.0.2)
[info] loading project definition from /Users/jz/code/zinc-bug-release-flag/project
[info] loading settings for project zinc-bug-release-flag from build.sbt ...
[info] set current project to zinc-bug-release-flag (in build file:/Users/jz/code/zinc-bug-release-flag/)
[info] Executing in batch mode. For better performance use sbt's shell
[success] Total time: 0 s, completed 2 Jun 2021, 1:40:53 pm
[debug] [zinc] IncrementalCompile -----------
[debug] IncrementalCompile.incrementalCompile
[debug] previous = Stamps for: 1 products, 1 sources, 1 libraries
[debug] current source = Set(${BASE}/src/main/scala/test.scala)
[debug] > initialChanges = InitialChanges(Changes(added = Set(), removed = Set(), changed = Set(), unmodified = ...),Set(),Set(),API Changes: Set())
[debug] No changes
```

Fixes #981 
