### PR TITLE
Run zinc benchmarks in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
           - os: ubuntu-latest
             java: 21
             jobtype: 4
+          - os: ubuntu-latest
+            java: 21
+            jobtype: 5
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
@@ -50,9 +53,14 @@ jobs:
       if: ${{ matrix.jobtype == 3 }}
       shell: bash
       run: |
-        sbt -v -Dfile.encoding=UTF-8 "runBenchmarks"
-    - name: Build and test (4)
+        sbt -v -Dfile.encoding=UTF-8 scalafmtCheckAll scalafmtSbtCheck
+    - name: Benchmark (Scalac) (4)
       if: ${{ matrix.jobtype == 4 }}
       shell: bash
       run: |
-        sbt -v -Dfile.encoding=UTF-8 scalafmtCheckAll scalafmtSbtCheck
+        sbt -v -Dfile.encoding=UTF-8 "-Dbenchmark.pattern=.*Scalac.*" "runBenchmarks"
+    - name: Benchmark (Shapeless) (5)
+      if: ${{ matrix.jobtype == 5 }}
+      shell: bash
+      run: |
+        sbt -v -Dfile.encoding=UTF-8 "-Dbenchmark.pattern=.*Shapeless.*" "runBenchmarks"

--- a/build.sbt
+++ b/build.sbt
@@ -697,11 +697,12 @@ crossTestBridges := (compilerBridgeTest.jvm(scala213) / Test / test).dependsOn(p
 addCommandAlias(
   "runBenchmarks", {
     val dir = IO.createTemporaryDirectory.getAbsolutePath
+    val pattern = sys.props.getOrElse("benchmark.pattern", "")
     Seq(
       s"${compilerBridge213.id}/packageBin",
       s"${compilerBridge212.id}/packageBin",
-      s"${zincBenchmarks.jvm(scala212).id}/Test/run $dir",
-      s"${zincBenchmarks.jvm(scala212).id}/jmh:run -p _tempDir=$dir -prof gc -foe true",
+      s"${zincBenchmarks.jvm(scala212).id}/Test/run $dir $pattern",
+      s"${zincBenchmarks.jvm(scala212).id}/jmh:run -p _tempDir=$dir -prof gc -foe true $pattern",
       s"""eval IO.delete(file("$dir"))""",
     ).mkString(";", ";", "")
   }


### PR DESCRIPTION
### Issue

With #1321, CI runs are taking twice as long. It would be better if we catch performance regression without longer CI wait time.

### Solution

This PR introduces a new flag `-Dbenchmark.pattern` that accepts a regex pattern to selectively run benchmarks with name that matches the pattern. For example:

```
sbt "-Dbenchmark.pattern=.*Scalac.*" runBenchmarks
```

would run `Scalac` benchmarks only.

Then in CI, run `Scalac` benchmarks and `Shapeless` benchmarks in parallel.

Closes #1322
