### PR TITLE
Invalidate sources that depends on `@inline` methods

### DIFF
--- a/internal/compiler-bridge/src/main/scala-2.11/xsbt/Compat.scala
+++ b/internal/compiler-bridge/src/main/scala-2.11/xsbt/Compat.scala
@@ -31,6 +31,10 @@ object Compat {
 
   // IMain in 2.13 accepts ReplReporter
   def replReporter(settings: Settings, writer: PrintWriter) = writer
+
+  implicit final class SettingsCompat(val settings: Settings) extends AnyVal {
+    @inline final def optInlinerEnabled: Boolean = false
+  }
 }
 
 /** Defines compatibility utils for [[ZincCompiler]]. */

--- a/internal/compiler-bridge/src/main/scala/xsbt/ExtractAPI.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ExtractAPI.scala
@@ -522,6 +522,7 @@ class ExtractAPI[GlobalType <: Global](
     val absOver = s.hasFlag(ABSOVERRIDE)
     val abs = s.hasFlag(ABSTRACT) || s.hasFlag(DEFERRED) || absOver
     val over = s.hasFlag(OVERRIDE) || absOver
+    val hasInline = s.annotations.exists(_.symbol.tpe == typeOf[scala.inline])
     new xsbti.api.Modifiers(
       abs,
       over,
@@ -529,7 +530,7 @@ class ExtractAPI[GlobalType <: Global](
       s.hasFlag(SEALED),
       isImplicit(s),
       s.hasFlag(LAZY),
-      s.hasFlag(MACRO),
+      s.hasFlag(MACRO) || hasInline,
       s.hasFlag(SUPERACCESSOR)
     )
   }

--- a/internal/compiler-bridge/src/main/scala/xsbt/ExtractAPI.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ExtractAPI.scala
@@ -523,7 +523,7 @@ class ExtractAPI[GlobalType <: Global](
     val absOver = s.hasFlag(ABSOVERRIDE)
     val abs = s.hasFlag(ABSTRACT) || s.hasFlag(DEFERRED) || absOver
     val over = s.hasFlag(OVERRIDE) || absOver
-    val hasInline = global.settings.optInlinerEnabled || s.annotations.exists(
+    val hasInline = global.settings.optInlinerEnabled && s.annotations.exists(
       _.symbol.tpe == typeOf[scala.inline]
     )
     new xsbti.api.Modifiers(

--- a/internal/compiler-bridge/src/main/scala/xsbt/ExtractAPI.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ExtractAPI.scala
@@ -519,10 +519,13 @@ class ExtractAPI[GlobalType <: Global](
   }
   private def getModifiers(s: Symbol): xsbti.api.Modifiers = {
     import Flags._
+    import xsbt.Compat._
     val absOver = s.hasFlag(ABSOVERRIDE)
     val abs = s.hasFlag(ABSTRACT) || s.hasFlag(DEFERRED) || absOver
     val over = s.hasFlag(OVERRIDE) || absOver
-    val hasInline = s.annotations.exists(_.symbol.tpe == typeOf[scala.inline])
+    val hasInline = global.settings.optInlinerEnabled || s.annotations.exists(
+      _.symbol.tpe == typeOf[scala.inline]
+    )
     new xsbti.api.Modifiers(
       abs,
       over,

--- a/internal/compiler-bridge/src/main/scala_2.10/xsbt/Compat.scala
+++ b/internal/compiler-bridge/src/main/scala_2.10/xsbt/Compat.scala
@@ -183,6 +183,8 @@ object Compat {
   implicit final class SettingsCompat(val settings: Settings) extends AnyVal {
     // Introduced in 2.11
     @inline final def fatalWarnings = settings.Xwarnfatal
+
+    @inline final def optInlinerEnabled: Boolean = false
   }
 
   implicit final class PositionOps(val self: sriu.Position) extends AnyVal {

--- a/zinc/src/sbt-test/source-dependencies/inline/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/inline/A.scala
@@ -1,0 +1,14 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+object A {
+  @inline
+  def x: Int = 1
+}

--- a/zinc/src/sbt-test/source-dependencies/inline/App.scala
+++ b/zinc/src/sbt-test/source-dependencies/inline/App.scala
@@ -1,0 +1,21 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+object App {
+  def main(args: Array[String]): Unit = {
+    val exp = args(0).toInt
+    val res = B.x
+    if (res != exp) {
+      val e = new Exception(s"assertion failed: expected $exp, obtained $res")
+      e.setStackTrace(Array())
+      throw e
+    }
+  }
+}

--- a/zinc/src/sbt-test/source-dependencies/inline/B.scala
+++ b/zinc/src/sbt-test/source-dependencies/inline/B.scala
@@ -1,0 +1,14 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+object B {
+  def x = A.x
+}

--- a/zinc/src/sbt-test/source-dependencies/inline/changes/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/inline/changes/A.scala
@@ -1,0 +1,15 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+object A {
+  @inline
+  def x: Int = 2
+}

--- a/zinc/src/sbt-test/source-dependencies/inline/incOptions.properties
+++ b/zinc/src/sbt-test/source-dependencies/inline/incOptions.properties
@@ -1,0 +1,12 @@
+#
+# Zinc - The incremental compiler for Scala.
+# Copyright Scala Center, Lightbend, and Mark Harrah
+#
+# Licensed under Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+#
+# See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.
+#
+
+scalac.options = -opt:l:inline -opt-inline-from:**

--- a/zinc/src/sbt-test/source-dependencies/inline/test
+++ b/zinc/src/sbt-test/source-dependencies/inline/test
@@ -1,0 +1,3 @@
+> run 1
+$ copy-file changes/A.scala A.scala
+> run 2


### PR DESCRIPTION
This PR fixes https://github.com/sbt/sbt/issues/4125, https://github.com/sbt/zinc/issues/537.

### Issue

When `@inline` method implementation changes, the public API of `@inline` method does not change, hence Zinc does not invalidate sources that depends on `@inline` method.

### Solution

The behaviour of `@inline` method is similar to macro methods. Hence, we can mark `@inline` method as macro and reuse existing Zinc invalidation logic for macro invalidation.

### TODOs

- This PR does not handle call-site `@inline`. To handle that case, we need to follow https://github.com/sbt/zinc/issues/537#issuecomment-421753875 and drop call-site `@inline` at compiler side.
- Even without `@inline` annotation, compiler may still sometimes inline a method. The compiler keep a log of inlined methods, so in a follow up PR, we can utilize that information instead of directly checking `@inline` annotation.