### PR TITLE
[2.x] fix `filterKeys` and `mapValues` warnings

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/APIs.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/APIs.scala
@@ -86,7 +86,7 @@ private class MAPIs(
   def removeInternal(removeClasses: Iterable[String]): APIs =
     new MAPIs(internal -- removeClasses, external)
   def filterExt(keep: String => Boolean): APIs =
-    new MAPIs(internal, external.filterKeys(keep).toMap)
+    new MAPIs(internal, external.view.filterKeys(keep).toMap)
 
   def internalAPI(className: String) = getAPI(internal, className)
   def externalAPI(ext: String) = getAPI(external, ext)

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
@@ -352,13 +352,13 @@ private class MStamps(
       lib: VirtualFileRef => Boolean
   ): Stamps =
     new MStamps(
-      products.filterKeys(prod).toMap, {
+      products.view.filterKeys(prod).toMap, {
         val rs = removeSources.toSet
         Map(sources.toSeq.filter {
           case (file, stamp) => !rs(file)
         }: _*)
       },
-      libraries.filterKeys(lib).toMap
+      libraries.view.filterKeys(lib).toMap
     )
 
   def groupBy[K](
@@ -370,9 +370,9 @@ private class MStamps(
 
     val constFalse = (f: VirtualFileRef) => false
     def kStamps(k: K): Stamps = new MStamps(
-      products.filterKeys(prod.getOrElse(k, constFalse)).toMap,
+      products.view.filterKeys(prod.getOrElse(k, constFalse)).toMap,
       sourcesMap.getOrElse(k, Map.empty[VirtualFileRef, XStamp]),
-      libraries.filterKeys(lib.getOrElse(k, constFalse)).toMap
+      libraries.view.filterKeys(lib.getOrElse(k, constFalse)).toMap
     )
 
     (for (k <- prod.keySet ++ sourcesMap.keySet ++ lib.keySet) yield (k, kStamps(k))).toMap

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/consistent/ConsistentAnalysisFormat.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/consistent/ConsistentAnalysisFormat.scala
@@ -190,7 +190,7 @@ class ConsistentAnalysisFormat(val mappers: ReadWriteMappers, sort: Boolean) {
       writeMaybeSortedStringMap(
         out,
         n,
-        m.mapValues(_.withCompilationTimestamp(DefaultCompilationTimestamp))
+        m.view.mapValues(_.withCompilationTimestamp(DefaultCompilationTimestamp))
       ) { ac =>
         writeAnalyzedClass(out, ac, storeApis)
       }

--- a/internal/zinc-persist/src/test/scala/sbt/inc/AnalysisGenerators.scala
+++ b/internal/zinc-persist/src/test/scala/sbt/inc/AnalysisGenerators.scala
@@ -151,7 +151,7 @@ object AnalysisGenerators {
   val genFileVORefRelation = genVirtualFileRefRelation(unique(genFileVRef)) _
 
   def rel[A, B](a: Seq[A], b: Seq[B]): Relation[A, B] =
-    Relation.reconstruct(zipMap(a, b).mapValues(Set(_)).toMap)
+    Relation.reconstruct(zipMap(a, b).view.mapValues(Set(_)).toMap)
 
   def genStringStringRelation(num: Int): Gen[Relation[String, String]] =
     for {

--- a/internal/zinc-testing/src/main/scala/xsbti/TestCallback.scala
+++ b/internal/zinc-testing/src/main/scala/xsbti/TestCallback.scala
@@ -37,7 +37,7 @@ class TestCallback extends AnalysisCallback2 {
   val apis: scala.collection.mutable.Map[VirtualFileRef, Set[ClassLike]] =
     scala.collection.mutable.Map.empty
 
-  def usedNames = usedNamesAndScopes.mapValues(_.map(_.name))
+  def usedNames = usedNamesAndScopes.view.mapValues(_.map(_.name))
 
   override def startSource(source: File): Unit = ???
   override def startSource(source: VirtualFile): Unit = {
@@ -182,7 +182,7 @@ object TestCallback {
           acc.addBinding(key, value)
       }
       // convert all collections to immutable variants
-      multiMap.toMap.mapValues(_.toSet).toMap.withDefaultValue(Set.empty)
+      multiMap.toMap.view.mapValues(_.toSet).toMap.withDefaultValue(Set.empty)
     }
   }
 }


### PR DESCRIPTION
https://github.com/scala/scala/blob/01f25e8c7f27dd2e3040d7a5b2ba4a0a2c816b68/src/library/scala/collection/Map.scala#L267-L276