### PR TITLE
use `ClassTag` instead of `Manifest`

### DIFF
--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Parser.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Parser.scala
@@ -212,7 +212,7 @@ private[sbt] object Parser {
       }
     }
   }
-  private def array[T: scala.reflect.Manifest](size: Int)(f: => T) = Array.tabulate(size)(_ => f)
+  private def array[T: scala.reflect.ClassTag](size: Int)(f: => T) = Array.tabulate(size)(_ => f)
   private def parseConstantPool(in: DataInputStream) = {
     val constantPoolSize = in.readUnsignedShort()
     val pool = new Array[Constant](constantPoolSize)


### PR DESCRIPTION
deprecated since Scala 3.


```
$ scala -deprecation
Welcome to Scala 3.3.1 (11.0.20, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                      
scala> def array[T: scala.reflect.Manifest](size: Int)(f: => T) = Array.tabulate(size)(_ => f)
def array[T](size: Int)(f: => T)(implicit evidence$1: Manifest[T]): Array[T]
                                                                                                                                      
scala> array[String](1)("a")
1 warning found
-- Deprecation Warning: --------------------------------------------------------
1 |array[String](1)("a")
  |                     ^
  |Compiler synthesis of Manifest and OptManifest is deprecated, instead
  |replace with the type `scala.reflect.ClassTag[String]`.
  |Alternatively, consider using the new metaprogramming features of Scala 3,
  |see https://docs.scala-lang.org/scala3/reference/metaprogramming.html
val res0: Array[String] = Array(a)
```