### PR TITLE
bump versions (Scala, sbt, test frameworks)

### DIFF
--- a/internal/zinc-benchmarks/src/test/scala/xsbt/ZincBenchmark.scala
+++ b/internal/zinc-benchmarks/src/test/scala/xsbt/ZincBenchmark.scala
@@ -106,7 +106,7 @@ private[xsbt] class ZincBenchmark(toCompile: BenchmarkProject, zincEnabled: Bool
 private[xsbt] object ZincBenchmark {
   // This is the Scala version used to compile the benchmark project
   // do not use `scala.util.Properties.versionNumberString`.
-  val scalaVersion = "2.13.6"
+  val scalaVersion = "2.13.8"
 
   /* ************************************************************* */
   /* Utils to programmatically instantiate Compiler from sbt setup  */

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val scala210 = "2.10.7"
   val scala211 = "2.11.12"
   val scala212 = "2.12.15"
-  val scala213 = "2.13.6"
+  val scala213 = "2.13.8"
   val defaultScalaVersion = scala212
   val allScalaVersions = Seq(defaultScalaVersion, scala210, scala211, scala213)
   val scala212_213 = Seq(defaultScalaVersion, scala213)
@@ -72,9 +72,9 @@ object Dependencies {
 
   val parserCombinator = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2"
   val sbinary = "org.scala-sbt" %% "sbinary" % "0.5.1"
-  val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.14.0"
-  val scalatest = "org.scalatest" %% "scalatest" % "3.2.0"
-  val junit = "junit" % "junit" % "4.12"
+  val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.15.3"
+  val scalatest = "org.scalatest" %% "scalatest" % "3.2.10"
+  val junit = "junit" % "junit" % "4.13.2"
   val verify = "com.eed3si9n.verify" %% "verify" % "0.2.0"
   val sjsonnew = Def.setting {
     "com.eed3si9n" %% "sjson-new-core" % contrabandSjsonNewVersion.value

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.6.1

--- a/zinc/src/sbt-test/macros/macro-arg-dep-nested/build.json
+++ b/zinc/src/sbt-test/macros/macro-arg-dep-nested/build.json
@@ -5,11 +5,11 @@
       "dependsOn": [
         "macro-provider"
       ],
-      "scalaVersion": "2.13.6"
+      "scalaVersion": "2.13.8"
     },
     {
       "name": "macro-provider",
-      "scalaVersion": "2.13.6"
+      "scalaVersion": "2.13.8"
     }
   ]
 }

--- a/zinc/src/sbt-test/macros/macro-arg-dep-stackoverflow/build.json
+++ b/zinc/src/sbt-test/macros/macro-arg-dep-stackoverflow/build.json
@@ -5,11 +5,11 @@
       "dependsOn": [
         "macro-provider"
       ],
-      "scalaVersion": "2.13.6"
+      "scalaVersion": "2.13.8"
     },
     {
       "name": "macro-provider",
-      "scalaVersion": "2.13.6"
+      "scalaVersion": "2.13.8"
     }
   ]
 }

--- a/zinc/src/sbt-test/macros/macro-arg-dep/build.json
+++ b/zinc/src/sbt-test/macros/macro-arg-dep/build.json
@@ -5,11 +5,11 @@
       "dependsOn": [
         "macro-provider"
       ],
-      "scalaVersion": "2.13.6"
+      "scalaVersion": "2.13.8"
     },
     {
       "name": "macro-provider",
-      "scalaVersion": "2.13.6"
+      "scalaVersion": "2.13.8"
     }
   ]
 }

--- a/zinc/src/sbt-test/macros/macro/build.json
+++ b/zinc/src/sbt-test/macros/macro/build.json
@@ -5,11 +5,11 @@
       "dependsOn": [
         "macro-provider"
       ],
-      "scalaVersion": "2.13.6"
+      "scalaVersion": "2.13.8"
     },
     {
       "name": "macro-provider",
-      "scalaVersion": "2.13.6"
+      "scalaVersion": "2.13.8"
     }
   ]
 }

--- a/zinc/src/sbt-test/source-dependencies/java-class-invs/build.json
+++ b/zinc/src/sbt-test/source-dependencies/java-class-invs/build.json
@@ -6,18 +6,18 @@
         "std",
         "lib"
       ],
