### PR TITLE
Fix DefaultExternalHooks copy methods

### DIFF
--- a/internal/compiler-interface/src/main/java/xsbti/compile/DefaultExternalHooks.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/DefaultExternalHooks.java
@@ -17,15 +17,25 @@ public class DefaultExternalHooks implements ExternalHooks {
     private Optional<ExternalHooks.Lookup> lookup = Optional.empty();
     private Optional<ClassFileManager> classFileManager = Optional.empty();
     private GetProvenance getProvenance = NoProvenance.INSTANCE;
+    private InvalidationProfiler invalidationProfiler = InvalidationProfiler.EMPTY.INSTANCE;
 
+    public DefaultExternalHooks(
+        Optional<ExternalHooks.Lookup> lookup,
+        Optional<ClassFileManager> classFileManager,
+        GetProvenance getProvenance,
+        InvalidationProfiler invalidationProfiler
+    ) {
+        this.lookup = lookup;
+        this.classFileManager = classFileManager;
+        this.getProvenance = getProvenance;
+        this.invalidationProfiler = invalidationProfiler;
+    }
     public DefaultExternalHooks(
             Optional<ExternalHooks.Lookup> lookup,
             Optional<ClassFileManager> classFileManager,
             GetProvenance getProvenance
     ) {
-        this.lookup = lookup;
-        this.classFileManager = classFileManager;
-        this.getProvenance = getProvenance;
+        this(lookup, classFileManager, getProvenance, InvalidationProfiler.EMPTY.INSTANCE);
     }
 
     public DefaultExternalHooks(Optional<ExternalHooks.Lookup> lookup, Optional<ClassFileManager> classFileManager) {
@@ -45,22 +55,30 @@ public class DefaultExternalHooks implements ExternalHooks {
     @Override public GetProvenance getProvenance() { return getProvenance; }
 
     @Override
+    public InvalidationProfiler getInvalidationProfiler() { return invalidationProfiler; }
+
+    @Override
     public ExternalHooks withExternalClassFileManager(ClassFileManager externalClassFileManager) {
         Optional<ClassFileManager> external = Optional.of(externalClassFileManager);
         Optional<ClassFileManager> mixedManager = classFileManager.isPresent()
             ? Optional.of(WrappedClassFileManager.of(classFileManager.get(), external))
             : external;
-        return new DefaultExternalHooks(lookup, mixedManager, getProvenance);
+        return new DefaultExternalHooks(lookup, mixedManager, getProvenance, invalidationProfiler);
     }
 
     @Override
     public ExternalHooks withExternalLookup(ExternalHooks.Lookup externalLookup) {
         Optional<Lookup> externalLookup1 = Optional.of(externalLookup);
-        return new DefaultExternalHooks(externalLookup1, classFileManager, getProvenance);
+        return new DefaultExternalHooks(externalLookup1, classFileManager, getProvenance, invalidationProfiler);
     }
 
     @Override
     public ExternalHooks withGetProvenance(GetProvenance getProvenance) {
-        return new DefaultExternalHooks(lookup, classFileManager, getProvenance);
+        return new DefaultExternalHooks(lookup, classFileManager, getProvenance, invalidationProfiler);
+    }
+
+    @Override
+    public ExternalHooks withInvalidationProfiler(InvalidationProfiler profiler) {
+        return new DefaultExternalHooks(lookup, classFileManager, getProvenance, profiler);
     }
 }


### PR DESCRIPTION
InvalidationProfiler was added to the ExternalHooks interface in fb8e03e87870429fbf518cf4466a3b1d7cebd418, but the default implementation didn't support passing around an instance of InvalidationProfile. This commit fixes it. 

cc @dwijnand 