### PR TITLE
Guard against invalid range positions returned by Javac

### DIFF
--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/DiagnosticsReporter.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/DiagnosticsReporter.scala
@@ -93,8 +93,10 @@ object DiagnosticsReporter {
       start: Long,
       end: Long
   ): (Integer, Integer, Integer, Integer, String) = {
+
     var startPos = start.toInt
     var endPos = end.toInt
+
     val lineContent = cc.subSequence(startPos, endPos).toString
     // ignore CR or LF - depending on which one isn't found
     var checkForN = true
@@ -213,7 +215,9 @@ object DiagnosticsReporter {
         source match {
           case Some(source: JavaFileObject) =>
             (Option(source.getCharContent(true)), startPosition, endPosition) match {
-              case (Some(cc), Some(start), Some(end)) =>
+              case (Some(cc), Some(start), Some(end))
+                  // Guard against Javac bug in parsing `public class ChrisTest { void m() { else null; }}`
+                  if end >= start =>
                 // can't optimise using line as it's not always the same as startLine
                 val range = contentAndRanges(cc, start, end)
                 (


### PR DESCRIPTION
```
==> project/build.properties <==
sbt.version=1.5.4

==> build.sbt <==
autoScalaLibrary := false

==> src/main/java/Test.java <==
public class Test {
  void m() {
    else null;
  }
}
```

Before:
```
[error] java.lang.RuntimeException: java.lang.StringIndexOutOfBoundsException: begin 42, end 37, length 54
[error] 	at jdk.compiler/com.sun.tools.javac.api.JavacTaskImpl.invocationHelper(JavacTaskImpl.java:168)
[error] 	at jdk.compiler/com.sun.tools.javac.api.JavacTaskImpl.doCall(JavacTaskImpl.java:100)
[error] 	at jdk.compiler/com.sun.tools.javac.api.JavacTaskImpl.call(JavacTaskImpl.java:94)
[error] 	at sbt.internal.inc.javac.LocalJavaCompiler.run(LocalJava.scala:331)
[error] 	at sbt.internal.inc.javac.AnalyzingJavaCompiler.$anonfun$compile$12(AnalyzingJavaCompiler.scala:167)
[error] 	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
[error] 	at sbt.internal.inc.javac.AnalyzingJavaCompiler.timed(AnalyzingJavaCompiler.scala:251)
[error] 	at sbt.internal.inc.javac.AnalyzingJavaCompiler.compile(AnalyzingJavaCompiler.scala:156)
[error] 	at sbt.internal.inc.MixedAnalyzingCompiler.$anonfun$compileJava$1(MixedAnalyzingCompiler.scala:98)
[error] 	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
[error] 	at sbt.internal.inc.MixedAnalyzingCompiler.timed(MixedAnalyzingCompiler.scala:241)
[error] 	at sbt.internal.inc.MixedAnalyzingCompiler.compileJava(MixedAnalyzingCompiler.scala:61)
[error] 	at sbt.internal.inc.MixedAnalyzingCompiler.compileJava0$1(MixedAnalyzingCompiler.scala:191)
[error] 	at sbt.internal.inc.MixedAnalyzingCompiler.compile(MixedAnalyzingCompiler.scala:204)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileInternal$1(IncrementalCompilerImpl.scala:528)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileInternal$1$adapted(IncrementalCompilerImpl.scala:528)
[error] 	at sbt.internal.inc.Incremental$.$anonfun$apply$5(Incremental.scala:174)
[error] 	at sbt.internal.inc.Incremental$.$anonfun$apply$5$adapted(Incremental.scala:172)
[error] 	at sbt.internal.inc.Incremental$$anon$2.run(Incremental.scala:457)
[error] 	at sbt.internal.inc.IncrementalCommon$CycleState.next(IncrementalCommon.scala:116)
[error] 	at sbt.internal.inc.IncrementalCommon$$anon$1.next(IncrementalCommon.scala:56)
[error] 	at sbt.internal.inc.IncrementalCommon$$anon$1.next(IncrementalCommon.scala:52)
[error] 	at sbt.internal.inc.IncrementalCommon.cycle(IncrementalCommon.scala:261)
[error] 	at sbt.internal.inc.Incremental$.$anonfun$incrementalCompile$8(Incremental.scala:412)
[error] 	at sbt.internal.inc.Incremental$.withClassfileManager(Incremental.scala:499)
[error] 	at sbt.internal.inc.Incremental$.incrementalCompile(Incremental.scala:399)
[error] 	at sbt.internal.inc.Incremental$.apply(Incremental.scala:166)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.compileInternal(IncrementalCompilerImpl.scala:528)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileIncrementally$1(IncrementalCompilerImpl.scala:482)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.handleCompilationError(IncrementalCompilerImpl.scala:332)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.compileIncrementally(IncrementalCompilerImpl.scala:420)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.compile(IncrementalCompilerImpl.scala:137)
[error] 	at sbt.Defaults$.compileIncrementalTaskImpl(Defaults.scala:2362)
[error] 	at sbt.Defaults$.$anonfun$compileIncrementalTask$2(Defaults.scala:2319)
[error] 	at sbt.internal.io.Retry$.apply(Retry.scala:46)
[error] 	at sbt.internal.io.Retry$.apply(Retry.scala:28)
[error] 	at sbt.internal.io.Retry$.apply(Retry.scala:23)
[error] 	at sbt.internal.server.BspCompileTask$.compute(BspCompileTask.scala:31)
[error] 	at sbt.Defaults$.$anonfun$compileIncrementalTask$1(Defaults.scala:2315)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:62)
[error] 	at sbt.std.Transform$$anon$4.work(Transform.scala:68)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:282)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:23)
[error] 	at sbt.Execute.work(Execute.scala:291)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:282)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:64)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
[error] 	at java.base/java.lang.Thread.run(Thread.java:831)
[error] Caused by: java.lang.StringIndexOutOfBoundsException: begin 42, end 37, length 54
[error] 	at java.base/java.lang.String.checkBoundsBeginEnd(String.java:3751)
[error] 	at java.base/java.lang.String.substring(String.java:1907)
[error] 	at java.base/java.lang.String.subSequence(String.java:1945)
[error] 	at sbt.internal.inc.javac.DiagnosticsReporter$.contentAndRanges(DiagnosticsReporter.scala:98)
[error] 	at sbt.internal.inc.javac.DiagnosticsReporter$PositionImpl$.apply(DiagnosticsReporter.scala:218)
[error] 	at sbt.internal.inc.javac.DiagnosticsReporter.report(DiagnosticsReporter.scala:50)
[error] 	at jdk.compiler/com.sun.tools.javac.api.ClientCodeWrapper$WrappedDiagnosticListener.report(ClientCodeWrapper.java:772)
```

After:
```
[info] welcome to sbt 1.5.4-SNAPSHOT (AdoptOpenJDK Java 16.0.1)
[info] loading global plugins from /Users/jz/.sbt/1.0/plugins
[info] loading project definition from /Users/jz/code/scratch/project
[info] loading settings for project scratch from build.sbt ...
[info] set current project to scratch (in build file:/Users/jz/code/scratch/)
[info] Executing in batch mode. For better performance use sbt's shell
[success] Total time: 0 s, completed 25 June 2021, 9:28:04 am
[info] compiling 1 Java source to /Users/jz/code/scratch/target/scala-2.12/classes ...
[error] /Users/jz/code/scratch/src/main/java/Test.java:3:1: not a statement
[error] /Users/jz/code/scratch/src/main/java/Test.java:3:1: 'else' without 'if'
[error] (Compile / compileIncremental) javac returned non-zero exit code
[error] Total time: 1 s, completed 25 June 2021, 9:28:05 am
```