### PR TITLE
remove explicit log4j dependency from zincScripted

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -656,7 +656,6 @@ lazy val zincScripted = (projectMatrix in internalPath / "zinc-scripted")
     ideSkipProject := true, // otherwise IntelliJ complains
     publish / skip := true,
     name := "zinc Scripted",
-    libraryDependencies ++= log4jDependencies,
     Compile / buildInfo := Nil, // Only generate build info for tests
     BuildInfoPlugin.buildInfoScopedSettings(Test),
     Test / buildInfoPackage := "sbt.internal.inc",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -83,13 +83,6 @@ object Dependencies {
   }
   val zeroAllocationHashing = "net.openhft" % "zero-allocation-hashing" % "0.10.1"
 
-  def log4jVersion = "2.16.0"
-  val log4jApi = "org.apache.logging.log4j" % "log4j-api" % log4jVersion
-  val log4jCore = "org.apache.logging.log4j" % "log4j-core" % log4jVersion
-  val log4jSlf4jImpl = "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4jVersion
-  // specify all of log4j modules to prevent misalignment
-  val log4jDependencies = Vector(log4jApi, log4jCore, log4jSlf4jImpl)
-
   def addTestDependencies(p: Project): Project =
     p.settings(
       libraryDependencies ++= Seq(


### PR DESCRIPTION
as Eugene has noted on e.g. #1011, we get our log4j from sbt-util. it appears to me the lines removed here aren't needed

@eed3si9n you added these lines as part of #601 — it isn't clear to me what your motivation might have been at the time. it's far enough back that perhaps things were different then, I don't know

the lines don't _actually_ result in an outdated/insecure version of log4j being used (except perhaps during testing, where log4j-slf4j-impl-2.16.0.jar was brought in, but surely that JAR isn't where any insecurity is, and anyway it was only being used in `zincScripted` which isn't published and is only used during test)

but regardless, the _appearance_ that an insecure dependency _might_ be used is worth correcting