### PR TITLE
fix JavaCompilerSpec with JDK 21

### DIFF
--- a/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/javac/JavaCompilerSpec.scala
+++ b/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/javac/JavaCompilerSpec.scala
@@ -98,8 +98,15 @@ class JavaCompilerSpec extends UnitSpec with Diagrams {
   }
 
   def findsErrors(compiler: XJavaTools) = IO.withTemporaryDirectory { out =>
+    val options = Seq("-deprecation") ++ {
+      if (scala.util.Properties.isJavaAtLeast("21")) {
+        Seq("-proc:none")
+      } else {
+        Nil
+      }
+    }
     val (result, problems) =
-      compile(compiler, Seq(knownSampleErrorFile), Seq("-deprecation"), out.toPath)
+      compile(compiler, Seq(knownSampleErrorFile), options, out.toPath)
     assert(result == false)
     assert(problems.size == {
       sys.props("java.specification.version") match {
@@ -226,10 +233,18 @@ class JavaCompilerSpec extends UnitSpec with Diagrams {
   }
 
   def forkSameAsLocal() = IO.withTemporaryDirectory { out =>
+    val options = Seq("-deprecation") ++ {
+      if (scala.util.Properties.isJavaAtLeast("21")) {
+        Seq("-proc:none")
+      } else {
+        Nil
+      }
+    }
+
     val (fresult, fproblems) =
-      compile(forked, Seq(knownSampleErrorFile), Seq("-deprecation"), out.toPath)
+      compile(forked, Seq(knownSampleErrorFile), options, out.toPath)
     val (lresult, lproblems) =
-      compile(local, Seq(knownSampleErrorFile), Seq("-deprecation"), out.toPath)
+      compile(local, Seq(knownSampleErrorFile), options, out.toPath)
     assert(fresult == lresult)
 
     (fproblems zip lproblems) foreach {


### PR DESCRIPTION
suppress following message

```
Note: Annotation processing is enabled because one or more processors were found
  on the class path. A future release of javac may disable annotation processing
  unless at least one processor is specified by name (-processor), or a search
  path is specified (--processor-path, --processor-module-path), or annotation
  processing is enabled explicitly (-proc:only, -proc:full).
  Use -Xlint:-options to suppress this message.
  Use -proc:none to disable annotation processing.
```