### PR TITLE
Add common VSCode metals temp folders to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ zinc/src/test/resources/bin
 metals.sbt
 .bsp
 .DS_Store
+.vscode
+.metals
+.bloop


### PR DESCRIPTION
Before

<img width="215" alt="Screenshot 2023-12-12 at 2 30 32 PM" src="https://github.com/sbt/zinc/assets/66892505/7106a874-f450-4e39-834f-cfbfcdfb7660">

(3k temp files from VSCode, metals and bloop detected by `Git`)

After

<img width="221" alt="Screenshot 2023-12-12 at 2 30 43 PM" src="https://github.com/sbt/zinc/assets/66892505/e07d772e-5ccc-48ad-bc95-83f345a3c788">

(0 temp file detected)