### PR TITLE
Fixes CodeAction (quickfix) support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import Util._
+import ZincBuildUtil._
 import Dependencies._
 import localzinc.Scripted, Scripted._
 import com.typesafe.tools.mima.core._, ProblemFilters._
@@ -280,7 +280,7 @@ lazy val zincPersist = (projectMatrix in internalPath / "zinc-persist")
     }),
     Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat,
     mimaSettings,
-    mimaBinaryIssueFilters ++= Util.excludeInternalProblems,
+    mimaBinaryIssueFilters ++= ZincBuildUtil.excludeInternalProblems,
     mimaBinaryIssueFilters ++= Seq(
       exclude[IncompatibleMethTypeProblem]("xsbti.*"),
       exclude[ReversedMissingMethodProblem]("xsbti.*"),
@@ -363,7 +363,7 @@ lazy val zincCore = (projectMatrix in internalPath / "zinc-core")
     name := "zinc Core",
     compileOrder := sbt.CompileOrder.Mixed,
     mimaSettings,
-    mimaBinaryIssueFilters ++= Util.excludeInternalProblems,
+    mimaBinaryIssueFilters ++= ZincBuildUtil.excludeInternalProblems,
     mimaBinaryIssueFilters ++= Seq(
       exclude[IncompatibleMethTypeProblem]("xsbti.*"),
       exclude[ReversedMissingMethodProblem]("xsbti.*"),
@@ -432,7 +432,7 @@ lazy val zincCompileCore = (projectMatrix in internalPath / "zinc-compile-core")
     Compile / managedSourceDirectories += (Compile / generateContrabands / sourceManaged).value,
     Compile / generateContrabands / sourceManaged := (internalPath / "zinc-compile-core" / "src" / "main" / "contraband-java").getAbsoluteFile,
     mimaSettings,
-    mimaBinaryIssueFilters ++= Util.excludeInternalProblems,
+    mimaBinaryIssueFilters ++= ZincBuildUtil.excludeInternalProblems,
   )
   .defaultAxes(VirtualAxis.jvm, VirtualAxis.scalaPartialVersion(scala212))
   .jvmPlatform(scalaVersions = List(scala212, scala213))
@@ -656,7 +656,7 @@ lazy val zincClassfile = (projectMatrix in internalPath / "zinc-classfile")
       exclude[IncompatibleResultTypeProblem]("sbt.internal.inc.IndexBasedZipOps.*"),
       exclude[ReversedMissingMethodProblem]("sbt.internal.inc.IndexBasedZipOps.*"),
     ),
-    mimaBinaryIssueFilters ++= Util.excludeInternalProblems,
+    mimaBinaryIssueFilters ++= ZincBuildUtil.excludeInternalProblems,
   )
   .defaultAxes(VirtualAxis.jvm, VirtualAxis.scalaPartialVersion(scala212))
   .jvmPlatform(scalaVersions = scala212_213)

