### PR TITLE
adding log4j 2.16.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -84,7 +84,7 @@ object Dependencies {
   }
   val zeroAllocationHashing = "net.openhft" % "zero-allocation-hashing" % "0.10.1"
 
-  def log4jVersion = "2.15.0"
+  def log4jVersion = "2.16.0"
   val log4jApi = "org.apache.logging.log4j" % "log4j-api" % log4jVersion
   val log4jCore = "org.apache.logging.log4j" % "log4j-core" % log4jVersion
   val log4jSlf4jImpl = "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4jVersion


### PR DESCRIPTION
added log4j 2.16 to mitigate vulnerability for JNDI Completely