### PR TITLE
remove unused JUnit dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -247,7 +247,7 @@ lazy val zincTesting = (projectMatrix in internalPath / "zinc-testing")
     name := "zinc Testing",
     baseSettings,
     noPublish,
-    libraryDependencies ++= Seq(scalaCheck, scalatest, junit, verify, sjsonnewScalaJson.value)
+    libraryDependencies ++= Seq(scalaCheck, scalatest, verify, sjsonnewScalaJson.value)
   )
   .defaultAxes(VirtualAxis.jvm, VirtualAxis.scalaPartialVersion(scala212))
   .jvmPlatform(scalaVersions = List(scala212, scala213))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -74,7 +74,6 @@ object Dependencies {
   val sbinary = "org.scala-sbt" %% "sbinary" % "0.5.1"
   val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.15.4"
   val scalatest = "org.scalatest" %% "scalatest" % "3.2.10"
-  val junit = "junit" % "junit" % "4.13.2"
   val verify = "com.eed3si9n.verify" %% "verify" % "2.0.1"
   val sjsonnew = Def.setting {
     "com.eed3si9n" %% "sjson-new-core" % contrabandSjsonNewVersion.value
@@ -97,7 +96,6 @@ object Dependencies {
         scalaCheck % Test,
         scalatest % Test,
         verify % Test,
-        junit % Test
       )
     )
 }


### PR DESCRIPTION
looks to me like we haven't had any JUnit tests since 2016