### PR TITLE
Improving error message for illegal zinc scripted test when running `zincScripted/Test/run`

### DIFF
--- a/internal/zinc-scripted/src/test/scala/sbt/inc/ScriptedMain.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/inc/ScriptedMain.scala
@@ -29,7 +29,7 @@ object ScriptedMain {
     run(baseDir, buffer = !disableBuffering, compileToJar, tests)
   }
 
-  private def detectScriptedTests(scriptedBase: File): Map[String, Set[String]] = {
+  def detectScriptedTests(scriptedBase: File): Map[String, Set[String]] = {
     val scriptedFiles: NameFilter = ("test": NameFilter) | "pending"
     val pairs = (scriptedBase * AllPassFilter * AllPassFilter * scriptedFiles).get.map { f =>
       val p = f.getParentFile

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncScriptedRunner.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncScriptedRunner.scala
@@ -19,6 +19,7 @@ import sbt.io.IO
 import sbt.util.{ Level, Logger }
 
 import scala.collection.parallel.ParSeq
+import sbt.inc.ScriptedMain._
 
 object ScriptedRunnerImpl {
   type TestRunner = () => Seq[Option[String]]
@@ -59,6 +60,11 @@ object ScriptedRunnerImpl {
     reportErrors(tests.flatMap(test => test.apply()).flatten.toList)
   }
 
-  def listTests(baseDir: Path, log: Logger): Seq[ScriptedTest] =
-    new ListTests(baseDir.toFile, _ => true, log).listTests
+  def listTests(baseDir: Path, log: Logger): Seq[ScriptedTest] = {
+    val foundScriptedTests = detectScriptedTests(baseDir.toFile)
+    def isScriptedTest(test: ScriptedTest) = {
+      foundScriptedTests(test.group).contains(test.name)
+    }
+    new ListTests(baseDir.toFile, isScriptedTest, log).listTests
+  }
 }


### PR DESCRIPTION
Closes #1291.

Log after the change

```
[IJ]zincScripted/Test/run
[info] running (fork) sbt.inc.ScriptedMain 
[info] About to run all scripted tests
[info] [warn] Tests skipped in group source-dependencies:
[info] [warn]  canon
[info] [warn]  illegal-test
[info] [info] + apiinfo/circular-structure
...
[success] Total time: 59 s, completed Nov 29, 2023, 1:35:12 p.m.
```