### PR TITLE
Don't use autoBoot / filterLibrary for 2.13 and 3

### DIFF
--- a/internal/compiler-bridge-test/src/test/scala/sbt/internal/inc/CompilingSpecification.scala
+++ b/internal/compiler-bridge-test/src/test/scala/sbt/internal/inc/CompilingSpecification.scala
@@ -39,7 +39,7 @@ trait CompilingSpecification extends AbstractBridgeProviderTestkit {
 
   def scalaCompiler(instance: xsbti.compile.ScalaInstance, bridgeJar: Path): AnalyzingCompiler = {
     val bridgeProvider = ZincUtil.constantBridgeProvider(instance, bridgeJar)
-    val classpath = ClasspathOptionsUtil.boot
+    val classpath = ClasspathOptionsUtil.noboot(instance.version)
     val cache = Some(new ClassLoaderCache(new URLClassLoader(Array())))
     new AnalyzingCompiler(instance, bridgeProvider, classpath, _ => (), cache)
   }

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/compile/ClasspathOptions.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/compile/ClasspathOptions.java
@@ -32,7 +32,7 @@ public final class ClasspathOptions implements java.io.Serializable {
     }
     /**
      * If true, includes the Scala library on the boot classpath.
-     * This should usually be true.
+     * This should usually be false.
      */
     public boolean bootLibrary() {
         return this.bootLibrary;
@@ -53,14 +53,14 @@ public final class ClasspathOptions implements java.io.Serializable {
     }
     /**
      * If true, automatically configures the boot classpath.
-     * This should usually be true.
+     * This should usually be false.
      */
     public boolean autoBoot() {
         return this.autoBoot;
     }
     /**
      * If true, the Scala library jar is filtered from the standard classpath.
-     * This should usually be true because the library should be included on the boot
+     * This should usually be false unless the library is included on the boot
      * classpath of the Scala compiler and not the standard classpath.
      */
     public boolean filterLibrary() {

--- a/internal/compiler-interface/src/main/contraband/incremental.contra
+++ b/internal/compiler-interface/src/main/contraband/incremental.contra
@@ -377,7 +377,7 @@ type Compilers {
 ## compiler-related parameters. Usually, values are all false for Java compilation.
 type ClasspathOptions {
   ## If true, includes the Scala library on the boot classpath.
-  ## This should usually be true.
+  ## This should usually be false.
   bootLibrary: Boolean!
 
   ## If true, includes the Scala compiler on the standard classpath.
@@ -389,11 +389,11 @@ type ClasspathOptions {
   extra: Boolean!
 
   ## If true, automatically configures the boot classpath.
-  ## This should usually be true.
+  ## This should usually be false.
   autoBoot: Boolean!
 
   ## If true, the Scala library jar is filtered from the standard classpath.
-  ## This should usually be true because the library should be included on the boot
+  ## This should usually be false unless the library is included on the boot
   ## classpath of the Scala compiler and not the standard classpath.
   filterLibrary: Boolean!
 }

--- a/internal/zinc-compile-core/src/main/java/xsbti/compile/ClasspathOptionsUtil.java
+++ b/internal/zinc-compile-core/src/main/java/xsbti/compile/ClasspathOptionsUtil.java
@@ -16,7 +16,6 @@ package xsbti.compile;
  * that create typical classpath options based on the desired use-case.
  */
 public interface ClasspathOptionsUtil {
-
     /**
      * Define a manual {@link ClasspathOptions} where the client manages everything.
      */
@@ -35,6 +34,16 @@ public interface ClasspathOptionsUtil {
     }
 
     /**
+     * Define {@link ClasspathOptions} where the Scala standard library is present in the classpath.
+     */
+    public static ClasspathOptions noboot(String scalaVersion) {
+        if (!scalaVersion.startsWith("2.") || scalaVersion.startsWith("2.13."))
+            return ClasspathOptions.of(false, false, false, false, false);
+        else
+            return boot();
+    }
+
+    /**
      * Define auto {@link ClasspathOptions} where:
      * 1. the Scala standard library is present in the classpath;
      * 2. the Compiler JAR is present in the classpath;
@@ -44,6 +53,19 @@ public interface ClasspathOptionsUtil {
      */
     public static ClasspathOptions auto() {
         return ClasspathOptions.of(true, true, true, true, true);
+    }
+
+    /**
+     * Define auto {@link ClasspathOptions} where:
+     * 1. the Scala standard library is present in the classpath;
+     * 2. the Compiler JAR is present in the classpath;
+     * 3. the extra JARs present in the Scala instance are added to the classpath.
+     */
+    public static ClasspathOptions autoNoboot(String scalaVersion) {
+        if (!scalaVersion.startsWith("2.") || scalaVersion.startsWith("2.13."))
+            return ClasspathOptions.of(false, true, true, false, false);
+        else
+            return auto();
     }
 
     /**
@@ -68,5 +90,15 @@ public interface ClasspathOptionsUtil {
      */
     public static ClasspathOptions repl() {
         return auto();
+    }
+
+    /**
+     * Define repl {@link ClasspathOptions} where:
+     * 1. the Scala standard library is present in the classpath;
+     * 2. the Compiler JAR is present in the classpath;
+     * 3. the extra JARs present in the Scala instance are added to the classpath.
+     */
+    public static ClasspathOptions replNoboot(String scalaVersion) {
+        return autoNoboot(scalaVersion);
     }
 }

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavaCompiler.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavaCompiler.scala
@@ -93,6 +93,7 @@ object JavaCompiler {
       cpOptions: ClasspathOptions
   ): Seq[String] = {
     val cp = classpath.map(converter.toPath)
+    // this seems to duplicate scala-library
     val augmentedClasspath: Seq[Path] =
       if (!cpOptions.autoBoot) cp
       else cp ++ scalaInstance.libraryJars.map(_.toPath)

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -196,7 +196,7 @@ class IncHandler(directory: Path, cacheDir: Path, scriptedLog: ManagedLogger, co
       toCache
     }
     val analyzingCompiler = scalaCompiler(si, compilerBridge)
-    val cs = incrementalCompiler.compilers(si, ClasspathOptionsUtil.boot, None, analyzingCompiler)
+    val cs = incrementalCompiler.compilers(si, ClasspathOptionsUtil.noboot(si.version), None, analyzingCompiler)
     IncState(si, cs, 0)
   }
 
@@ -204,7 +204,7 @@ class IncHandler(directory: Path, cacheDir: Path, scriptedLog: ManagedLogger, co
 
   def scalaCompiler(instance: XScalaInstance, bridgeJar: Path): AnalyzingCompiler = {
     val bridgeProvider = ZincUtil.constantBridgeProvider(instance, bridgeJar)
-    val classpath = ClasspathOptionsUtil.boot
+    val classpath = ClasspathOptionsUtil.noboot(instance.version)
     new AnalyzingCompiler(instance, bridgeProvider, classpath, unit, IncHandler.classLoaderCache)
   }
 

--- a/zinc/src/main/scala/sbt/internal/inc/ZincUtil.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/ZincUtil.scala
@@ -82,7 +82,11 @@ object ZincUtil {
    * @return A Scala compiler ready to be used.
    */
   def scalaCompiler(scalaInstance: ScalaInstance, compilerBridgeJar: Path): AnalyzingCompiler = {
-    scalaCompiler(scalaInstance, compilerBridgeJar, ClasspathOptionsUtil.boot)
+    scalaCompiler(
+      scalaInstance,
+      compilerBridgeJar,
+      ClasspathOptionsUtil.noboot(scalaInstance.version)
+    )
   }
 
   /**
@@ -98,7 +102,11 @@ object ZincUtil {
    * @return A Scala compiler ready to be used.
    */
   def scalaCompiler(scalaInstance: ScalaInstance, compilerBridgeJar: File): AnalyzingCompiler = {
-    scalaCompiler(scalaInstance, compilerBridgeJar.toPath, ClasspathOptionsUtil.boot)
+    scalaCompiler(
+      scalaInstance,
+      compilerBridgeJar.toPath,
+      ClasspathOptionsUtil.noboot(scalaInstance.version)
+    )
   }
 
   // def compilers(


### PR DESCRIPTION
Passing `-bootclasspath /path/to/scala-library.jar` to the Scala compiler is only done for historical reasons. Putting the Scala library on the ordinary classspath is equivalent.

This commit adds a `noboot` factory for ClasspathOptions which doesn't use `-bootclasspath` for Scala 2.13 and Scala 3.

This change was made in the context of [SIP-51, unfreeze the Scala library](https://docs.scala-lang.org/sips/drop-stdlib-forwards-bin-compat.html) / https://github.com/sbt/sbt/pull/7480, but it's just a cleanup and not actually required.