### PR TITLE
Add `.bsp` and `.DS_Store` into `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ target-2.13/
 zinc/src/test/resources/bin
 .idea
 metals.sbt
+.bsp
+.DS_Store


### PR DESCRIPTION
`.bsp` and `.DS_Store` are common temp file/folders. Hence adding them to `.gitignore` so `git` can ignore them.