### PR TITLE
Parse column/position information from javac error messages

### DIFF
--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/DiagnosticsReporter.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/DiagnosticsReporter.scala
@@ -200,7 +200,8 @@ object DiagnosticsReporter {
       def endPosition: Option[Long] = checkNoPos(d.getEndPosition)
 
       val line: Optional[Integer] = o2jo(checkNoPos(d.getLineNumber) map (_.toInt))
-      val pointer: Optional[Integer] = o2jo(checkNoPos(d.getColumnNumber) map (_.toInt))
+      // column number is 1-based, xsbti.Position#pointer is 0-based.
+      val pointer: Optional[Integer] = o2jo(checkNoPos(d.getColumnNumber - 1) map (_.toInt))
       val offset: Optional[Integer] = o2jo(checkNoPos(d.getPosition) map (_.toInt))
       val startOffset: Optional[Integer] = o2jo(startPosition map (_.toInt))
       val endOffset: Optional[Integer] = o2jo(endPosition map (_.toInt))

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/DiagnosticsReporter.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/DiagnosticsReporter.scala
@@ -244,10 +244,10 @@ object DiagnosticsReporter {
         }
 
       val pointerSpace = pointer.map[String] { p =>
-        lineContent.toList.take(p.intValue()).map {
+        lineContent.take(p.intValue()).map {
           case '\t' => '\t'
           case _    => ' '
-        }.mkString
+        }
       }
 
       new PositionImpl(

--- a/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/javac/JavaCompilerSpec.scala
+++ b/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/javac/JavaCompilerSpec.scala
@@ -114,14 +114,17 @@ class JavaCompilerSpec extends UnitSpec with Diagrams {
         case _           => 5
       }
     })
-    val importWarn = warnOnLine(lineno = 12, lineContent = Some("java.rmi.RMISecurityException"))
-    val enclosingError = errorOnLine(lineno = 25, message = Some("not an enclosing class: C.D"))
+    val importWarn =
+      warnOnLine(lineno = 12, colno = 15, lineContent = Some("java.rmi.RMISecurityException"))
+    val enclosingError =
+      errorOnLine(lineno = 25, colno = 9, message = Some("not an enclosing class: C.D"))
     val beAnExpectedError =
       List(
         importWarn,
-        errorOnLine(14),
-        errorOnLine(15),
-        warnOnLine(18),
+        errorOnLine(14, 7),
+        errorOnLine(15, 11),
+        warnOnLine(18, 18),
+        warnOnLine(18, 14), // could be expected depending on Java version
         enclosingError
       ) reduce (_ or _)
     problems foreach { p =>
@@ -140,7 +143,7 @@ class JavaCompilerSpec extends UnitSpec with Diagrams {
       }
     })
     assert(problems.size == 2)
-    val beAnExpectedError = List(errorOnLine(14), errorOnLine(15)) reduce (_ or _)
+    val beAnExpectedError = List(errorOnLine(14, 7), errorOnLine(15, 11)) reduce (_ or _)
     problems foreach { p =>
       p should beAnExpectedError
     }
@@ -192,20 +195,43 @@ class JavaCompilerSpec extends UnitSpec with Diagrams {
     lineNumberCheck && messageCheck
   }
 
