### PR TITLE
Updated log4j version due to a vulnerability fix

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -84,7 +84,7 @@ object Dependencies {
   }
   val zeroAllocationHashing = "net.openhft" % "zero-allocation-hashing" % "0.10.1"
 
-  def log4jVersion = "2.11.2"
+  def log4jVersion = "2.15.0"
   val log4jApi = "org.apache.logging.log4j" % "log4j-api" % log4jVersion
   val log4jCore = "org.apache.logging.log4j" % "log4j-core" % log4jVersion
   val log4jSlf4jImpl = "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4jVersion


### PR DESCRIPTION
Updated log4j version due to a vulnerability fix: https://www.theverge.com/2021/12/10/22828303/log4j-library-vulnerability-log4shell-zero-day-exploit