### PR TITLE
Infinite Compile Fix

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
@@ -482,9 +482,11 @@ private[inc] abstract class IncrementalCommon(
       log.debug("No classes were invalidated.")
       Set.empty
     } else {
-      val allInvalidations = firstClassInvalidation ++ secondClassInvalidation
-      log.debug(s"Invalidated classes: ${allInvalidations.mkString(", ")}")
-      allInvalidations
+      if (invalidateTransitively) {
+        newInvalidations ++ recompiledClasses
+      } else {
+        firstClassInvalidation ++ secondClassInvalidation
+      }
     }
   }
 


### PR DESCRIPTION
To prevent the infinite compile, when we have transitive invalidations include recomplied classes in the next incremental compile round.

This fix has been validated in production at [Visier](https://github.com/visier) for the past month

Resolves:
* https://github.com/sbt/zinc/issues/1120
* https://github.com/sbt/sbt/issues/6183