### PR TITLE
Undo Protobuf workaround for build to work on Apple Silicon

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -312,21 +312,9 @@ lazy val zincPersistCore = (project in internalPath / "zinc-persist-core")
     crossPaths := false,
     autoScalaLibrary := false,
     exportJars := true,
-    ProtobufConfig / version := "3.11.4", // sync version w/ plugins.sbt
+    ProtobufConfig / version := "3.24.4",
     ProtobufConfig / protobufRunProtoc := { args =>
-      // as per https://github.com/os72/protoc-jar/issues/93 , this is needed
-      // to work around the lack of support for Apple M1 architecture.
-      // (there is an upstream fix, but as of February 2022 there is no
-      // protoc-jar release containing the fix)
-      val workaround =
-        System.getProperty("os.name") == "Mac OS X" &&
-          System.getProperty("os.arch") == "aarch64"
-      try {
-        if (workaround)
-          System.setProperty("os.arch", "x86_64")
-        Protoc.runProtoc(s"-v${(ProtobufConfig / version).value}" +: args.toArray)
-      } finally if (workaround)
-          System.setProperty("os.arch", "aarch64")
+      Protoc.runProtoc(s"-v${(ProtobufConfig / version).value}" +: args.toArray)
     },
     publish / skip := true,
     assembly / assemblyShadeRules := Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.5.3")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.6")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")
 addSbtPlugin("com.github.sbt" % "sbt-protobuf" % "0.7.2")
-libraryDependencies += "com.github.os72" % "protoc-jar" % "3.11.4" // sync w/ ProtobufConfig / version
+libraryDependencies += "com.github.os72" % "protoc-jar" % "3.11.4"
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.3")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.9.1")


### PR DESCRIPTION
As in https://repo1.maven.org/maven2/com/google/protobuf/protoc/3.17.3/, Apple Silicon Protobuf build is now available, therefore no need for workaround.

Reverts https://github.com/sbt/zinc/pull/1036