### PR TITLE
Use the most up-to-date analysis for binary to source class name lookup

### DIFF
--- a/zinc/src/sbt-test/source-dependencies/empty-package/test
+++ b/zinc/src/sbt-test/source-dependencies/empty-package/test
@@ -3,7 +3,13 @@ $ copy-file changes/Use.scala Use.scala
 > compile
 
 $ copy-file changes/Define2.scala Define.scala
-> compile
+
+# We usually call `compile` right before a checkDependencies call
+# However, as per https://github.com/sbt/zinc/pull/1287#issue-2010864729
+# The check would be too late to catch the missing dependency between a.Use and pkgName.Test
+# As invalidateInitial introduces library dependency between a.Use and pkgName.Test
+
+> checkDependencies a.Use: pkgName.Test
 
 $ delete Define.scala
 -> compile


### PR DESCRIPTION
This PR fixes #1268

### Cause

During Dependency Extraction, `internalBinaryToSourceClassName` is used to map binary class name to source class name. It is constructed at the first cycle. Hence in subsequent cycles, it is outdated. This results in missing internal member reference dependency between `a.Use` `pkgName.Test`.

To fix it, we rebuild lookup using the most up-to-date analysis.

### Other changes

This PR also removed `internalSourceToClassNamesMap`. It is currently not used, but it has the same staleness problem as `internalBinaryToSourceClassName`. So might as well remove it to prevent someone from accidentally using it in the future.

### Why `empty-package` erroneously passed on zinc repo

The complier bridge did recognize a dependency between `a.Use` and `pkgName.Test` exists. However, since `internalBinaryToSourceClassName` was stale, zinc failed to map `pkgName.Test` back to its `.scala` source file, and instead misclassified the dependency as a external library dependency. This can be observed in the [zinc test log](https://gist.github.com/lrytz/e42076ecadc49c770465f97c12a0602b):

```
[debug] previous = Stamps for: 4 products, 2 sources, 1 libraries
[debug] current source = Set(${BASE}/pro/Use.scala)
[debug] Invalidating '${BASE}/pro/target/classes/pkgName/Test.class' because pkgName.Test$ came from analysis Analysis: 2 Scala sources, 4 classes
```

Then in `invalidateInitial`, all sources that depends on `pkgName.Test` library is invalidated via `val byLibraryDep = changes.libraryDeps.flatMap(previous.usesLibrary)`

### Validating the fix

`empty-package` test is modified to assert dependency between `a.Use` `pkgName.Test` must exist after the 2nd compilation run. 

Running the modified `empty-package` on current latest `develop` branch commit now results in [test failure](https://gist.github.com/Friendseeker/7ea5ed3ef7d5f1a54f5abbfe5fbfb15a).
