### PR TITLE
[2.x] use `iterator` instead of deprecated `toIterator`

### DIFF
--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaders.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaders.scala
@@ -191,8 +191,8 @@ trait NativeCopyLoader extends ClassLoader {
 
   private[this] def findLibrary0(name: String): String = {
     val mappedName = System.mapLibraryName(name)
-    val explicit = explicitLibraries.toIterator.filter(_.getFileName.toString == mappedName)
-    val search = searchPaths.toIterator flatMap relativeLibrary(mappedName)
+    val explicit = explicitLibraries.iterator.filter(_.getFileName.toString == mappedName)
+    val search = searchPaths.iterator flatMap relativeLibrary(mappedName)
     val combined = explicit ++ search
     if (combined.hasNext) copy(combined.next()) else null
   }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Locate.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Locate.scala
@@ -49,7 +49,7 @@ object Locate {
       }
   }
   def find[S](name: String, gets: Stream[String => Either[Boolean, S]]): Either[Boolean, S] =
-    find[S](name, gets.toIterator)
+    find[S](name, gets.iterator)
 
   /**
    * Returns a function that searches the provided class path for

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/text/RelationsTextFormat.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/text/RelationsTextFormat.scala
@@ -82,7 +82,7 @@ trait RelationsTextFormat extends FormatCommons {
     def read(in: BufferedReader): Relations = {
       def readRelation[A, B](relDesc: Descriptor[A, B]): Map[A, Set[B]] = {
         import relDesc._
-        val items = readPairs(in)(header, keyMapper.read, valueMapper.read).toIterator
+        val items = readPairs(in)(header, keyMapper.read, valueMapper.read).iterator
         // Reconstruct the multi-map efficiently, using the writing strategy above
         val builder = Map.newBuilder[A, Set[B]]
         var currentKey = null.asInstanceOf[A]


### PR DESCRIPTION
https://github.com/scala/scala/blob/01f25e8c7f27dd2e3040d7a5b2ba4a0a2c816b68/src/library/scala/collection/IterableOnce.scala#L201-L202