### PR TITLE
Make `compiler-bridge-test` show up in IntelliJ

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -532,12 +532,11 @@ lazy val compilerBridge213 = compilerBridge.jvm(scala213)
  * This is split into a separate subproject because testing introduces more dependencies
  * (Zinc API Info, which transitively depends on IO).
  */
-lazy val compilerBridgeTest = (project in internalPath / "compiler-bridge-test")
-  .dependsOn(zinc.jvm(scala213) % "compile->compile;test->test", compilerInterface.jvm(false))
+lazy val compilerBridgeTest = (projectMatrix in internalPath / "compiler-bridge-test")
+  .dependsOn(zinc % "compile->compile;test->test", compilerInterface)
   .settings(
     name := "Compiler Bridge Test",
     baseSettings,
-    scalaVersion := scala213,
     compilerVersionDependentScalacOptions,
     // we need to fork because in unit tests we set usejavacp = true which means
     // we are expecting all of our dependencies to be on classpath so Scala compiler
@@ -549,6 +548,8 @@ lazy val compilerBridgeTest = (project in internalPath / "compiler-bridge-test")
     Test / javaOptions += s"-Dzinc.build.compilerbridge.scalaVersion=${scalaVersion.value}",
     publish / skip := true,
   )
+  .defaultAxes(VirtualAxis.jvm, VirtualAxis.scalaPartialVersion(scala212))
+  .jvmPlatform(scalaVersions = scala212_213)
 
 val scalaPartialVersion = Def.setting(CrossVersion.partialVersion(scalaVersion.value))
 
@@ -691,7 +692,7 @@ val publishBridges = taskKey[Unit]("")
 val crossTestBridges = taskKey[Unit]("")
 
 publishBridges := Def.task(()).dependsOn(bridges: _*).value
-crossTestBridges := (compilerBridgeTest / Test / test).dependsOn(publishBridges).value
+crossTestBridges := (compilerBridgeTest.jvm(scala213) / Test / test).dependsOn(publishBridges).value
 
 addCommandAlias(
   "runBenchmarks", {


### PR DESCRIPTION
Partially fix https://github.com/sbt/zinc/issues/1296

Validating the fix

<img width="1088" alt="Screenshot 2023-12-02 at 10 19 16 AM" src="https://github.com/sbt/zinc/assets/66892505/807ea724-19ad-4654-bddc-117e44f38844">

As shown in screenshot, `compiler-bridge-test` now shows up as a project in IDE, with smart IDE features (e.g. Type Inference) working.
