### PR TITLE
Clean up scala-xml dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -255,7 +255,6 @@ lazy val zincTesting = (projectMatrix in internalPath / "zinc-testing")
     baseSettings,
     publish / skip := true,
     libraryDependencies ++= Seq(scalaCheck, scalatest, verify, sjsonnewScalaJson.value),
-    // scala-compiler depends on 1.x, but 2.x works too
     dependencyOverrides += "org.scala-lang.modules" %% "scala-xml" % "2.3.0"
   )
   .defaultAxes(VirtualAxis.jvm, VirtualAxis.scalaPartialVersion(scala212))

--- a/build.sbt
+++ b/build.sbt
@@ -255,7 +255,7 @@ lazy val zincTesting = (projectMatrix in internalPath / "zinc-testing")
     baseSettings,
     publish / skip := true,
     libraryDependencies ++= Seq(scalaCheck, scalatest, verify, sjsonnewScalaJson.value),
-    dependencyOverrides += "org.scala-lang.modules" %% "scala-xml" % "2.3.0"
+    dependencyOverrides += scalaXml,
   )
   .defaultAxes(VirtualAxis.jvm, VirtualAxis.scalaPartialVersion(scala212))
   .jvmPlatform(scalaVersions = List(scala212, scala213))


### PR DESCRIPTION
- in build def, remove outdated comment
- in build def, don't repeat scala-xml version number

minor cleanup I noticed in the context of https://github.com/sbt/zinc/pull/1355