### PR TITLE
Delete products of previous analysis when dropping previous analysis

### DIFF
--- a/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
@@ -541,8 +541,13 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
     previousSetup match {
       // The dummy output needs to be changed to .jar for this to work again.
       // case _ if compileToJarSwitchedOn(mixedCompiler.config)             => Analysis.empty
-      case Some(prev) if equiv.equiv(prev, currentSetup)                   => previousAnalysis
-      case Some(prev) if !equivPairs.equiv(prev.extra, currentSetup.extra) => Analysis.empty
+      case Some(prev) if equiv.equiv(prev, currentSetup) => previousAnalysis
+      case Some(prev) if !equivPairs.equiv(prev.extra, currentSetup.extra) =>
+        val classFileManager =
+          ClassFileManager.getClassFileManager(incOptions, output, outputJarContent)
+        val products = previousAnalysis.asInstanceOf[Analysis].relations.allProducts
+        classFileManager.delete(products.map(converter.toVirtualFile).toArray)
+        Analysis.empty
       case _ =>
         val srcs = config.sources.toSet
         Incremental.prune(srcs, previousAnalysis, output, outputJarContent, converter, incOptions)

--- a/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
@@ -543,6 +543,7 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
       // case _ if compileToJarSwitchedOn(mixedCompiler.config)             => Analysis.empty
       case Some(prev) if equiv.equiv(prev, currentSetup) => previousAnalysis
       case Some(prev) if !equivPairs.equiv(prev.extra, currentSetup.extra) =>
+        import sbt.internal.inc.ClassFileManager
         val classFileManager =
           ClassFileManager.getClassFileManager(incOptions, output, outputJarContent)
         val products = previousAnalysis.asInstanceOf[Analysis].relations.allProducts


### PR DESCRIPTION
This PR fixes #1234, https://github.com/sbt/sbt/issues/2074, https://github.com/sbt/zinc/issues/825

### Issue

`prevAnalysis` in [IncrementalCompilerImpl.scala](https://github.com/sbt/zinc/compare/develop...Friendseeker:stale-class-file?expand=1#diff-f3f7fb9bf49541573396f7ab4faa2942f055e4c7c60701035e9fa39fe192833b) drops previous analysis when `setup` is changed.

However, it kept all products of previous analysis, hence these stale products never gets removed.

### Fix

When the previous analysis is dropped, delete all products of previous analysis.

### Validating the fix

Followed https://github.com/jackkoenig/zinc-bug-example with custom zinc build containing the fix.

```
❯ git status 
On branch main
Your branch is ahead of 'origin/main' by 1 commit.
  (use "git push" to publish your local commits)

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	.java-version

nothing added to commit but untracked files present (use "git add" to track)

~/zinc-bug-example-2/zinc-bug-example main* ⇡
❯ jenv local 19.0

~/zinc-bug-example-2/zinc-bug-example main* ⇡
❯ sbt compile
[info] welcome to sbt 1.9.7 (Oracle Corporation Java 19.0.1)
[info] loading global plugins from /Users/jiahuitan/.sbt/1.0/plugins
[info] loading project definition from /Users/jiahuitan/zinc-bug-example-2/zinc-bug-example/project
[info] loading settings for project root from build.sbt ...
[info] set current project to zinc-bug-example (in build file:/Users/jiahuitan/zinc-bug-example-2/zinc-bug-example/)
[info] Executing in batch mode. For better performance use sbt's shell
[info] compiling 4 Scala sources to /Users/jiahuitan/zinc-bug-example-2/zinc-bug-example/target/scala-2.13/classes ...
[success] Total time: 2 s, completed Nov 30, 2023, 4:24:54 p.m.

~/zinc-bug-example-2/zinc-bug-example main* ⇡
❯ jenv local 21.0

~/zinc-bug-example-2/zinc-bug-example main* ⇡
❯ git apply moveB.diff

~/zinc-bug-example-2/zinc-bug-example main* ⇡
❯ sbt compile
[info] welcome to sbt 1.9.7 (Oracle Corporation Java 21.0.1)
[info] loading global plugins from /Users/jiahuitan/.sbt/1.0/plugins
[info] loading project definition from /Users/jiahuitan/zinc-bug-example-2/zinc-bug-example/project
[info] loading settings for project root from build.sbt ...
[info] set current project to zinc-bug-example (in build file:/Users/jiahuitan/zinc-bug-example-2/zinc-bug-example/)
[info] Executing in batch mode. For better performance use sbt's shell
[info] compiling 4 Scala sources to /Users/jiahuitan/zinc-bug-example-2/zinc-bug-example/target/scala-2.13/classes ...
[success] Total time: 2 s, completed Nov 30, 2023, 4:25:28 p.m.
```

Credit to 
- @jackkoenig for providing reproduction & pinpointing exact cause of the problem
- @armanbilge for guiding me to setup custom zinc build