### PR TITLE
[1.x] Add missing condition for `AnalysisFormatBenchmark` CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
       run: |
         sbt -v -Dfile.encoding=UTF-8 "-Dbenchmark.pattern=.*Shapeless.*" "runBenchmarks"
     - name: Benchmark (AnalysisFormatBenchmark) against Target Branch (6)
-      if: ${{ matrix.jobtype == 6 }}
+      if: ${{ github.event_name == 'pull_request' && matrix.jobtype == 6 }}
       shell: bash
       run: |
         sbt -v -Dfile.encoding=UTF-8 "-Dbenchmark.pattern=.*AnalysisFormatBenchmark.*" "runBenchmarks"


### PR DESCRIPTION
#1408 missed a condition that cause  `AnalysisFormatBenchmark` to be run twice in [non-PR commits](https://github.com/sbt/zinc/actions/runs/11064554838/job/30742528750).

This PR adds back the condition.