### PR TITLE
[1.x] Refine early return condition in `invalidateAfterInternalCompilation`

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
@@ -464,16 +464,10 @@ private[inc] abstract class IncrementalCommon(
     val dependsOnClass = findClassDependencies(_, relations)
     val firstClassInvalidation: Set[String] = {
       val invalidated =
-        if (invalidateTransitively) {
-          // Invalidate by brute force (normally happens when we've done more than 3 incremental runs)
-          IncrementalCommon.transitiveDeps(initial, log)(dependsOnClass)
-        } else {
-          changes.apiChanges.flatMap(invalidateClassesInternally(relations, _, isScalaClass)).toSet
-        }
-      val included = includeTransitiveInitialInvalidations(initial, invalidated, dependsOnClass)
-      log.debug("Final step, transitive dependencies:\n\t" + included)
-      included
+        changes.apiChanges.flatMap(invalidateClassesInternally(relations, _, isScalaClass)).toSet
+      includeTransitiveInitialInvalidations(initial, invalidated, dependsOnClass)
     }
+    log.debug("Final step, transitive dependencies:\n\t" + firstClassInvalidation)
 
     // Invalidate classes linked with a class file that is produced by more than one source file
     val secondClassInvalidation = IncrementalCommon.invalidateNamesProducingSameClassFile(relations)
@@ -506,7 +500,13 @@ private[inc] abstract class IncrementalCommon(
       Set.empty
     } else {
       if (invalidateTransitively) {
-        newInvalidations ++ recompiledClasses
+        val firstClassTransitiveInvalidation = includeTransitiveInitialInvalidations(
+          initial,
+          IncrementalCommon.transitiveDeps(initial, log)(dependsOnClass),
+          dependsOnClass
+        )
+        log.debug("Invalidate by brute force:\n\t" + firstClassTransitiveInvalidation)
+        firstClassTransitiveInvalidation ++ secondClassInvalidation ++ thirdClassInvalidation
       } else {
         firstClassInvalidation ++ secondClassInvalidation ++ thirdClassInvalidation
       }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
@@ -506,7 +506,7 @@ private[inc] abstract class IncrementalCommon(
           dependsOnClass
         )
         log.debug("Invalidate by brute force:\n\t" + firstClassTransitiveInvalidation)
-        firstClassTransitiveInvalidation ++ secondClassInvalidation ++ thirdClassInvalidation
+        firstClassTransitiveInvalidation ++ secondClassInvalidation ++ thirdClassInvalidation ++ recompiledClasses
       } else {
         firstClassInvalidation ++ secondClassInvalidation ++ thirdClassInvalidation
       }

--- a/zinc/src/sbt-test/source-dependencies/transitive-early-stopping/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/transitive-early-stopping/A.scala
@@ -1,0 +1,3 @@
+object A {
+  val a: Int = 0
+}

--- a/zinc/src/sbt-test/source-dependencies/transitive-early-stopping/B.scala
+++ b/zinc/src/sbt-test/source-dependencies/transitive-early-stopping/B.scala
@@ -1,0 +1,3 @@
+object B {
+  val b = A.a
+}

--- a/zinc/src/sbt-test/source-dependencies/transitive-early-stopping/C.scala
+++ b/zinc/src/sbt-test/source-dependencies/transitive-early-stopping/C.scala
@@ -1,0 +1,4 @@
+object C {
+  val c1 = B.b
+  val c2: Int = 0;
+}

--- a/zinc/src/sbt-test/source-dependencies/transitive-early-stopping/D.scala
+++ b/zinc/src/sbt-test/source-dependencies/transitive-early-stopping/D.scala
@@ -1,0 +1,3 @@
+object D {
+  val d: Int = C.c2
+}

--- a/zinc/src/sbt-test/source-dependencies/transitive-early-stopping/changes/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/transitive-early-stopping/changes/A.scala
@@ -1,0 +1,3 @@
+object A {
+  val a: String = ""
+}

--- a/zinc/src/sbt-test/source-dependencies/transitive-early-stopping/test
+++ b/zinc/src/sbt-test/source-dependencies/transitive-early-stopping/test
@@ -1,0 +1,5 @@
+> compile
+
+$ copy-file changes/A.scala A.scala
+> compile
+> checkIterations 4


### PR DESCRIPTION
### Issue

In https://github.com/sbt/zinc/issues/1396, the project takes 4 cycles to compile when transitive step is set to 3, yet the project only takes 3 cycles when transitive step is above 3.

This indicates transitive invalidation interferes with cycle stopping condition. Even though everything is complied by cycle 3, when `invalidateTransitively` flag is set, we enter cycle 4 regardless.

### Solution

In `invalidateAfterInternalCompilation`, we should use a non-transitive version of `firstClassInvalidation` to compute `newInvalidations`, while using a transitive version of `firstClassInvalidation` to compute all invalidations when `invalidateTransitively` flag is set.

### Testing

A scripted test is added. Without the PR it takes 5 iterations. With the PR it takes 4 iterations.