### PR TITLE
[1.x] Emit `SourceInfos` when incremental compilation fails

### DIFF
--- a/internal/compiler-interface/src/main/java/xsbti/AnalysisCallback3.java
+++ b/internal/compiler-interface/src/main/java/xsbti/AnalysisCallback3.java
@@ -1,0 +1,21 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package xsbti;
+import xsbti.compile.analysis.ReadSourceInfos;
+
+/**
+ * Extension to {@link AnalysisCallback2}.
+ * Similar to {@link AnalysisCallback2}, it serves as compatibility layer for Scala compilers.
+ */
+public interface AnalysisCallback3 extends AnalysisCallback2 {
+    ReadSourceInfos getSourceInfos();
+}

--- a/internal/compiler-interface/src/main/java/xsbti/CompileFailed2.java
+++ b/internal/compiler-interface/src/main/java/xsbti/CompileFailed2.java
@@ -1,0 +1,22 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package xsbti;
+
+import xsbti.compile.analysis.ReadSourceInfos;
+
+public abstract class CompileFailed2 extends CompileFailed {
+    /**
+     * Returns SourceInfos containing problems for each file.
+     * This includes problems found by most recent compilation run.
+     */
+    public abstract ReadSourceInfos sourceInfos();
+}

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/RawCompiler.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/RawCompiler.scala
@@ -15,6 +15,7 @@ package inc
 
 import java.nio.file.Path
 import sbt.internal.util.FeedbackProvidedException
