### PR TITLE
[1.x] Use `hashCode` instead of XOR hash in `extraHash` computation

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -886,7 +886,7 @@ private final class AnalysisCallback(
                 val externalParentsAPI = externalParents.map(analysis.apis.externalAPI)
                 val internalParentsAPI = internalParents.map(analysis.apis.internalAPI)
                 val parentsHashes = (externalParentsAPI ++ internalParentsAPI).map(_.extraHash())
-                parentsHashes.fold(currentExtraHash)(_ ^ _)
+                parentsHashes.hashCode
               case None => currentExtraHash
             }
           }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -886,7 +886,7 @@ private final class AnalysisCallback(
                 val externalParentsAPI = externalParents.map(analysis.apis.externalAPI)
                 val internalParentsAPI = internalParents.map(analysis.apis.internalAPI)
                 val parentsHashes = (externalParentsAPI ++ internalParentsAPI).map(_.extraHash())
-                parentsHashes.hashCode
+                (parentsHashes + currentExtraHash).hashCode()
               case None => currentExtraHash
             }
           }


### PR DESCRIPTION
### Issue

From #1399

> We use `parentsHashes.fold(currentExtraHash)(_ ^ _) ` which is a bad way to combine hashes together. If we use XOR to combine different hashes, identical hashes gets cancelled out. Since we are doing hierarchical hashing here I have a concern that such cancellation would happen.

Also nowhere else in Zinc codebase do we use XOR to combine hashes, so there is also a consistency issue.

### Fix

Replace XOR with `hashCode`.

