### PR TITLE
[1.x] Add log for third class invalidation

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
@@ -492,6 +492,7 @@ private[inc] abstract class IncrementalCommon(
       val transitive = IncrementalCommon.transitiveDeps(recompiledClasses, log)(dependsOnClass)
       (transitive -- recompiledClasses).filter(analysis.apis.internalAPI(_).hasMacro)
     }
+    log.debug(s"Invalidated macros due to upstream dependencies change: ${thirdClassInvalidation}")
 
     val newInvalidations =
       (firstClassInvalidation -- recompiledClasses) ++ secondClassInvalidation ++ thirdClassInvalidation


### PR DESCRIPTION
In #1396 it took me a while to figure out why `net.gamatron.json.Schema` is invalidated. This is due to `thirdClassInvalidation` not logged.

This PR adds the missing log.