### PR TITLE
Include internal dependency in `extraHash` computation

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -892,9 +892,11 @@ private final class AnalysisCallback(
             incHandlerOpt match {
               case Some(handler) =>
                 val analysis = handler.previousAnalysis
-                val parents = analysis.relations.inheritance.external.forward(className)
-                val parentsAPI = parents.map(analysis.apis.externalAPI)
-                val parentsHashes = parentsAPI.map(_.extraHash())
+                val externalParents = analysis.relations.inheritance.external.forward(className)
+                val internalParents = analysis.relations.inheritance.internal.forward(className)
+                val externalParentsAPI = externalParents.map(analysis.apis.externalAPI)
+                val internalParentsAPI = internalParents.map(analysis.apis.internalAPI)
+                val parentsHashes = (externalParentsAPI ++ internalParentsAPI).map(_.extraHash())
                 parentsHashes.fold(currentExtraHash)(_ ^ _)
               case None => currentExtraHash
             }

--- a/zinc/src/sbt-test/source-dependencies/trait-private-val-mix-transitive-inheritance/a/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/trait-private-val-mix-transitive-inheritance/a/A.scala
@@ -1,0 +1,5 @@
+package a
+
+trait A {
+  private val a1: String = ""
+}

--- a/zinc/src/sbt-test/source-dependencies/trait-private-val-mix-transitive-inheritance/a/B.scala
+++ b/zinc/src/sbt-test/source-dependencies/trait-private-val-mix-transitive-inheritance/a/B.scala
@@ -1,0 +1,3 @@
+package b
+
+trait B extends a.A

--- a/zinc/src/sbt-test/source-dependencies/trait-private-val-mix-transitive-inheritance/a/changes/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/trait-private-val-mix-transitive-inheritance/a/changes/A.scala
@@ -1,0 +1,5 @@
+package a
+
+trait A {
+  private val a2: String = ""
+}

--- a/zinc/src/sbt-test/source-dependencies/trait-private-val-mix-transitive-inheritance/build.json
+++ b/zinc/src/sbt-test/source-dependencies/trait-private-val-mix-transitive-inheritance/build.json
@@ -1,0 +1,7 @@
+{
+  "projects": [
+    {"name": "main", "dependsOn": ["a", "c"], "scalaVersion": "2.13.12"},
+    {"name": "c", "dependsOn": ["a"], "scalaVersion": "2.13.12"},
+    {"name": "a", "scalaVersion": "2.13.12"}
+  ]
+}

--- a/zinc/src/sbt-test/source-dependencies/trait-private-val-mix-transitive-inheritance/c/C.scala
+++ b/zinc/src/sbt-test/source-dependencies/trait-private-val-mix-transitive-inheritance/c/C.scala
@@ -1,0 +1,3 @@
+package c
+
+class C extends b.B

--- a/zinc/src/sbt-test/source-dependencies/trait-private-val-mix-transitive-inheritance/main/Main.scala
+++ b/zinc/src/sbt-test/source-dependencies/trait-private-val-mix-transitive-inheritance/main/Main.scala
@@ -1,0 +1,4 @@
+object Main extends App {
+  val impl = new c.C()
+  println("OK")
+}

--- a/zinc/src/sbt-test/source-dependencies/trait-private-val-mix-transitive-inheritance/test
+++ b/zinc/src/sbt-test/source-dependencies/trait-private-val-mix-transitive-inheritance/test
@@ -1,0 +1,3 @@
+> main/run
+$ copy-file a/changes/A.scala a/A.scala
+> main/run


### PR DESCRIPTION
### Issue

PR #1289 addressed under-compilation for traits with transitive external inheritance dependencies by propagating `TraitPrivateMembersModified` from parent trait to child traits.

However, when the hierarchy consists a mix of internal & external dependencies, `TraitPrivateMembersModified` would fail to propagate, resulting in under compilation.

For example, say `c.C -> b.B -> a.A`, (`c.C` extends `c.B`, `c.B` extends `a.A`), for which `c.C` and `c.B, a.A` are on different projects, then when `a.A` 's private member is changed, the propagation stops at `c.B` since computation of `c.B`'s `extraHash` only takes account of `a.A`'s external dependency, while `a.A` is part of `c.B`'s internal dependency. Hence `c.C` never gets recompiled.

### Fix

Include internal dependency in `extraHash` computation.