### PR TITLE
Upgrade util to 1.6.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
   val scala212_213 = Seq(defaultScalaVersion, scala213)
 
   private val ioVersion = nightlyVersion.getOrElse("1.6.0")
-  private val utilVersion = nightlyVersion.getOrElse("1.6.0")
+  private val utilVersion = nightlyVersion.getOrElse("1.6.1")
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion
 


### PR DESCRIPTION
util 1.6.0 depends on log4j 2.17.0 which is vulnerable.

util 1.6.1, targeting 2.17.1, was released and sbt was upgraded, but not zinc itself.