### PR TITLE
Fix IncOptions.useOptimizedSealed not working for Scala 2.13

### DIFF
--- a/internal/compiler-bridge-test/src/test/scala/sbt/internal/inc/ExtractUsedNamesSpecification.scala
+++ b/internal/compiler-bridge-test/src/test/scala/sbt/internal/inc/ExtractUsedNamesSpecification.scala
@@ -3,6 +3,7 @@ package internal
 package inc
 
 import org.scalatest.diagrams.Diagrams
+import xsbti.UseScope
 
 class ExtractUsedNamesSpecification
     extends UnitSpec
@@ -223,7 +224,6 @@ class ExtractUsedNamesSpecification
   }
 
   // This doesn't work in 2.13.0-RC1
-  /*
   it should "extract sealed classes scope" in {
     val sealedClassName = "Sealed"
     val sealedClass =
@@ -238,12 +238,12 @@ class ExtractUsedNamesSpecification
       val (_, callback) = compileSrcs(List(List(sealedClass, in)))
       val clientNames = callback.usedNamesAndScopes.filterKeys(!_.startsWith("base."))
 
-      val names: Set[String] = clientNames.flatMap {
+      val names = clientNames.flatMap {
         case (_, usages) =>
           usages.filter(_.scopes.contains(UseScope.PatMatTarget)).map(_.name)
-      }(collection.breakOut)
+      }
 
-      names
+      names.toSet
     }
 
     def classWithPatMatOfType(tpe: String) =
@@ -259,13 +259,15 @@ class ExtractUsedNamesSpecification
 
     // findPatMatUsages(classWithPatMatOfType()) shouldEqual Set(sealedClassName)
 
-    Option is sealed
+    // Option is sealed
     findPatMatUsages(classWithPatMatOfType(s"Option[$sealedClassName]")) shouldEqual Set(
       sealedClassName,
-      "Option")
+      "Option"
+    )
     // Seq and Set is not
     findPatMatUsages(classWithPatMatOfType(s"Seq[Set[$sealedClassName]]")) shouldEqual Set(
-      sealedClassName)
+      sealedClassName
+    )
 
     def inNestedCase(tpe: String) =
       s"""package client
@@ -293,7 +295,6 @@ class ExtractUsedNamesSpecification
     findPatMatUsages(notUsedInPatternMatch) shouldEqual Set()
     ()
   }
-   */
 
   /**
    * Standard names that appear in every compilation unit that has any class

--- a/internal/compiler-bridge/src/main/scala/xsbt/ExtractUsedNames.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ExtractUsedNames.scala
@@ -250,6 +250,9 @@ class ExtractUsedNames[GlobalType <: CallbackGlobal](val global: GlobalType)
 
     private def handleClassicTreeNode(tree: Tree): Unit = tree match {
       // Register names from pattern match target type in PatMatTarget scope
+      case matchNode: Match =>
+        updateCurrentOwner()
+        PatMatDependencyTraverser.traverse(matchNode.selector.tpe)
       case ValDef(mods, _, tpt, _) if mods.isCase && mods.isSynthetic =>
         updateCurrentOwner()
         PatMatDependencyTraverser.traverse(tpt.tpe)

--- a/zinc/src/test/scala/sbt/inc/NameHashingCompilerSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/NameHashingCompilerSpec.scala
@@ -121,12 +121,11 @@ class NameHashingCompilerSpec extends BaseCompilerSpec {
       optimizedSealed = false
     )
 
-    // TODO: potential under compilation on 2.13 https://github.com/sbt/zinc/issues/753
-    // testIncrementalCompilation(
-    //   changes = Seq(Other -> addNewSealedChildren),
-    //   transitiveChanges = Set(Other3, Other),
-    //   optimizedSealed = true
-    // )
+    testIncrementalCompilation(
+      changes = Seq(Other -> addNewSealedChildren),
+      transitiveChanges = Set(Other3, Other),
+      optimizedSealed = true
+    )
   }
 
 }


### PR DESCRIPTION
In `ExtractUsedName.scala`, whenever a pattern matching involving a sealed class is encountered, the dependency is registered, but only with `Default` scope instead of `PatMat` scope.

To fix it, an extra match case is added in `handleClassicTreeNode` to register the dependency in `PatMat` scope.

Closes #753 #1229