--- a/internal/compiler-bridge/src/main/scala/xsbt/CompilerBridge.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CompilerBridge.scala
@@ -149,6 +149,8 @@ private final class CachedCompiler0(
       underlyingReporter: DelegatingReporter,
       compileProgress: CompileProgress
   ): Unit = {
+    // cast down to AnalysisCallback2
+    val callback2 = callback.asInstanceOf[xsbti.AnalysisCallback2]
 
     if (command.shouldStopWithInfo) {
       underlyingReporter.info(null, command.getInfoMessage(compiler), true)
@@ -163,7 +165,17 @@ private final class CachedCompiler0(
       run.compileFiles(sources)
       processUnreportedWarnings(run)
       underlyingReporter.problems.foreach(p =>
-        callback.problem(p.category, p.position, p.message, p.severity, true)
+        callback2.problem2(
+          p.category,
+          p.position,
+          p.message,
+          p.severity,
+          true,
+          p.rendered,
+          p.diagnosticCode,
+          p.diagnosticRelatedInformation,
+          p.actions
+        )
       )
     }
 

--- a/internal/compiler-bridge/src/main/scala/xsbt/DelegatingReporter.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/DelegatingReporter.scala
@@ -231,9 +231,14 @@ private final class DelegatingReporter(
 
   private def getActions(pos: Position, pos1: xsbti.Position, msg: String): List[Action] =
     if (pos.isRange) Nil
-    else if (msg.startsWith("procedure syntax is deprecated:")) {
-      val edit = workspaceEdit(List(textEdit(pos1, ": Unit = {")))
-      action("procedure syntax", None, edit) :: Nil
+    else if (msg.contains("procedure syntax is deprecated")) {
+      if (msg.contains("add `: Unit =`")) {
+        val edit = workspaceEdit(List(textEdit(pos1, ": Unit = ")))
+        action("procedure syntax (defn)", None, edit) :: Nil
+      } else if (msg.contains("add `: Unit`")) {
+        val edit = workspaceEdit(List(textEdit(pos1, ": Unit")))
+        action("procedure syntax (decl)", None, edit) :: Nil
+      } else Nil
     } else Nil
 
   import xsbti.Severity.{ Info, Warn, Error }

--- a/internal/compiler-interface/src/main/java/xsbti/AnalysisCallback2.java
+++ b/internal/compiler-interface/src/main/java/xsbti/AnalysisCallback2.java
@@ -1,0 +1,50 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package xsbti;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Extension to AnalsysisCallback.
+ * This is a compatibility layer created for Scala 3.x compilers.
+ * Even though compiler-interface is NOT intended to be a public API,
+ * Scala 3 compiler publishes their own compiler bridge against Zinc de jour.
+ * By having this interface, they can test if `callback` supports AnalysisCallback2.
+ */
+public interface AnalysisCallback2 extends AnalysisCallback {
+    /**
+     * Register a compilation problem.
+     *
+     * This error may have already been logged or not. Unreported problems may
+     * happen because the reporting option was not enabled via command-line.
+     *
+     * @param what The headline of the error.
+     * @param pos At a given source position.
+     * @param msg The in-depth description of the error.
+     * @param severity The severity of the error reported.
+     * @param reported Flag that confirms whether this error was reported or not.
+     * @param rendered If present, the string shown to the user when displaying this Problem.
+     * @param diagnosticCode The unique code attached to the diagnostic being reported.
+     * @param diagnosticRelatedInformation The possible releated information for the diagnostic being reported.
+     * @param actions Actions (aka quick fixes) that are able to either fix or address the issue that is causing this problem.
+     */
+    void problem2(String what,
+                 Position pos,
+                 String msg,
+                 Severity severity,
+                 boolean reported,
+                 Optional<String> rendered,
+                 Optional<DiagnosticCode> diagnosticCode,
+                 List<DiagnosticRelatedInformation> diagnosticRelatedInformation,
+                 List<Action> actions);
+}

--- a/internal/zinc-testing/src/main/scala/xsbti/TestCallback.scala
+++ b/internal/zinc-testing/src/main/scala/xsbti/TestCallback.scala
@@ -13,15 +13,15 @@ package xsbti
 
 import java.io.File
 import java.nio.file.Path
-import java.util
-import java.util.Optional
+import java.{ util => ju }
+import ju.Optional
 
 import xsbti.api.{ DependencyContext, ClassLike }
 
 import scala.collection.mutable.ArrayBuffer
 
-class TestCallback extends AnalysisCallback {
-  case class TestUsedName(name: String, scopes: util.EnumSet[UseScope])
+class TestCallback extends AnalysisCallback2 {
+  case class TestUsedName(name: String, scopes: ju.EnumSet[UseScope])
 
   val classDependencies = new ArrayBuffer[(String, String, DependencyContext)]
   val binaryDependencies =
@@ -108,7 +108,7 @@ class TestCallback extends AnalysisCallback {
     ()
   }
 
-  def usedName(className: String, name: String, scopes: util.EnumSet[UseScope]): Unit =
+  def usedName(className: String, name: String, scopes: ju.EnumSet[UseScope]): Unit =
     usedNamesAndScopes(className) += TestUsedName(name, scopes)
 
   override def api(source: File, api: ClassLike): Unit = ???
@@ -124,19 +124,31 @@ class TestCallback extends AnalysisCallback {
 
   override def enabled(): Boolean = true
 
-  def problem(
+  override def problem(
       category: String,
       pos: xsbti.Position,
       message: String,
       severity: xsbti.Severity,
-      reported: Boolean
+      reported: Boolean,
+  ): Unit = ()
+
+  override def problem2(
+      category: String,
+      pos: Position,
+      msg: String,
+      severity: Severity,
+      reported: Boolean,
+      rendered: Optional[String],
+      diagnosticCode: Optional[xsbti.DiagnosticCode],
+      diagnosticRelatedInformation: ju.List[xsbti.DiagnosticRelatedInformation],
+      actions: ju.List[xsbti.Action],
   ): Unit = ()
 
   override def dependencyPhaseCompleted(): Unit = {}
 
   override def apiPhaseCompleted(): Unit = {}
 
-  override def classesInOutputJar(): util.Set[String] = java.util.Collections.emptySet()
+  override def classesInOutputJar(): ju.Set[String] = ju.Collections.emptySet()
 
   override def isPickleJava: Boolean = false
 

--- a/project/ZincBuildUtil.scala
+++ b/project/ZincBuildUtil.scala
@@ -2,7 +2,7 @@ import sbt._
 import Keys._
 import xsbti.compile.CompileAnalysis
 
-object Util {
+object ZincBuildUtil {
   lazy val apiDefinitions = TaskKey[Seq[File]]("api-definitions")
   lazy val genTestResTask = TaskKey[Seq[File]]("gen-test-resources")
 


### PR DESCRIPTION
Fixes https://github.com/sbt/zinc/issues/1225

This adds `AnalysisCallback2` interface that's capable of forwarding CodeAction to the Analysis file.
