### PR TITLE
Increase default transitive step to `5`

### DIFF
--- a/internal/compiler-interface/src/main/contraband-java/xsbti/compile/IncOptions.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/compile/IncOptions.java
@@ -10,7 +10,7 @@ package xsbti.compile;
  */
 public final class IncOptions implements java.io.Serializable {
     public static int defaultTransitiveStep() {
-        return 3;
+        return 5;
     }
     public static double defaultRecompileAllFraction() {
         return 0.5;

--- a/internal/compiler-interface/src/main/contraband/incremental.contra
+++ b/internal/compiler-interface/src/main/contraband/incremental.contra
@@ -106,7 +106,7 @@ type IncOptions {
   @since("1.4.0")
 
   #x public static int defaultTransitiveStep() {
-  #x     return 3;
+  #x     return 5;
   #x }
   #x public static double defaultRecompileAllFraction() {
   #x     return 0.5;


### PR DESCRIPTION
### Issue

Transitive step is a mechanism intended to reduce overall zinc compile time by mass invalidating files once zinc enters too many cycles, under the assumption that when zinc enters many cycles, it would be faster to just mass invalidate instead of keeping the cycles going. We currently set transitive steps to 3 so zinc would mass invalidate after 3 cycles.

However evidences suggest that 3 is too small.

- https://github.com/JetBrains/intellij-scala/blob/9b5e23971d4d42ca6cecb59acfb66640507c2b3f/scala/compile-server/src/org/jetbrains/jps/incremental/scala/local/SbtCompiler.scala#L49
-  https://github.com/sbt/zinc/issues/1396#issuecomment-2354719327

### Solution

Similar to Intellij Scala Plugin, we raise the number of transitive steps to 5.