### PR TITLE
[2.x] Avoid using ZipError

### DIFF
--- a/internal/zinc-classfile/src/main/java/sbt/internal/inc/zip/ZipCentralDir.java
+++ b/internal/zinc-classfile/src/main/java/sbt/internal/inc/zip/ZipCentralDir.java
@@ -302,8 +302,8 @@ public class ZipCentralDir {
         IndexNode child;  // 1st child
     }
 
-    private static void zerror(String msg) {
-        throw new ZipError(msg);
+    private static void zerror(String msg) throws ZipException {
+        throw new ZipException(msg);
     }
 
     private void buildNodeTree() {


### PR DESCRIPTION
Per https://github.com/sbt/zinc/issues/1385, `ZipError` will be deprecated. This migrates to `ZipException`.
