### PR TITLE
Avoid spurious recompilations when unrelated constructor with default argument changes

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/ClassName.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ClassName.scala
@@ -58,6 +58,9 @@ trait ClassName extends Compat {
   protected def constructorNameAsString(cls: Symbol): String =
     cls.fullName(';') ++ ";init;"
 
+  protected def constructorNameAsString(cls: Symbol, index: String): String =
+    cls.fullName(';') ++ s";init;default;$index"
+
   /**
    * Mangle a JVM symbol name in a format better suited for internal uses by sbt.
    */

--- a/zinc/src/sbt-test/source-dependencies/constructors-unrelated-2/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/constructors-unrelated-2/A.scala
@@ -1,0 +1,4 @@
+class A {
+  var z = B.z // introduce a member ref dependency to B
+  var c: C = new C(1)
+}

--- a/zinc/src/sbt-test/source-dependencies/constructors-unrelated-2/B.scala
+++ b/zinc/src/sbt-test/source-dependencies/constructors-unrelated-2/B.scala
@@ -1,0 +1,7 @@
+class B(val z: Int) {
+  def this(x: Int, y: Int = 2) = this(x + y)
+}
+
+object B {
+  val z = 1
+}

--- a/zinc/src/sbt-test/source-dependencies/constructors-unrelated-2/C.scala
+++ b/zinc/src/sbt-test/source-dependencies/constructors-unrelated-2/C.scala
@@ -1,0 +1,3 @@
+class C(z: String) {
+  def this(x: Int, y: Int = 2) = this("")
+}

--- a/zinc/src/sbt-test/source-dependencies/constructors-unrelated-2/changes/B.scala
+++ b/zinc/src/sbt-test/source-dependencies/constructors-unrelated-2/changes/B.scala
@@ -1,0 +1,7 @@
+class B(val z: Int) {
+  def this(x: Int, y: String = "") = this(x + y.toInt)
+}
+
+object B {
+  val z = 1
+}

--- a/zinc/src/sbt-test/source-dependencies/constructors-unrelated-2/changes/C.scala
+++ b/zinc/src/sbt-test/source-dependencies/constructors-unrelated-2/changes/C.scala
@@ -1,0 +1,3 @@
+class C(z: String) {
+  def this(x: Boolean, y: Int = 2) = this("")
+}

--- a/zinc/src/sbt-test/source-dependencies/constructors-unrelated-2/test
+++ b/zinc/src/sbt-test/source-dependencies/constructors-unrelated-2/test
@@ -1,0 +1,8 @@
+> compile
+$ copy-file changes/B.scala B.scala
+# Second compilation round, there should be no third round (we don't need to recompile A.scala)
+> compile
+# Check that there were only two rounds of compilation
+> checkIterations 2
+$ copy-file changes/C.scala C.scala
+-> compile


### PR DESCRIPTION
### Issue

Constructor sometimes has name `<init>$default$number` (e.g.  `<init>$default$1`,  `<init>$default$2`) instead of `<init>`. Hence two unrelated constructors have the same name.

#288 ensured that two unrelated `<init>` constructor have different names by prepending constructor name with class name, however #288 did not handle `<init>$default$`.

### Fix

Prepend `<init>$default$` with the class name.

c.c. https://github.com/sbt/zinc/pull/288, https://github.com/sbt/zinc/issues/578#issuecomment-417599988