### PR TITLE
chore(deps): log4j 2.17.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -84,7 +84,7 @@ object Dependencies {
   }
   val zeroAllocationHashing = "net.openhft" % "zero-allocation-hashing" % "0.10.1"
 
-  def log4jVersion = "2.16.0"
+  def log4jVersion = "2.17.0"
   val log4jApi = "org.apache.logging.log4j" % "log4j-api" % log4jVersion
   val log4jCore = "org.apache.logging.log4j" % "log4j-core" % log4jVersion
   val log4jSlf4jImpl = "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4jVersion


### PR DESCRIPTION
Even 2.16.0 is vulnerable, 2.17.0 should be used instead.

See this for details: https://issues.apache.org/jira/browse/LOG4J2-3230