### PR TITLE
Register inheritance relationship for SAM-type lambda

### DIFF
--- a/internal/compiler-bridge/src/main/scala-2.11/xsbt/Compat.scala
+++ b/internal/compiler-bridge/src/main/scala-2.11/xsbt/Compat.scala
@@ -21,6 +21,9 @@ abstract class Compat {
   import global._
 
   protected def processOriginalTreeAttachment(in: Tree)(func: Tree => Unit): Unit = ()
+
+  protected def processSAMAttachment(f: Function)(addDependency: Symbol => Unit): Unit =
+    ()
 }
 object Compat {
   // IR is renamed to Results

--- a/internal/compiler-bridge/src/main/scala-2.12/xsbt/Compat.scala
+++ b/internal/compiler-bridge/src/main/scala-2.12/xsbt/Compat.scala
@@ -24,6 +24,12 @@ abstract class Compat {
   protected def processOriginalTreeAttachment(in: Tree)(func: Tree => Unit): Unit = {
     Compat.OriginalTreeTraverser.Instance.traverseOriginal(in)(func)
   }
+
+  protected def processSAMAttachment(f: Function)(addDependency: Symbol => Unit): Unit = {
+    f.attachments.get[SAMFunction].foreach(sam => {
+      addDependency(sam.samTp.typeSymbol)
+    })
+  }
 }
 object Compat {
   // IR is renamed to Results

--- a/internal/compiler-bridge/src/main/scala/xsbt/Dependency.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/Dependency.scala
@@ -475,6 +475,16 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile with 
         val sym = if (tree.symbol.isModule) tree.symbol.moduleClass else tree.symbol
         localToNonLocalClass.resolveNonLocal(sym)
         super.traverse(tree)
+
+      case f: Function =>
+        processSAMAttachment(f)(symbol => {
+          addDependency(symbol)
+          // Not using addInheritanceDependency as it would incorrectly classify dependency as non-local
+          // ref: https://github.com/scala/scala/pull/10617/files#r1415226169
+          val from = resolveDependencySource
+          addClassDependency(_localInheritanceCache, processor.localInheritance, from, symbol)
+        })
+        super.traverse(tree)
       case other => super.traverse(other)
     }
   }

--- a/internal/compiler-bridge/src/main/scala_2.10/xsbt/Compat.scala
+++ b/internal/compiler-bridge/src/main/scala_2.10/xsbt/Compat.scala
@@ -147,6 +147,8 @@ abstract class Compat {
   }
 
   protected def processOriginalTreeAttachment(in: Tree)(func: Tree => Unit): Unit = ()
+  protected def processSAMAttachment(f: Function)(addDependency: Symbol => Unit): Unit =
+    ()
 }
 
 /** Defines compatibility utils for [[ZincCompiler]]. */

--- a/internal/compiler-bridge/src/main/scala_2.13/xsbt/Compat.scala
+++ b/internal/compiler-bridge/src/main/scala_2.13/xsbt/Compat.scala
@@ -28,6 +28,12 @@ abstract class Compat {
       func(a.original)
     }
   }
+
+  protected def processSAMAttachment(f: Function)(addDependency: Symbol => Unit): Unit = {
+    f.attachments.get[SAMFunction].foreach(sam => {
+      addDependency(sam.samTp.typeSymbol)
+    })
+  }
 }
 object Compat {
   // IR is renamed to Results

--- a/zinc/src/sbt-test/source-dependencies/sam-local-inheritance/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/sam-local-inheritance/A.scala
@@ -1,0 +1,4 @@
+
+trait A {
+  def foo(): Int
+}

--- a/zinc/src/sbt-test/source-dependencies/sam-local-inheritance/B.scala
+++ b/zinc/src/sbt-test/source-dependencies/sam-local-inheritance/B.scala
@@ -1,0 +1,3 @@
+class B {
+  val f: A = () => 1
+}

--- a/zinc/src/sbt-test/source-dependencies/sam-local-inheritance/C.scala
+++ b/zinc/src/sbt-test/source-dependencies/sam-local-inheritance/C.scala
@@ -1,0 +1,1 @@
+class C extends B

--- a/zinc/src/sbt-test/source-dependencies/sam-local-inheritance/changes/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/sam-local-inheritance/changes/A.scala
@@ -1,0 +1,3 @@
+trait A {
+  def foo(): AnyVal
+}

--- a/zinc/src/sbt-test/source-dependencies/sam-local-inheritance/test
+++ b/zinc/src/sbt-test/source-dependencies/sam-local-inheritance/test
@@ -1,0 +1,13 @@
+> compile
+
+> checkRecompilations 0 A B C
+
+# change the SAM type
+$ copy-file changes/A.scala A.scala
+
+> compile
+
+> checkIterations 3
+> checkRecompilations 1 A
+# SAM type change does not affect C, hence C should not be recompiled
+> checkRecompilations 2 B

--- a/zinc/src/sbt-test/source-dependencies/sam/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/sam/A.scala
@@ -1,0 +1,4 @@
+
+trait A {
+  def foo(): Int
+}

--- a/zinc/src/sbt-test/source-dependencies/sam/B.scala
+++ b/zinc/src/sbt-test/source-dependencies/sam/B.scala
@@ -1,0 +1,3 @@
+class B {
+  val f: A = () => 1
+}

--- a/zinc/src/sbt-test/source-dependencies/sam/changes/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/sam/changes/A.scala
@@ -1,0 +1,3 @@
+trait A {
+  def foo(): String
+}

--- a/zinc/src/sbt-test/source-dependencies/sam/test
+++ b/zinc/src/sbt-test/source-dependencies/sam/test
@@ -1,0 +1,7 @@
+> compile
+
+# change the SAM type
+$ copy-file changes/A.scala A.scala
+
+# Both A.scala and B.scala should be recompiled, producing a compile error
+-> compile


### PR DESCRIPTION
During dependency extraction, register inheritance dependency for each SAM-type lambda, by fetching SAM type from tree attachment.

Fixes #830