### PR TITLE
Pass `-nowarn` flag to slience compiler warning during benchmarking

### DIFF
--- a/internal/zinc-benchmarks/src/test/scala/xsbt/ZincBenchmark.scala
+++ b/internal/zinc-benchmarks/src/test/scala/xsbt/ZincBenchmark.scala
@@ -75,10 +75,10 @@ private[xsbt] class ZincBenchmark(toCompile: BenchmarkProject, zincEnabled: Bool
         Map.empty,
         outputToJar = false,
         subproject,
-        scalacOptions = nowarn,
         // ignore `buildInfo.scalacOptions` that was recovered from the build
         // [info] [error] ## Exception when compiling 564 sources to /private/var/folders/hg/2602nfrs2958vnshglyl3srw0000gn/T/sbt_ed541eaf/scala/scala/classes
         // [info] [error] scala.reflect.internal.Symbols$CyclicReference: illegal cyclic reference involving object Predef
+        scalacOptions = nowarn,
       )
     }
 

--- a/internal/zinc-benchmarks/src/test/scala/xsbt/ZincBenchmark.scala
+++ b/internal/zinc-benchmarks/src/test/scala/xsbt/ZincBenchmark.scala
@@ -50,6 +50,7 @@ private[xsbt] class ZincBenchmark(toCompile: BenchmarkProject, zincEnabled: Bool
   }
 
   private val UseJavaCpArg = Array("-usejavacp")
+  private val nowarn = Seq("-nowarn")
   def readSetup(compilationDir: File): ZincSetup = {
     def createSetup(subproject: String, compilationInfo: CompilationInfo) = {
 
@@ -74,10 +75,10 @@ private[xsbt] class ZincBenchmark(toCompile: BenchmarkProject, zincEnabled: Bool
         Map.empty,
         outputToJar = false,
         subproject,
+        scalacOptions = nowarn,
         // ignore `buildInfo.scalacOptions` that was recovered from the build
         // [info] [error] ## Exception when compiling 564 sources to /private/var/folders/hg/2602nfrs2958vnshglyl3srw0000gn/T/sbt_ed541eaf/scala/scala/classes
         // [info] [error] scala.reflect.internal.Symbols$CyclicReference: illegal cyclic reference involving object Predef
-        List()
       )
     }
 


### PR DESCRIPTION
### Issue

When running benchmarking, there's lots of compiler warnings from the projects being benchmarked on that do not provide any meaningful info.

Example:
```
[info] [warn] /tmp/sbt_c424be7/milessabin/shapeless/benchmark-target/62611554399e0d04466da95591253706b2d3020d/core/shared/src/main/managed/shapeless/polynbuilders.scala:445:8: reference to at is ambiguous;
[info] [warn] it is both defined in the enclosing trait Poly11Builder and inherited in the enclosing object build as method at (defined in trait Poly11)
[info] [warn] In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
[info] [warn] Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.at`.
[info] [warn] Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quickfixable]
[info] [warn]        at(tL(functions))
[info] [warn]        ^
[info] [warn] /tmp/sbt_c424be7/milessabin/shapeless/benchmark-target/62611554399e0d04466da95591253706b2d3020d/core/shared/src/main/managed/shapeless/polynbuilders.scala:485:8: reference to at is ambiguous;
[info] [warn] it is both defined in the enclosing trait Poly12Builder and inherited in the enclosing object build as method at (defined in trait Poly12)
[info] [warn] In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
[info] [warn] Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.at`.
[info] [warn] Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quickfixable]
[info] [warn]        at(tL(functions))
[info] [warn]        ^
[info] [warn] /tmp/sbt_c424be7/milessabin/shapeless/benchmark-target/62611554399e0d04466da95591253706b2d3020d/core/shared/src/main/managed/shapeless/polynbuilders.scala:525:8: reference to at is ambiguous;
```

### Change

Silence these warnings

### Validating the PR

The [CI result](https://github.com/sbt/zinc/actions/runs/7367572696/job/20050986272?pr=1320) now omits these warnings.