### PR TITLE
Copy bytes directly instead of using `scala.reflect.io.Streamable`

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/AbstractZincFile.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/AbstractZincFile.scala
@@ -12,7 +12,6 @@
 package xsbt
 
 import xsbti.{ PathBasedFile, VirtualFile }
-import scala.reflect.io.Streamable
 
 private trait AbstractZincFile extends scala.reflect.io.AbstractFile {
   def underlying: VirtualFile
@@ -25,7 +24,22 @@ private final class ZincPlainFile private[xsbt] (val underlying: PathBasedFile)
 private final class ZincVirtualFile private[xsbt] (val underlying: VirtualFile)
     extends scala.reflect.io.VirtualFile(underlying.name, underlying.id)
     with AbstractZincFile {
-  Streamable.closing(output)(_.write(Streamable.bytes(underlying.input))) // fill in the content
+  val buffer = new Array[Byte](4096)
+
+  val in = underlying.input()
+  val output0 = output
+
+  try {
+    var readBytes = in.read(buffer)
+
+    while (readBytes != -1) {
+      output0.write(buffer, 0, readBytes)
+      readBytes = in.read(buffer)
+    }
+  } finally {
+    in.close()
+    output0.close()
+  }
 }
 
 private object AbstractZincFile {


### PR DESCRIPTION
`scala.reflect.io.Streamable` is way slower than copying bytes directly. Depending on buildtool implementations of `VirtualFile` and `FileConverter` the code path may end up running this method which for smaller files (1Kb) is 10x slower and for larger ones (20Kb+) even 20x slower. This can add up for bigger codebases. 