-  def lineMatches(p: Problem, lineno: Int, lineContent: Option[String] = None): Boolean = {
+  def lineMatches(
+      p: Problem,
+      lineno: Int,
+      colno: Int,
+      lineContent: Option[String] = None
+  ): Boolean = {
     def lineContentCheck = lineContent forall (content => p.position.lineContent contains content)
     def lineNumberCheck = p.position.line.isPresent && (p.position.line.get == lineno)
-    lineNumberCheck && lineContentCheck
+    def columnCheck = {
+      val res = p.position.pointer.isPresent && (p.position.pointer.get == colno)
+      if (!res) {
+        println(s"got ${p.position().pointer().get}, expected $colno, problem $p")
+      }
+      res
+    }
+    lineNumberCheck && columnCheck && lineContentCheck
   }
 
-  def errorOnLine(lineno: Int, message: Option[String] = None, lineContent: Option[String] = None) =
-    problemOnLine(lineno, Severity.Error, message, lineContent)
+  def errorOnLine(
+      lineno: Int,
+      colno: Int,
+      message: Option[String] = None,
+      lineContent: Option[String] = None
+  ) =
+    problemOnLine(lineno, colno, Severity.Error, message, lineContent)
 
-  def warnOnLine(lineno: Int, message: Option[String] = None, lineContent: Option[String] = None) =
-    problemOnLine(lineno, Severity.Warn, message, lineContent)
+  def warnOnLine(
+      lineno: Int,
+      colno: Int,
+      message: Option[String] = None,
+      lineContent: Option[String] = None
+  ) =
+    problemOnLine(lineno, colno, Severity.Warn, message, lineContent)
 
   private def problemOnLine(
       lineno: Int,
+      colno: Int,
       severity: Severity,
       message: Option[String],
       lineContent: Option[String]
@@ -218,9 +244,10 @@ class JavaCompilerSpec extends UnitSpec with Diagrams {
         messageMatches(p, lineno, message) && lineMatches(
           p,
           lineno,
+          colno,
           lineContent
         ) && p.severity == severity,
-        s"Expected $problemType on line $lineno$msg$content, but found $p",
+        s"Expected $problemType on line $lineno, column $colno$msg$content, but found $p",
         "Problem matched: " + p
       )
     }

--- a/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/javac/javaErrorParserSpec.scala
+++ b/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/javac/javaErrorParserSpec.scala
@@ -80,8 +80,8 @@ class JavaErrorParserSpec extends UnitSpec with Diagrams {
     val logger = ConsoleLogger()
     val problems = parser.parseProblems(sampleErrorPosition, logger)
     assert(problems.size == 1)
-    problems(0).position.offset.isPresent shouldBe true
-    problems(0).position.offset.get shouldBe 23
+    problems(0).position.pointer.isPresent shouldBe true
+    problems(0).position.pointer.get shouldBe 23
   }
 
   def parseMultipleErrors() = {

--- a/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/javac/javaErrorParserSpec.scala
+++ b/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/javac/javaErrorParserSpec.scala
@@ -80,8 +80,17 @@ class JavaErrorParserSpec extends UnitSpec with Diagrams {
     val logger = ConsoleLogger()
     val problems = parser.parseProblems(sampleErrorPosition, logger)
     assert(problems.size == 1)
-    problems(0).position.pointer.isPresent shouldBe true
-    problems(0).position.pointer.get shouldBe 23
+    val position = problems.head.position
+
+    position.sourcePath.isPresent shouldBe true
+    position.sourcePath.get shouldBe "/home/me/projects/sample/src/main/java/A.java"
+    position.line.isPresent shouldBe true
+    position.line.get shouldBe 6
+    position.lineContent should include("System.out.println(foobar);")
+    position.pointer.isPresent shouldBe true
+    position.pointer.get shouldBe 23
+    position.pointerSpace.isPresent shouldBe true
+    position.pointerSpace.get shouldBe (" " * 23)
   }
 
   def parseMultipleErrors() = {
@@ -89,6 +98,61 @@ class JavaErrorParserSpec extends UnitSpec with Diagrams {
     val logger = ConsoleLogger()
     val problems = parser.parseProblems(sampleMultipleErrors, logger)
     assert(problems.size == 5)
+
+    val position1 = problems(0).position
+    position1.sourcePath.isPresent shouldBe true
+    position1.sourcePath.get shouldBe "/home/foo/sbt/internal/inc/javac/test1.java"
+    position1.line.isPresent shouldBe true
+    position1.line.get shouldBe 3
+    position1.lineContent should include("public class Test {")
+    position1.pointer.isPresent shouldBe true
+    position1.pointer.get shouldBe 7
+    position1.pointerSpace.isPresent shouldBe true
+    position1.pointerSpace.get shouldBe (" " * 7)
+
+    val position2 = problems(1).position
+    position2.sourcePath.isPresent shouldBe true
+    position2.sourcePath.get shouldBe "/home/foo/sbt/internal/inc/javac/test1.java"
+    position2.line.isPresent shouldBe true
+    position2.line.get shouldBe 1
+    position2.lineContent should include("import java.rmi.RMISecurityException;")
+    position2.pointer.isPresent shouldBe true
+    position2.pointer.get shouldBe 15
+    position2.pointerSpace.isPresent shouldBe true
+    position2.pointerSpace.get shouldBe (" " * 15)
+
+    val position3 = problems(2).position
+    position3.sourcePath.isPresent shouldBe true
+    position3.sourcePath.get shouldBe "/home/foo/sbt/internal/inc/javac/test1.java"
+    position3.line.isPresent shouldBe true
+    position3.line.get shouldBe 4
+    position3.lineContent should include("public NotFound foo() { return 5; }")
+    position3.pointer.isPresent shouldBe true
+    position3.pointer.get shouldBe 11
+    position3.pointerSpace.isPresent shouldBe true
+    position3.pointerSpace.get shouldBe (" " * 11)
+
+    val position4 = problems(3).position
+    position4.sourcePath.isPresent shouldBe true
+    position4.sourcePath.get shouldBe "/home/foo/sbt/internal/inc/javac/test1.java"
+    position4.line.isPresent shouldBe true
+    position4.line.get shouldBe 7
+    position4.lineContent should include("""throw new RMISecurityException("O NOES");""")
+    position4.pointer.isPresent shouldBe true
+    position4.pointer.get shouldBe 18
+    position4.pointerSpace.isPresent shouldBe true
+    position4.pointerSpace.get shouldBe (" " * 18)
+
+    val position5 = problems(4).position
+    position5.sourcePath.isPresent shouldBe true
+    position5.sourcePath.get shouldBe "/home/foo/sbt/internal/inc/javac/test1.java"
+    position5.line.isPresent shouldBe true
+    position5.line.get shouldBe 7
+    position5.lineContent should include("""throw new RMISecurityException("O NOES");""")
+    position5.pointer.isPresent shouldBe true
+    position5.pointer.get shouldBe 14
+    position5.pointerSpace.isPresent shouldBe true
+    position5.pointerSpace.get shouldBe (" " * 14)
   }
 
   def parseMultipleErrors2() = {
@@ -144,7 +208,7 @@ class JavaErrorParserSpec extends UnitSpec with Diagrams {
 
   def sampleErrorPosition =
     """
-      |A.java:6: cannot find symbol
+      |/home/me/projects/sample/src/main/java/A.java:6: cannot find symbol
       |symbol  : variable foobar
       |location: class A
       |    System.out.println(foobar);


### PR DESCRIPTION
Resolves #1372 .

I've made a binary incompatible change to `sbt.internal.inc.javac.JavaPosition`. What is the binary compatibility guarantee of this package, given that it has `internal` in the name?

I can re-add the old constructor to preserve binary compatibility. However, even if I add the constructor once more, one of its parameters is no longer uses in the same way as it was before.

Any advice or preference on this matter is appreciated.