### PR TITLE
[2.x] Fix mixed compilation to JAR

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ ThisBuild / version := {
   nightlyVersion match {
     case Some(v) => v
     case _ =>
-      if ((ThisBuild / isSnapshot).value) "2.0.0-alpha12-SNAPSHOT"
+      if ((ThisBuild / isSnapshot).value) "2.0.0-alpha15-SNAPSHOT"
       else old
   }
 }

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/JarUtils.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/JarUtils.scala
@@ -113,9 +113,9 @@ object JarUtils {
      */
     def fromURL(url: URL, jar: Path): ClassInJar = {
       val path = url.getPath
-      if (!path.contains("!")) sys.error(s"unexpected URL $url that does not include '!'")
+      if (!path.contains("!/")) sys.error(s"unexpected URL $url that does not include '!/'")
       else {
-        val Array(_, cls) = url.getPath.split("!")
+        val Array(_, cls) = url.getPath.split("!/")
         apply(jar, cls)
       }
     }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -635,8 +635,8 @@ private final class AnalysisCallback(
   private[this] val localClasses = new TrieMap[VirtualFileRef, ConcurrentSet[VirtualFileRef]]
   // mapping between src class name and binary (flat) class name for classes generated from src file
   private[this] val classNames = new TrieMap[VirtualFileRef, ConcurrentSet[(String, String)]]
-  // generated class file to its source class name
-  private[this] val classToSource = new TrieMap[VirtualFileRef, String]
+  // generated class name to its source class name
+  private[this] val binaryNameToSourceName = new TrieMap[String, String]
   // internal source dependencies
   private[this] val intSrcDeps = new TrieMap[String, ConcurrentSet[InternalDependency]]
   // external source dependencies
@@ -779,8 +779,7 @@ private final class AnalysisCallback(
         // dependency is a product of a source not included in this compilation
         classDependency(dependsOn, fromClassName, context)
       case None =>
-        val vf = converter.toVirtualFile(classFile)
-        classToSource.get(vf) match {
+        binaryNameToSourceName.get(onBinaryClassName) match {
           case Some(dependsOn) =>
             // dependency is a product of a source in this compilation step,
             //  but not in the same compiler run (as in javac v. scalac)
@@ -842,7 +841,7 @@ private final class AnalysisCallback(
     val vf = converter.toVirtualFile(classFile)
     add(nonLocalClasses, source, (vf, binaryClassName))
     add(classNames, source, (srcClassName, binaryClassName))
-    classToSource.put(vf, srcClassName)
+    binaryNameToSourceName.put(binaryClassName, srcClassName)
     ()
   }
 

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -70,7 +70,8 @@ final class MixedAnalyzingCompiler(
 
         def toVirtualFile(p: Path) = config.converter.toVirtualFile(p.toAbsolutePath)
 
-        JarUtils.getOutputJar(output) match {
+        val outputJarOpt = JarUtils.getOutputJar(output)
+        outputJarOpt match {
           case Some(outputJar) if !javac.supportsDirectToJar =>
             val outputDir = JarUtils.javacTempOutput(outputJar)
             Files.createDirectories(outputDir)
@@ -80,7 +81,7 @@ final class MixedAnalyzingCompiler(
               config.converter,
               joptions,
               CompileOutput(outputDir),
-              Some(outputJar),
+              outputJarOpt,
               callback,
               incToolOptions,
               config.reporter,
@@ -96,7 +97,7 @@ final class MixedAnalyzingCompiler(
                 config.converter,
                 joptions,
                 output,
-                None,
+                outputJarOpt,
                 callback,
                 incToolOptions,
                 config.reporter,


### PR DESCRIPTION
For the second compilation step of a mixed compilation (Scala then Java, or vice versa), Zinc copies the current output Jar to a temporary jar. All dependencies on this temporary jar must be declared as internal class dependencies. To do so we we cannot use the declared class file (the temporary jar), instead we use the binary class name, which is stored in a `binaryNameToClassName` map.