### PR TITLE
Increase `onIncState` timeout to 10 minutes

### DIFF
--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -175,7 +175,7 @@ class IncHandler(directory: Path, cacheDir: Path, scriptedLog: ManagedLogger, co
       run: IncState => Future[Unit]
   ): IncState = {
     val instance = i.getOrElse(onNewIncState(p))
-    try Await.result(run(instance), 60.seconds)
+    try Await.result(run(instance), 600.seconds)
     catch {
       case NonFatal(e) =>
         instance.compilations.clear()


### PR DESCRIPTION
### Issue

When using an active debugger, the timeout gets hit frequently as it usually takes more than 60 seconds to examine stacktrace.

### Solution

Increase the timeout to 10 minutes.