### PR TITLE
Removes system error on empty name hashes

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -958,7 +958,7 @@ private final class AnalysisCallback(
         NameHashing.merge(nm1, nm2)
       case (Some(nm), None) => nm
       case (None, Some(nm)) => nm
-      case (None, None)     => sys.error("Failed to find name hashes for " + className)
+      case (None, None)     => Array.empty
     }
   }
 


### PR DESCRIPTION
* Returning an empty array passes all tests and scripted tests
* Will prevent the error in https://github.com/sbt/sbt/issues/7157