### PR TITLE
[2.x] Fix compile errors in `zinc-scripted`

### DIFF
--- a/internal/zinc-scripted/src/test/scala/sbt/inc/ScriptedMain.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/inc/ScriptedMain.scala
@@ -31,12 +31,12 @@ object ScriptedMain {
 
   def detectScriptedTests(scriptedBase: File): Map[String, Set[String]] = {
     val scriptedFiles: NameFilter = ("test": NameFilter) | "pending"
-    val pairs = (scriptedBase * AllPassFilter * AllPassFilter * scriptedFiles).get.map { f =>
+    val pairs = (scriptedBase * AllPassFilter * AllPassFilter * scriptedFiles).get().map { f =>
       val p = f.getParentFile
       (p.getParentFile.getName, p.getName)
     }
 
-    pairs.groupBy(_._1).mapValues(_.map(_._2).toSet)
+    pairs.groupBy(_._1).view.mapValues(_.map(_._2).toSet).toMap
   }
 
   private def parseScripted(

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncScriptedRunner.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncScriptedRunner.scala
@@ -19,6 +19,7 @@ import sbt.io.IO
 import sbt.util.{ Level, Logger }
 
 import scala.collection.parallel.ParSeq
+import collection.parallel.CollectionsHaveToParArray
 import sbt.inc.ScriptedMain._
 
 object ScriptedRunnerImpl {

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/ScriptedTests.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/ScriptedTests.scala
@@ -53,8 +53,8 @@ final class ScriptedTests(
     // Test group and names may be file filters (like '*')
     val groupAndNameDirs = for {
       ScriptedTest(group, name) <- tests
-      groupDir <- resourceBaseDirectory.toFile.glob(group).get.map(_.toPath)
-      testDir <- groupDir.toFile.*(name).get.map(_.toPath)
+      groupDir <- resourceBaseDirectory.toFile.glob(group).get().map(_.toPath)
+      testDir <- groupDir.toFile.*(name).get().map(_.toPath)
     } yield (groupDir, testDir)
 
     val labelsAndDirs = groupAndNameDirs.map {
@@ -157,7 +157,7 @@ final class ScriptedTests(
           // Run the test and delete files (except global that holds local scala jars)
           val runTest = () => commonRunTest(label, batchTmpDir, handlers, runner, states, logger)
           val result = runOrHandleDisabled(label, batchTmpDir, runTest, logger)
-          IO.delete(batchTmpDir.toFile.*("*" -- "global").get)
+          IO.delete(batchTmpDir.toFile.*("*" -- "global").get())
           result
       }
     finally runner.cleanUpHandlers(seqHandlers, states)


### PR DESCRIPTION
This PR fixes all of the errors emitted by presentational compiler in `zinc-scripted`.

With the PR changes `zincScripted3 / Test / compile` now emit no compiler error.