### PR TITLE
Force the type of an annotation's typeSymbol before checking isStatic

### DIFF
--- a/zinc/src/sbt-test/source-dependencies/trait-local-change/build.json
+++ b/zinc/src/sbt-test/source-dependencies/trait-local-change/build.json
@@ -1,0 +1,8 @@
+{
+  "projects": [
+    {
+      "name": "pro",
+      "scalaVersion": "2.13.6"
+    }
+  ]
+}

--- a/zinc/src/sbt-test/source-dependencies/trait-local-change/changes/A2.scala
+++ b/zinc/src/sbt-test/source-dependencies/trait-local-change/changes/A2.scala
@@ -1,0 +1,3 @@
+trait A {
+  def f: String = "b"
+}

--- a/zinc/src/sbt-test/source-dependencies/trait-local-change/pro/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/trait-local-change/pro/A.scala
@@ -1,0 +1,3 @@
+trait A {
+  def f: String = "a"
+}

--- a/zinc/src/sbt-test/source-dependencies/trait-local-change/pro/B.scala
+++ b/zinc/src/sbt-test/source-dependencies/trait-local-change/pro/B.scala
@@ -1,0 +1,1 @@
+class B extends A

--- a/zinc/src/sbt-test/source-dependencies/trait-local-change/test
+++ b/zinc/src/sbt-test/source-dependencies/trait-local-change/test
@@ -1,0 +1,7 @@
+> pro/clean
+> pro/compile
+$ copy-file changes/A2.scala pro/A.scala
+# Second compilation round, there should be no third round (we don't need to recompile B.scala)
+> pro/compile
+# Check that there were only two rounds of compilation
+> pro/checkIterations 2


### PR DESCRIPTION
Before 2.13, `isStatic` is implemented by
`isNonBottomSubClass(StaticAnnotationClass)`
which forces the annotation symbol's type.

In 2.13, Java annotations are identified by flags. This check doesn't
force the info, and the flags are missing if the info is still a
`ClassfileLoader`.

This leads to spurious API changes (annotation goes missing) if the
depending if the info is already forced or not.

A fix for this will be in 2.13.7, but we should still work around it
in Zinc to make sure it works correctly on 2.13.0-6.

Fixes https://github.com/sbt/zinc/issues/998