### PR TITLE
Delete orphan class files during incremental compilation

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -404,6 +404,17 @@ object Incremental {
     val hasSubprojectChange = initialChanges.external.apiChanges.nonEmpty
     val analysis = withClassfileManager(options, converter, output, outputJarContent) {
       classfileManager =>
+        val nDeleted =
+          IncrementalCommon.deleteOrphanClassFiles(
+            sources,
+            previous,
+            classfileManager,
+            converter,
+            output
+          )
+        if (nDeleted > 0) {
+          incremental.log.debug(s"$nDeleted orphan classfiles deleted")
+        }
         if (hasModified)
           incremental.cycle(
             initialInvClasses,

--- a/zinc/src/test/resources/sources/Foo2.scala
+++ b/zinc/src/test/resources/sources/Foo2.scala
@@ -1,0 +1,16 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Lightbend, Inc. and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package pkg2
+
+object Foo {
+  val x = 1
+}

--- a/zinc/src/test/scala/sbt/inc/BaseCompilerSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/BaseCompilerSpec.scala
@@ -24,6 +24,8 @@ class BaseCompilerSpec extends BridgeProviderSpecification {
 
   def assertExists(p: Path) = assert(Files.exists(p), s"$p does not exist")
 
+  def assertNotExists(p: Path) = assert(!Files.exists(p), s"$p exists")
+
   def lastClasses(a: Analysis) = {
     a.compilations.allCompilations.map { c =>
       a.apis.internal.collect {

--- a/zinc/src/test/scala/sbt/inc/SourceFiles.scala
+++ b/zinc/src/test/scala/sbt/inc/SourceFiles.scala
@@ -14,6 +14,7 @@ package sbt.inc
 object SourceFiles {
   val Good = "Good.scala"
   val Foo = "Foo.scala"
+  val Foo2 = "Foo2.scala"
   val NestedJavaClasses = "NestedJavaClasses.java"
 
   object Naha {


### PR DESCRIPTION
During incremental compilation, it is possible for there to be .class files in the output classes directory that are unknown to the previous Analysis. These files can break incremental compilation. Now, Zinc will recursively walk the output directory and delete any .class files unknown to the previous Analysis ("orphan" class files) before starting the incremental compile.

I suspect this PR isn't _quite right_ but I think the test is at least decent and I think the basic logic is probably right although perhaps this sort of functionality should be folded into the `Analysis` object--I'm not sure.

Fixes #1234