### PR TITLE
Make `zinc-benchmarks` show up in IntelliJ

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -376,7 +376,7 @@ lazy val zincBenchmarks = (projectMatrix in internalPath / "zinc-benchmarks")
   .enablePlugins(JmhPlugin)
   .settings(
     publish / skip := true,
-    ideSkipProject := true, // otherwise IntelliJ complains
+    baseSettings,
     name := "Benchmarks of Zinc and the compiler bridge",
     libraryDependencies ++= Seq(
       "org.eclipse.jgit" % "org.eclipse.jgit" % "6.7.0.202309050840-r",


### PR DESCRIPTION
<img width="1008" alt="Screenshot 2023-12-02 at 8 39 36 PM" src="https://github.com/sbt/zinc/assets/66892505/690e4bf1-92a6-4262-b8f2-a37358aa9033">
