### PR TITLE
Use a repeatable hash code for empty files

### DIFF
--- a/zinc/src/main/scala/sbt/internal/inc/caching/ClasspathCache.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/caching/ClasspathCache.scala
@@ -16,7 +16,7 @@ import java.nio.file.attribute.{ BasicFileAttributes, FileTime }
 import java.util.concurrent.ConcurrentHashMap
 
 import xsbti.compile.FileHash
-import sbt.internal.inc.{ EmptyStamp, Stamper }
+import sbt.internal.inc.Stamper
 import sbt.io.IO
 import scala.util.control.NonFatal
 
@@ -38,8 +38,7 @@ object ClasspathCache {
   // For more safety, store both the time and size
   private type JarMetadata = (FileTime, Long)
   private[this] val cacheMetadataJar = new ConcurrentHashMap[Path, (JarMetadata, FileHash)]()
-  private[this] final val emptyStampCode = EmptyStamp.hashCode()
-  private def emptyFileHash(file: Path) = FileHash.of(file, emptyStampCode)
+  private def emptyFileHash(file: Path) = FileHash.of(file, 42)
   private def genFileHash(file: Path, metadata: JarMetadata): FileHash = {
     val newHash = FileHash.of(file, Stamper.forFarmHashP(file).getValueId())
     cacheMetadataJar.put(file, (metadata, newHash))


### PR DESCRIPTION
The current `emptyStampCode` is a system identity hash code that changes between runs in different JVMs or ClassLoaders. This leads to unnecessary invalidations, especially when you use `ConsistentAnalysisFormat` and expect to get identical outputs for identical inputs. Since it is chosen arbitrarily, there is no reason not to hard-code an arbitrary value to get repeatable outputs.

(In our Bazel-based Scala tooling we currently use a copy of `ClasspathCache` with this fix which is wired into the build via `ExternalHooks.Lookup`, which adds a lot of boilerplate for such a small change.)