### PR TITLE
Notify ClassFileManager from IncOptions in Incremental.prune

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -488,8 +488,7 @@ object Incremental {
     IncrementalCommon.pruneClassFilesOfInvalidations(
       invalidatedSrcs,
       previous,
-      ClassFileManager
-        .deleteImmediately(output, outputJarContent, incOptions.auxiliaryClassFiles()),
+      ClassFileManager.getClassFileManager(incOptions, output, outputJarContent),
       converter
     )
   }


### PR DESCRIPTION
The `Incremental.prune` method creates a `deleteImmediately` `ClassFileManager` to prune the classfiles of invalidated sources. This means that the external `ClassFileManager` defined in `options.externalHooks` is not notified about these deletions.

Changing this to use `ClassFileManager.getClassFileManager` creates a `WrappedClassFileManager`, which also uses `deleteImmediately` (unless configured otherwise by `incOptions.classfileManagerType`), and additionaly notifies the external manager from `options.externalHooks`.

Fixes https://github.com/sbt/zinc/issues/1147