+import xsbti.compile.analysis.ReadSourceInfos
 import xsbti.compile.{ ClasspathOptions, ScalaInstance => XScalaInstance }
 
 /**
@@ -98,11 +99,12 @@ class CompileFailed(
     val arguments: Array[String],
     override val toString: String,
     val problems: Array[xsbti.Problem],
+    val sourceInfosOption: Option[ReadSourceInfos],
     cause: Throwable
 ) extends xsbti.CompileFailed(cause)
     with FeedbackProvidedException {
 
   def this(arguments: Array[String], toString: String, problems: Array[xsbti.Problem]) = {
-    this(arguments, toString, problems, null)
+    this(arguments, toString, problems, None, null)
   }
 }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -590,7 +590,7 @@ private final class AnalysisCallback(
     progress: Option[CompileProgress],
     incHandlerOpt: Option[Incremental.IncrementalCallback],
     log: Logger
-) extends xsbti.AnalysisCallback2 {
+) extends xsbti.AnalysisCallback3 {
   import Incremental.CompileCycleResult
 
   // This must have a unique value per AnalysisCallback
@@ -1064,6 +1064,25 @@ private final class AnalysisCallback(
           externalDeps,
           libDeps
         )
+    }
+  }
+
+  def getSourceInfos: SourceInfos = {
+    // Collect Source Info from current run
+    val sources = reporteds.keySet ++ unreporteds.keySet ++ mainClasses.keySet
+    val sourceToInfo = sources.map { source =>
+      val info = SourceInfos.makeInfo(
+        getOrNil(reporteds.iterator.map { case (k, v) => k -> v.asScala.toSeq }.toMap, source),
+        getOrNil(unreporteds.iterator.map { case (k, v) => k -> v.asScala.toSeq }.toMap, source),
+        getOrNil(mainClasses.iterator.map { case (k, v) => k -> v.asScala.toSeq }.toMap, source)
+      )
+      (source, info)
+    }.toMap
+    val sourceInfoFromCurrentRun = SourceInfos.of(sourceToInfo)
+    // Collect reported problems from previous run
+    incHandlerOpt.map(_.previousAnalysisPruned) match {
+      case Some(prevAnalysis) => prevAnalysis.infos ++ sourceInfoFromCurrentRun
+      case None               => sourceInfoFromCurrentRun
     }
   }
 

--- a/internal/zinc-testing/src/main/scala/xsbti/TestCallback.scala
+++ b/internal/zinc-testing/src/main/scala/xsbti/TestCallback.scala
@@ -15,12 +15,12 @@ import java.io.File
 import java.nio.file.Path
 import java.{ util => ju }
 import ju.Optional
-
-import xsbti.api.{ DependencyContext, ClassLike }
+import xsbti.api.{ ClassLike, DependencyContext }
+import xsbti.compile.analysis.ReadSourceInfos
 
 import scala.collection.mutable.ArrayBuffer
 
-class TestCallback extends AnalysisCallback2 {
+class TestCallback extends AnalysisCallback3 {
   case class TestUsedName(name: String, scopes: ju.EnumSet[UseScope])
 
   val classDependencies = new ArrayBuffer[(String, String, DependencyContext)]
@@ -153,6 +153,8 @@ class TestCallback extends AnalysisCallback2 {
   override def isPickleJava: Boolean = false
 
   override def getPickleJarPair = Optional.empty()
+
+  override def getSourceInfos: ReadSourceInfos = new TestSourceInfos
 }
 
 object TestCallback {

--- a/internal/zinc-testing/src/main/scala/xsbti/TestSourceInfo.scala
+++ b/internal/zinc-testing/src/main/scala/xsbti/TestSourceInfo.scala
@@ -1,0 +1,23 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package xsbti
+
+import xsbti.compile.analysis.SourceInfo
+
+class TestSourceInfo extends SourceInfo {
+
+  override def getReportedProblems: Array[Problem] = Array.empty[Problem]
+
+  override def getUnreportedProblems: Array[Problem] = Array.empty[Problem]
+
+  override def getMainClasses: Array[String] = Array.empty[String]
+}

--- a/internal/zinc-testing/src/main/scala/xsbti/TestSourceInfos.scala
+++ b/internal/zinc-testing/src/main/scala/xsbti/TestSourceInfos.scala
@@ -1,0 +1,24 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package xsbti
+
+import xsbti.compile.analysis.{ ReadSourceInfos, SourceInfo }
+
+import java.util
+
+class TestSourceInfos extends ReadSourceInfos {
+
+  override def get(sourceFile: VirtualFileRef): SourceInfo = new TestSourceInfo
+
+  override def getAllSourceInfos: util.Map[VirtualFileRef, SourceInfo] =
+    new util.HashMap[VirtualFileRef, SourceInfo]()
+}

--- a/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/IncrementalCompilerImpl.scala
@@ -331,11 +331,19 @@ class IncrementalCompilerImpl extends IncrementalCompiler {
     try {
       compilerRun
     } catch {
+      case e: xsbti.CompileFailed2 => throw new sbt.internal.inc.CompileFailed(
+          e.arguments,
+          e.toString,
+          e.problems,
+          Some(e.sourceInfos()),
+          e,
+        ) // just ignore
       case e: xsbti.CompileFailed =>
         throw new sbt.internal.inc.CompileFailed(
           e.arguments,
           e.toString,
           e.problems,
+          None,
           e
         ) // just ignore
       case e: CompileFailed        => throw e // just ignore

--- a/zinc/src/test/scala/sbt/inc/IncrementalCompilerSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/IncrementalCompilerSpec.scala
@@ -240,4 +240,25 @@ class IncrementalCompilerSpec extends BaseCompilerSpec {
         }
       } finally comp.close()
   }
+
+  it should "emit SourceInfos when incremental compilation fails" in withTmpDir {
+    tmp =>
+      val project = VirtualSubproject(tmp.toPath / "p1")
+      val comp = project.setup.createCompiler()
+      val s1 = "object A { final val i = 1"
+      val f1 = StringVirtualFile("A.scala", s1)
+      try {
+        val exception = intercept[CompileFailed] {
+          comp.compile(f1)
+        }
+        exception.sourceInfosOption match {
+          case Some(sourceInfos) =>
+            assert(
+              !sourceInfos.getAllSourceInfos.isEmpty,
+              "Expected non-empty source infos"
+            )
+          case None => fail("Expected sourceInfos")
+        }
+      } finally comp.close()
+  }
 }


### PR DESCRIPTION
This PR implements https://github.com/sbt/zinc/issues/932 via building `SourceInfos` from analysis callback and pass them to `handleErrors` in `CompilerBridge.scala`.

c.c. @adpi2 