### PR TITLE
remove unused resolvers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,8 +91,6 @@ Global / semanticdbVersion := "4.4.28"
 ThisBuild / Test / fork := true
 
 def baseSettings: Seq[Setting[_]] = Seq(
-  resolvers += Resolver.typesafeIvyRepo("releases"),
-  resolvers += Resolver.sonatypeRepo("snapshots"),
   testOptions += Tests.Argument(TestFrameworks.ScalaCheck, "-w", "1", "-verbosity", "2"),
   testFrameworks += new TestFramework("verify.runner.Framework"),
   compile / javacOptions ++= Seq("-Xlint", "-Xlint:-serial"),


### PR DESCRIPTION
this was causing a bunch of warning noise about having multiple resolvers with the same name

it's also a performance concern for contributors.

I admit to not knowing what the motivation was for including them in the first place, but I suspect it no longer applies, and in any case, "if you liked it you should have put a comment on it"