### PR TITLE
[2.x] Run `AnalysisFormatBenchmark` during CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,18 +65,18 @@ jobs:
       shell: bash
       run: |
         sbt -v -Dfile.encoding=UTF-8 "-Dbenchmark.pattern=.*Shapeless.*" "runBenchmarks"
-    - name: Checkout Develop Branch (4, 5)
+    - name: Checkout Target Branch (4, 5)
       if: ${{ github.event_name == 'pull_request' && (matrix.jobtype == 4 || matrix.jobtype == 5) }}
       uses: actions/checkout@v4
       with:
         clean: false
-        ref: develop
-    - name: Benchmark (Scalac) against Develop Branch (4)
+        ref: ${{ github.event.pull_request.base.ref }}
+    - name: Benchmark (Scalac) against Target Branch (4)
       if: ${{ github.event_name == 'pull_request' && matrix.jobtype == 4 }}
       shell: bash
       run: |
         sbt -v -Dfile.encoding=UTF-8 "-Dbenchmark.pattern=.*Scalac.*" "zincBenchmarks3/Jmh/clean" "runBenchmarks"
-    - name: Benchmark (Shapeless) against Develop Branch (5)
+    - name: Benchmark (Shapeless) against Target Branch (5)
       if: ${{ github.event_name == 'pull_request' && matrix.jobtype == 5 }}
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
           - os: ubuntu-latest
             java: 21
             jobtype: 5
+          - os: ubuntu-latest
+            java: 21
+            jobtype: 6
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
@@ -65,8 +68,13 @@ jobs:
       shell: bash
       run: |
         sbt -v -Dfile.encoding=UTF-8 "-Dbenchmark.pattern=.*Shapeless.*" "runBenchmarks"
-    - name: Checkout Target Branch (4, 5)
-      if: ${{ github.event_name == 'pull_request' && (matrix.jobtype == 4 || matrix.jobtype == 5) }}
+    - name: Benchmark (AnalysisFormatBenchmark) (6)
+      if: ${{ matrix.jobtype == 6 }}
+      shell: bash
+      run: |
+        sbt -v -Dfile.encoding=UTF-8 "-Dbenchmark.pattern=.*AnalysisFormatBenchmark.*" "zincBenchmarks3/Jmh/clean" "runBenchmarks"
+    - name: Checkout Target Branch (4, 5, 6)
+      if: ${{ github.event_name == 'pull_request' && (matrix.jobtype == 4 || matrix.jobtype == 5 || matrix.jobtype == 6) }}
       uses: actions/checkout@v4
       with:
         clean: false
@@ -81,4 +89,8 @@ jobs:
       shell: bash
       run: |
         sbt -v -Dfile.encoding=UTF-8 "-Dbenchmark.pattern=.*Shapeless.*" "zincBenchmarks3/Jmh/clean" "runBenchmarks"
-        
+    - name: Benchmark (AnalysisFormatBenchmark) against Target Branch (6)
+      if: ${{ github.event_name == 'pull_request' && matrix.jobtype == 6 }}
+      shell: bash
+      run: |
+        sbt -v -Dfile.encoding=UTF-8 "-Dbenchmark.pattern=.*AnalysisFormatBenchmark.*" "zincBenchmarks3/Jmh/clean" "runBenchmarks"


### PR DESCRIPTION
With this PR

- `AnalysisFormatBenchmark` is run automatically during CI similar to other benchmarks.
- Benchmarks are run against PR target branch instead of hardcoded `1.10.x`/`develop` branch

