### PR TITLE
Display error messages based on the transformed positions when source mapping is perfomed

### DIFF
--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/LoggedReporter.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/LoggedReporter.scala
@@ -129,12 +129,16 @@ class LoggedReporter(
       (problem0.category, problem0.position, problem0.message, problem0.severity, problem0.rendered)
     // Note: positions in reported errors can be fixed with `sourcePositionMapper`.
     val transformedPos: Position = sourcePositionMapper(position)
+    val transformed = transformedPos.sourceFile != position.sourceFile
     val problem = InterfaceUtil.problem(
       category,
       transformedPos,
       message,
       severity,
-      InterfaceUtil.jo2o(rendered)
+      // When the source mapping is performed,
+      // the information based on the `transformedPos` should be displayed
+      // even if the `rendered` is defined.
+      if (transformed) None else InterfaceUtil.jo2o(rendered)
     )
     allProblems += problem0
     severity match {


### PR DESCRIPTION
This commit is to improve Twirl's error message with Scala3.
https://github.com/playframework/twirl/issues/498

As I commented [here](https://github.com/sbt/zinc/issues/1074#issuecomment-1073247308), I think it is better to solve this problem on sbt's side, instead of letting Dotty use `sourcePositionMappers`.

This pull request makes sbt ignore `Problem#rendered` passed from the compiler if source mapping is actually performed.
Sbt will display the error message based on the `Position` transformed by source mapping.
When the source mapping is not performed, the message in `Problem#rendered` is displayed as before.