### PR TITLE
Add support for `-Xshow-phases`

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
@@ -102,6 +102,8 @@ sealed class ZincCompiler(settings: Settings, dreporter: DelegatingReporter, out
     val analyzer = new Analyzer(global)
     def newPhase(prev: Phase) = analyzer.newPhase(prev)
     def name = phaseName
+
+    def description = "analyzes the generated class files and maps them to sources"
   }
 
   /** Phase that extracts dependency information */
@@ -116,6 +118,8 @@ sealed class ZincCompiler(settings: Settings, dreporter: DelegatingReporter, out
     val dependency = new Dependency(global)
     def newPhase(prev: Phase) = dependency.newPhase(prev)
     def name = phaseName
+
+    def description = "extracts dependency information"
   }
 
   /**
@@ -136,13 +140,18 @@ sealed class ZincCompiler(settings: Settings, dreporter: DelegatingReporter, out
     val api = new API(global)
     def newPhase(prev: Phase) = api.newPhase(prev)
     def name = phaseName
+
+    def description = "constructs a representation of the public API"
   }
 
   override lazy val phaseDescriptors = {
     phasesSet += sbtAnalyzer
+    phasesDescMap(sbtAnalyzer) = sbtAnalyzer.description
     if (callback.enabled()) {
       phasesSet += sbtDependency
+      phasesDescMap(sbtDependency) = sbtDependency.description
       phasesSet += apiExtractor
+      phasesDescMap(apiExtractor) = apiExtractor.description
     }
     this.computePhaseDescriptors
   }

--- a/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
@@ -103,7 +103,7 @@ sealed class ZincCompiler(settings: Settings, dreporter: DelegatingReporter, out
     def newPhase(prev: Phase) = analyzer.newPhase(prev)
     def name = phaseName
 
-    def description = "analyzes the generated class files and maps them to sources"
+    def description = "analyze the generated class files and map them to sources"
   }
 
   /** Phase that extracts dependency information */
@@ -119,7 +119,7 @@ sealed class ZincCompiler(settings: Settings, dreporter: DelegatingReporter, out
     def newPhase(prev: Phase) = dependency.newPhase(prev)
     def name = phaseName
 
-    def description = "extracts dependency information"
+    def description = "extract dependency information"
   }
 
   /**
@@ -141,7 +141,7 @@ sealed class ZincCompiler(settings: Settings, dreporter: DelegatingReporter, out
     def newPhase(prev: Phase) = api.newPhase(prev)
     def name = phaseName
 
-    def description = "constructs a representation of the public API"
+    def description = "construct a representation of the public API"
   }
 
   override lazy val phaseDescriptors = {

--- a/internal/compiler-bridge/src/main/scala/xsbt/CompilerBridge.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CompilerBridge.scala
@@ -152,6 +152,7 @@ private final class CachedCompiler0(
     // cast down to AnalysisCallback2
     val callback2 = callback.asInstanceOf[xsbti.AnalysisCallback2]
 
+    compiler.set(callback, underlyingReporter)
     if (command.shouldStopWithInfo) {
       underlyingReporter.info(null, command.getInfoMessage(compiler), true)
       throw new InterfaceCompileFailed(args, Array(), StopInfoError)
@@ -159,7 +160,6 @@ private final class CachedCompiler0(
 
     if (noErrors(underlyingReporter)) {
       debug(log, prettyPrintCompilationArguments(args))
-      compiler.set(callback, underlyingReporter)
       val run = new compiler.ZincRun(compileProgress)
 
       run.compileFiles(sources)

--- a/zinc/src/test/scala/sbt/inc/IncrementalCompilerSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/IncrementalCompilerSpec.scala
@@ -211,4 +211,18 @@ class IncrementalCompilerSpec extends BaseCompilerSpec {
       comp.close()
     }
   }
+
+  it should "not throw NullPointerException when passing -Xshow-phases to scalac" in withTmpDir {
+    tmp =>
+      val comp = ProjectSetup.simple(
+        tmp.toPath,
+        Seq(SourceFiles.Good),
+        Seq("-Xshow-phases")
+      ).createCompiler()
+      try {
+        assertThrows[CompileFailed] {
+          comp.doCompile()
+        }
+      } finally comp.close()
+  }
 }

--- a/zinc/src/test/scala/sbt/inc/TestProjectSetup.scala
+++ b/zinc/src/test/scala/sbt/inc/TestProjectSetup.scala
@@ -148,9 +148,13 @@ case class CompilerSetup(
 case class ProjectPaths(baseDir: Path) {}
 
 object ProjectSetup {
-  def simple(baseDir: Path, classes: Seq[String]): ProjectSetup = {
+  def simple(
+      baseDir: Path,
+      classes: Seq[String],
+      scalacOptions: Seq[String] = Nil
+  ): ProjectSetup = {
     val sources = Map(Paths.get("src") -> classes.map(Paths.get(_)))
-    ProjectSetup(VirtualSubproject(baseDir), sources, Nil, Map.empty)
+    ProjectSetup(VirtualSubproject(baseDir), sources, Nil, Map.empty, scalacOptions = scalacOptions)
   }
 }
 


### PR DESCRIPTION
Closes #621

Output of `-Xshow-phases` with the PR

```
[info] [info]      phase name  id  description
[info] [info]      ----------  --  -----------
[info] [info]          parser   1  parse source into ASTs, perform simple desugaring
[info] [info]           namer   2  resolve names, attach symbols to named trees
[info] [info]  packageobjects   3  load package objects
[info] [info]           typer   4  the meat and potatoes: type the trees
[info] [info]          patmat   5  translate match expressions
[info] [info]  superaccessors   6  add super accessors in traits and nested classes
[info] [info]      extmethods   7  add extension methods for inline classes
[info] [info]         pickler   8  serialize symbol tables
[info] [info]        xsbt-api   9  construct a representation of the public API
[info] [info] xsbt-dependency  10  extract dependency information
[info] [info]       refchecks  11  reference/override checking, translate nested objects
[info] [info]         uncurry  12  uncurry, translate function values to anonymous classes
[info] [info]          fields  13  synthesize accessors and fields, add bitmaps for lazy vals
[info] [info]       tailcalls  14  replace tail calls by jumps
[info] [info]      specialize  15  @specialized-driven class and method specialization
[info] [info]   explicitouter  16  this refs to outer pointers
[info] [info]         erasure  17  erase types, add interfaces for traits
[info] [info]     posterasure  18  clean up erased inline classes
[info] [info]      lambdalift  19  move nested functions to top level
[info] [info]    constructors  20  move field definitions into constructors
[info] [info]         flatten  21  eliminate inner classes
[info] [info]           mixin  22  mixin composition
[info] [info]         cleanup  23  platform-specific cleanups, generate reflective calls
[info] [info]      delambdafy  24  remove lambdas
[info] [info]             jvm  25  generate JVM bytecode
[info] [info]   xsbt-analyzer  26  analyze the generated class files and map them to sources
[info] [info]        terminal  27  the last phase during a compilation run
```