### PR TITLE
Add pending scripted test for #616

### DIFF
--- a/zinc/src/sbt-test/source-dependencies/default-namespace-implicit/Baz.scala
+++ b/zinc/src/sbt-test/source-dependencies/default-namespace-implicit/Baz.scala
@@ -1,0 +1,3 @@
+package sbt.zinc.example
+
+case class Baz(value: Int)

--- a/zinc/src/sbt-test/source-dependencies/default-namespace-implicit/Foo.scala
+++ b/zinc/src/sbt-test/source-dependencies/default-namespace-implicit/Foo.scala
@@ -1,0 +1,8 @@
+import sbt.zinc.example.Baz
+// Adding the below import to changes/Foo.scala and Foo.scala make issue go away
+// import `package`.b
+class Foo(implicit baz: Baz)
+
+object Foo {
+  val f = new Foo
+}

--- a/zinc/src/sbt-test/source-dependencies/default-namespace-implicit/changes/Foo.scala
+++ b/zinc/src/sbt-test/source-dependencies/default-namespace-implicit/changes/Foo.scala
@@ -1,0 +1,11 @@
+import sbt.zinc.example.Baz
+// Adding the below import to changes/Foo.scala and Foo.scala make issue go away
+// import `package`.b
+class Foo(implicit baz: Baz)
+
+object Foo {
+  val f = new Foo
+}
+
+
+// Random Placeholder comment to let Zinc detect that Foo has changed

--- a/zinc/src/sbt-test/source-dependencies/default-namespace-implicit/package.scala
+++ b/zinc/src/sbt-test/source-dependencies/default-namespace-implicit/package.scala
@@ -1,0 +1,5 @@
+import sbt.zinc.example.Baz
+
+object `package` {
+  implicit val b = Baz(55)
+}

--- a/zinc/src/sbt-test/source-dependencies/default-namespace-implicit/pending
+++ b/zinc/src/sbt-test/source-dependencies/default-namespace-implicit/pending
@@ -1,0 +1,7 @@
+> compile
+
+# Signal to Zinc that Foo is changed, such that it will be recompiled next
+$ copy-file changes/Foo.scala Foo.scala
+
+# fails with: `could not find implicit value for parameter baz: sbt.zinc.example.Baz`
+> compile


### PR DESCRIPTION
The PR adds pending scripted test for #616

Test log for added test
```
[error] ${BASE}/Foo.scala:9:13: could not find implicit value for parameter baz: sbt.zinc.example.Baz
[error]     val f = new Foo
[error]             ^
[error] one error found
[debug] Compilation failed (CompilerInterface)
[error] sbt.internal.inc.BatchScriptRunner$PreciseScriptedError: {line 6} Command failed: 'compile'
[error] Caused by: Compilation failed
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.handleCompilationError(IncrementalCompilerImpl.scala:339)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.compileIncrementally(IncrementalCompilerImpl.scala:425)

```