### PR TITLE
fix `raw type` warnings

### DIFF
--- a/internal/compiler-interface/src/main/java/xsbti/api/SafeLazy.java
+++ b/internal/compiler-interface/src/main/java/xsbti/api/SafeLazy.java
@@ -55,14 +55,14 @@ public final class SafeLazy {
     private Thunky<T> thunky;
 
     Impl(Supplier<T> thunk) {
-      this.thunky = new Thunky(thunk, null);
+      this.thunky = new Thunky<>(thunk, null);
     }
 
     public T get() {
       Thunky<T> t = thunky;
       if (t.result == null) {
         T r = t.thunk.get();
-        t = new Thunky(null, r);
+        t = new Thunky<>(null, r);
         thunky = t;
       }
       return t.result;


### PR DESCRIPTION
```
[warn] /home/runner/work/zinc/zinc/internal/compiler-interface/src/main/java/xsbti/api/SafeLazy.java:58:1: found raw type: xsbti.api.SafeLazy.Thunky
[warn]   missing type arguments for generic class xsbti.api.SafeLazy.Thunky<T>
[warn] Thunky
[warn] /home/runner/work/zinc/zinc/internal/compiler-interface/src/main/java/xsbti/api/SafeLazy.java:58:1: unchecked call to Thunky(java.util.function.Supplier<T>,T) as a member of the raw type xsbti.api.SafeLazy.Thunky
[warn] new Thunky(thunk, null)
[warn] /home/runner/work/zinc/zinc/internal/compiler-interface/src/main/java/xsbti/api/SafeLazy.java:65:1: found raw type: xsbti.api.SafeLazy.Thunky
[warn]   missing type arguments for generic class xsbti.api.SafeLazy.Thunky<T>
[warn] Thunky
[warn] /home/runner/work/zinc/zinc/internal/compiler-interface/src/main/java/xsbti/api/SafeLazy.java:65:1: unchecked call to Thunky(java.util.function.Supplier<T>,T) as a member of the raw type xsbti.api.SafeLazy.Thunky
[warn] new Thunky(null, r)
```