-      "scalaVersion": "2.13.6"
+      "scalaVersion": "2.13.8"
     },
     {
       "name": "lib",
       "dependsOn": [
         "std"
       ],
-      "scalaVersion": "2.13.6"
+      "scalaVersion": "2.13.8"
     },
     {
       "name": "std",
-      "scalaVersion": "2.13.6"
+      "scalaVersion": "2.13.8"
     }
   ]
 }

--- a/zinc/src/sbt-test/source-dependencies/subproject-api-update/build.json
+++ b/zinc/src/sbt-test/source-dependencies/subproject-api-update/build.json
@@ -5,11 +5,11 @@
       "dependsOn": [
         "core"
       ],
-      "scalaVersion": "2.13.6"
+      "scalaVersion": "2.13.8"
     },
     {
       "name": "core",
-      "scalaVersion": "2.13.6"
+      "scalaVersion": "2.13.8"
     }
   ]
 }

--- a/zinc/src/sbt-test/source-dependencies/subproject-java/build.json
+++ b/zinc/src/sbt-test/source-dependencies/subproject-java/build.json
@@ -5,11 +5,11 @@
       "dependsOn": [
         "dep"
       ],
-      "scalaVersion": "2.13.6"
+      "scalaVersion": "2.13.8"
     },
     {
       "name": "dep",
-      "scalaVersion": "2.13.6"
+      "scalaVersion": "2.13.8"
     }
   ]
 }

--- a/zinc/src/sbt-test/source-dependencies/subproject-pipelining-mixed/build.json
+++ b/zinc/src/sbt-test/source-dependencies/subproject-pipelining-mixed/build.json
@@ -5,11 +5,11 @@
       "dependsOn": [
         "dep"
       ],
-      "scalaVersion": "2.13.6"
+      "scalaVersion": "2.13.8"
     },
     {
       "name": "dep",
-      "scalaVersion": "2.13.6"
+      "scalaVersion": "2.13.8"
     }
   ]
 }

--- a/zinc/src/sbt-test/source-dependencies/subproject-pipelining-noclobber/build.json
+++ b/zinc/src/sbt-test/source-dependencies/subproject-pipelining-noclobber/build.json
@@ -5,11 +5,11 @@
       "dependsOn": [
         "dep"
       ],
-      "scalaVersion": "2.13.6"
+      "scalaVersion": "2.13.8"
     },
     {
       "name": "dep",
-      "scalaVersion": "2.13.6"
+      "scalaVersion": "2.13.8"
     }
   ]
 }

--- a/zinc/src/sbt-test/source-dependencies/subproject-pipelining-optout/build.json
+++ b/zinc/src/sbt-test/source-dependencies/subproject-pipelining-optout/build.json
@@ -5,11 +5,11 @@
       "dependsOn": [
         "dep"
       ],
-      "scalaVersion": "2.13.6"
+      "scalaVersion": "2.13.8"
     },
     {
       "name": "dep",
-      "scalaVersion": "2.13.6"
+      "scalaVersion": "2.13.8"
     }
   ]
 }

--- a/zinc/src/sbt-test/source-dependencies/subproject-pipelining/build.json
+++ b/zinc/src/sbt-test/source-dependencies/subproject-pipelining/build.json
@@ -5,11 +5,11 @@
       "dependsOn": [
         "dep"
       ],
-      "scalaVersion": "2.13.6"
+      "scalaVersion": "2.13.8"
     },
     {
       "name": "dep",
-      "scalaVersion": "2.13.6"
+      "scalaVersion": "2.13.8"
     }
   ]
 }

--- a/zinc/src/sbt-test/source-dependencies/trait-local-change/build.json
+++ b/zinc/src/sbt-test/source-dependencies/trait-local-change/build.json
@@ -2,7 +2,7 @@
   "projects": [
     {
       "name": "pro",
-      "scalaVersion": "2.13.6"
+      "scalaVersion": "2.13.8"
     }
   ]
 }


### PR DESCRIPTION
sbt 1.5.5 -> 1.6.1
Scala 2.13.6 -> 2.13.8
JUnit 4.11 -> 4.13.2
ScalaTest 3.2.0 -> 3.2.10
ScalaCheck 1.14.0 -> 1.15.3