### PR TITLE
[1.x] Make `zinc-scripted` show up in IntelliJ

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -686,7 +686,6 @@ lazy val zincScripted = (projectMatrix in internalPath / "zinc-scripted")
   .enablePlugins(BuildInfoPlugin)
   .settings(
     baseSettings,
-    ideSkipProject := true, // otherwise IntelliJ complains
     publish / skip := true,
     name := "zinc Scripted",
     Compile / buildInfo := Nil, // Only generate build info for tests


### PR DESCRIPTION
This PR makes `zinc-scripted` show up in IntelliJ.

Previous attempt #1298 was blocked by https://github.com/sbt/zinc/pull/1298#discussion_r1443496016. This is unblocked as we no longer need the change in https://github.com/sbt/zinc/pull/1298#discussion_r1443496016 for the import to succeed.