### PR TITLE
Do not use `invalidationResults` to compute next invalidations

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -937,7 +937,7 @@ private final class AnalysisCallback(
         if (!writtenEarlyArtifacts) // writing implies the updates merge has happened
           mergeUpdates() // must merge updates each cycle or else scalac will clobber it
       }
-      incHandler.completeCycle(invalidationResults, getAnalysis)
+      incHandler.completeCycle(None, getAnalysis)
     } else {
       throw new IllegalStateException(
         "can't call AnalysisCallback#getCycleResultOnce more than once"

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -1090,14 +1090,14 @@ private final class AnalysisCallback(
 
   override def dependencyPhaseCompleted(): Unit = {
     val incHandler = incHandlerOpt.getOrElse(sys.error("incHandler was expected"))
-    if (invalidationResults.isEmpty) {
+    if (earlyOutput.isDefined && invalidationResults.isEmpty) {
       val a = getAnalysis
       val CompileCycleResult(continue, invalidations, merged) =
         incHandler.mergeAndInvalidate(a, false)
       // Store invalidations and continuation decision; the analysis will be computed again after Analyze phase.
       invalidationResults = Some(CompileCycleResult(continue, invalidations, Analysis.empty))
       // If there will be no more compilation cycles, store the early analysis file and update the pickle jar
-      if (earlyOutput.isDefined && !continue && lookup.shouldDoEarlyOutput(merged)) {
+      if (!continue && lookup.shouldDoEarlyOutput(merged)) {
         writeEarlyArtifacts(merged)
       }
     }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -937,7 +937,7 @@ private final class AnalysisCallback(
         if (!writtenEarlyArtifacts) // writing implies the updates merge has happened
           mergeUpdates() // must merge updates each cycle or else scalac will clobber it
       }
-      incHandler.completeCycle(None, getAnalysis)
+      incHandler.completeCycle(invalidationResults, getAnalysis)
     } else {
       throw new IllegalStateException(
         "can't call AnalysisCallback#getCycleResultOnce more than once"

--- a/zinc/src/sbt-test/source-dependencies/cyclic-dependency/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/cyclic-dependency/A.scala
@@ -1,0 +1,13 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+class A() extends ABase()
+

--- a/zinc/src/sbt-test/source-dependencies/cyclic-dependency/ABase.java
+++ b/zinc/src/sbt-test/source-dependencies/cyclic-dependency/ABase.java
@@ -1,0 +1,14 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+public abstract class ABase {
+    H h;
+}

--- a/zinc/src/sbt-test/source-dependencies/cyclic-dependency/H.scala
+++ b/zinc/src/sbt-test/source-dependencies/cyclic-dependency/H.scala
@@ -1,0 +1,12 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+class H() extends HBase()

--- a/zinc/src/sbt-test/source-dependencies/cyclic-dependency/HBase.java
+++ b/zinc/src/sbt-test/source-dependencies/cyclic-dependency/HBase.java
@@ -1,0 +1,14 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+public abstract class HBase {
+    A a;
+}

--- a/zinc/src/sbt-test/source-dependencies/cyclic-dependency/changes/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/cyclic-dependency/changes/A.scala
@@ -1,0 +1,16 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+class A() extends ABase()
+
+
+
+// random placeholder change

--- a/zinc/src/sbt-test/source-dependencies/cyclic-dependency/changes/ABase.java
+++ b/zinc/src/sbt-test/source-dependencies/cyclic-dependency/changes/ABase.java
@@ -1,0 +1,16 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+public abstract class ABase {
+    H h;
+}
+
+// Random changes to force recompilation

--- a/zinc/src/sbt-test/source-dependencies/cyclic-dependency/incOptions.properties
+++ b/zinc/src/sbt-test/source-dependencies/cyclic-dependency/incOptions.properties
@@ -1,0 +1,1 @@
+pipelining = false

--- a/zinc/src/sbt-test/source-dependencies/cyclic-dependency/test
+++ b/zinc/src/sbt-test/source-dependencies/cyclic-dependency/test
@@ -3,4 +3,4 @@
 $ copy-file changes/ABase.java ABase.java
 $ copy-file changes/A.scala A.scala
 
-> checkIterations 1
+> checkIterations 2

--- a/zinc/src/sbt-test/source-dependencies/cyclic-dependency/test
+++ b/zinc/src/sbt-test/source-dependencies/cyclic-dependency/test
@@ -1,0 +1,6 @@
+> compile
+
+$ copy-file changes/ABase.java ABase.java
+$ copy-file changes/A.scala A.scala
+
+> checkIterations 1


### PR DESCRIPTION
### Issue

`invalidationResults` in `AnalysisCallback` is computed twice, once in API phase, once in dependency phase. It is not updated again after Java analysis, hence `invalidationResults` contains incorrect information for Java sources.

### Fix

Do not use `invalidationResults` when computing `CompileCycleResult`.

### Trivia

I am not 100% certain yet, but this is probably the root cause of https://github.com/sbt/sbt/issues/6183, as

- `invalidationResults` is added in Zinc 1.4.0 and https://github.com/sbt/sbt/issues/6183 appears after Zinc 1.4.0 is released
- [Reproduction](https://github.com/jdsalchow/compile_loop) of infinite compile by jdsalchow now terminates before `invalidateTransitively` flag is set with the PR change.

c.c. @LaCuneta This should fix #1311 or at least partially fix it (if #1311 has multiple causes).