### PR TITLE
fixes so we can build on JDK 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
           - os: ubuntu-latest
             java: 11
             jobtype: 1
+          - os: ubuntu-latest
+            java: 17
+            jobtype: 1
           - os: windows-latest
             java: 8
             jobtype: 2

--- a/build.sbt
+++ b/build.sbt
@@ -206,6 +206,18 @@ lazy val zinc = (projectMatrix in (zincRootPath / "zinc"))
       BuildInfoKey.map(compilerBridge213 / Compile / classDirectory)("classDirectory213" -> _._2),
     ),
     Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat,
+    // so we have full access to com.sun.tools.javac on JDK 17
+    Test / javaOptions ++= (
+      if (System.getProperty("java.version").startsWith("1.8"))
+        Seq()
+      else
+        Seq(
+          "--add-opens",
+          "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+          "--add-opens",
+          "jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+        )
+    ),
     mimaSettings,
     mimaBinaryIssueFilters ++= Seq(
       exclude[DirectMissingMethodProblem]("sbt.internal.*"),

--- a/internal/compiler-interface/src/main/java/xsbti/VirtualFile.java
+++ b/internal/compiler-interface/src/main/java/xsbti/VirtualFile.java
@@ -37,7 +37,7 @@ import java.io.InputStream;
  * <p>A <code>VirtualFile</code> can also be created with plain <code>String</code>s
  * to represent the content, without any "real" files.
  * </p>
- * <h3>OK, but how does the compiler compile these?</h3>
+ * <h2>OK, but how does the compiler compile these?</h2>
  * See <code>IncrementalCompiler.java</code>.
  * At the top layer of Zinc, we are passing in the source files as a
  * sequence of {@link VirtualFile}s.

--- a/internal/compiler-interface/src/main/java/xsbti/VirtualFileRef.java
+++ b/internal/compiler-interface/src/main/java/xsbti/VirtualFileRef.java
@@ -26,7 +26,7 @@ package xsbti;
  * following flow of operation.
  * </p>
  *
- * <h3>Flow of operation</h3>
+ * <h2>Flow of operation</h2>
  * <p>Suppose that there are two people Alice and Bob who are working on the same repo.
  * On Alice's machine, the build tool would construct
  * an instance of {@link FileConverter} used for the entire build.
@@ -55,7 +55,7 @@ package xsbti;
  * be called the same, hopefully he can resume incremental compilation.
  * </p>
  *
- * <h3>Difference between VirtualFileRef and VirtualFile</h3>
+ * <h2>Difference between VirtualFileRef and VirtualFile</h2>
  * <p><code>VirtualFileRef</code> on its own can only have identity
  * information to be compared against another.
  * At the most basic level this could be implemented as
@@ -72,7 +72,7 @@ package xsbti;
  * represent something more concrete, like a local file or
  * an in-memory file.
  *
- * <h3>ok, so how would the compiler compile this?</h3>
+ * <h2>ok, so how would the compiler compile this?</h2>
  * See <code>IncrementalCompile.scala</code>.
  * At the top layer of Zinc, we are passing in the source files as a
  * sequence of {@link VirtualFile}s.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ scalacOptions += "-feature"
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.4")
-addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.5.1")
+addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.5.3")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "3.0.2")
 addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.6.5")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,4 +11,4 @@ libraryDependencies += "com.github.os72" % "protoc-jar" % "3.11.4" // sync w/ Pr
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.1")
 addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.5.2")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.1.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.4")
 addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.5.3")
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.2")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "3.0.2")
 addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.6.5")
 libraryDependencies += "com.github.os72" % "protoc-jar" % "3.11.4" // sync w/ ProtobufConfig / version


### PR DESCRIPTION
newer sbt-assembly version has the necessary ASM upgrade, is the main change

main motivation: I'd like to be able to do my local development work on 17. but also, it's good for the CI in this repo, and the Scala 2 community build too, to be able to run the tests on JDK 17, just in case.