### PR TITLE
[2.x] replace deprecated `Traversable` and `TraversableOnce`

### DIFF
--- a/internal/zinc-apiinfo/src/main/scala/xsbt/api/HashAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/xsbt/api/HashAPI.scala
@@ -143,7 +143,7 @@ final class HashAPI private (
       i += 1
     }
   }
-  final def hashSymmetric[T](ts: TraversableOnce[T], hashF: T => Unit): Unit = {
+  final def hashSymmetric[T](ts: IterableOnce[T], hashF: T => Unit): Unit = {
     val current = hash
     val tsHash: Hash = ts match {
       case ts: collection.Iterable[T] =>
@@ -218,7 +218,7 @@ final class HashAPI private (
    *
    * NOTE: This method doesn't perform any filtering of passed definitions.
    */
-  def hashDefinitionsWithExtraHash(ds: TraversableOnce[Definition], extraHash: Hash): Unit = {
+  def hashDefinitionsWithExtraHash(ds: IterableOnce[Definition], extraHash: Hash): Unit = {
     def hashDefinitionCombined(d: Definition): Unit = {
       hashDefinition(d)
       extend(extraHash)

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Compilations.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Compilations.scala
@@ -30,7 +30,7 @@ trait Compilations extends ReadCompilations {
 object Compilations {
   val empty: Compilations = new MCompilations(Seq.empty)
   def of(s: Seq[Compilation]): Compilations = new MCompilations(s)
-  def merge(s: Traversable[Compilations]): Compilations =
+  def merge(s: Iterable[Compilations]): Compilations =
     of((s flatMap { _.allCompilations }).toSeq.distinct)
 }
 

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/SourceInfo.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/SourceInfo.scala
@@ -38,7 +38,7 @@ object SourceInfos {
   ): SourceInfo =
     new UnderlyingSourceInfo(reported, unreported, mainClasses)
 
-  def merge(infos: Traversable[SourceInfos]): SourceInfos =
+  def merge(infos: Iterable[SourceInfos]): SourceInfos =
     infos.foldLeft(SourceInfos.empty)(_ ++ _)
 
   def merge1(info1: SourceInfo, info2: SourceInfo) = {

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Stamp.scala
@@ -311,7 +311,7 @@ object Stamps {
   ): Stamps =
     new MStamps(products, sources, libraries)
 
-  def merge(stamps: Traversable[Stamps]): Stamps = stamps.foldLeft(Stamps.empty)(_ ++ _)
+  def merge(stamps: Iterable[Stamps]): Stamps = stamps.foldLeft(Stamps.empty)(_ ++ _)
 }
 
 private class MStamps(

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/text/FormatCommons.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/text/FormatCommons.scala
@@ -155,7 +155,7 @@ trait FormatCommons {
 
   protected def readMappedPairs[K, V](
       in: BufferedReader
-  )(expectedHeader: String, s2k: String => K, s2v: (K, String) => V): Traversable[(K, V)] = {
+  )(expectedHeader: String, s2k: String => K, s2v: (K, String) => V): Iterable[(K, V)] = {
     def toPair(s: String): (K, V) = {
       if (s == null) throw new EOFException
       val p = s.indexOf(" -> ")


### PR DESCRIPTION
https://github.com/scala/scala/blob/01f25e8c7f27dd2e3040d7a5b2ba4a0a2c816b68/src/library/scala/package.scala#L45-L53