### PR TITLE
Improve performance of LookupImpl.LookupAnalysis via pre-built index

### DIFF
--- a/zinc/src/main/scala/sbt/internal/inc/LookupImpl.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/LookupImpl.scala
@@ -31,6 +31,14 @@ class LookupImpl(compileConfiguration: CompileConfiguration, previousSetup: Opti
     }
   }
 
+  private lazy val binaryClassNameToAnalysis: Map[String, Analysis] = {
+    analyses.flatMap { analysis =>
+      analysis.relations.productClassName._2s.map { binaryClassName =>
+        binaryClassName -> analysis
+      }
+    }.toMap
+  }
+
   lazy val previousClasspathHash: Vector[FileHash] = {
     previousSetup match {
       case Some(x) => x.options.classpathHash.toVector
@@ -45,7 +53,7 @@ class LookupImpl(compileConfiguration: CompileConfiguration, previousSetup: Opti
   private val entry = MixedAnalyzingCompiler.classPathLookup(compileConfiguration)
 
   override def lookupAnalysis(binaryClassName: String): Option[CompileAnalysis] =
-    analyses.find(_.relations.productClassName._2s.contains(binaryClassName))
+    binaryClassNameToAnalysis.get(binaryClassName)
 
   override def lookupOnClasspath(binaryClassName: String): Option[VirtualFileRef] =
     entry(binaryClassName)


### PR DESCRIPTION
`LookupImpl.LookupAnalysis` takes `O(classpath length)` to run. In project with long classpath, `LookupImpl.LookupAnalysis` is noticeable in profiling. (According to #593)

This PR introduces a `binaryClassNameToAnalysis` lookup table to reduce lookup time complexity.

For memory consumption of `binaryClassNameToAnalysis`, assuming there are 10000 binary class names in the worst case, each with 50 characters (100 bytes), the total key size is 10000 * 100 bytes = 1 MB, which is small.

Closes #593.