### PR TITLE
[2.x] Create empty output jar before compilation

### DIFF
--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/JarUtils.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/JarUtils.scala
@@ -238,8 +238,8 @@ object JarUtils {
         }
         cleanupPreviousJar(prevJar, outputJar)
       case None =>
-        compile(Nil)
         createOutputJarIfMissing(output)
+        compile(Nil)
     }
   }
 


### PR DESCRIPTION
In some Java version (e.g., temurin:11.0.23), the Scala 3 compiler crashes if the jar output file does not exist.