### PR TITLE
[2.x] avoid deprecated eta-expand syntax

### DIFF
--- a/internal/zinc-apiinfo/src/main/scala/xsbt/api/HashAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/xsbt/api/HashAPI.scala
@@ -223,7 +223,7 @@ final class HashAPI private (
       hashDefinition(d)
       extend(extraHash)
     }
-    hashSymmetric(ds, hashDefinitionCombined _)
+    hashSymmetric(ds, hashDefinitionCombined)
   }
   def hashDefinition(d: Definition): Unit = {
     hashString(d.name)

--- a/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/ClassToAPISpecification.scala
+++ b/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/ClassToAPISpecification.scala
@@ -60,7 +60,7 @@ class ClassToAPISpecification extends UnitSpec {
     val (Seq(tempSrcFile), analysisCallback) =
       JavaCompilerForUnitTesting.compileJavaSrcs(src)(readAPI)
     val apis = analysisCallback.apis(tempSrcFile)
-    apis.groupBy(_.name).map((companions _).tupled).toSet
+    apis.groupBy(_.name).map(companions.tupled).toSet
   }
 
   private def companions(className: String, classes: Set[ClassLike]): Companions = {

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
@@ -184,7 +184,7 @@ private[inc] abstract class IncrementalCommon(
               newApiChanges,
               recompiledClasses,
               cycleNum >= options.transitiveStep,
-              IncrementalCommon.comesFromScalaSource(previous.relations, Some(analysis.relations)) _
+              IncrementalCommon.comesFromScalaSource(previous.relations, Some(analysis.relations))
             )
 
         // No matter what shouldDoIncrementalCompilation returns, we are not in fact going to
@@ -554,7 +554,7 @@ private[inc] abstract class IncrementalCommon(
     val byLibraryDep = changes.libraryDeps.flatMap(previous.usesLibrary)
     val byExtSrcDep = {
       // Invalidate changes
-      val isScalaSource = IncrementalCommon.comesFromScalaSource(previous) _
+      val isScalaSource = IncrementalCommon.comesFromScalaSource(previous)
       changes.external.apiChanges.iterator.flatMap { externalAPIChange =>
         invalidateClassesExternally(previous, externalAPIChange, isScalaSource)
       }.toSet

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalNameHashing.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalNameHashing.scala
@@ -43,7 +43,7 @@ private[inc] class IncrementalNameHashingCommon(
       relations: Relations,
       apis: APIs
   ): Set[String] = {
-    val findSubclasses = relations.inheritance.internal.reverse _
+    val findSubclasses = relations.inheritance.internal.reverse
     val invalidatedClassesAndCodefinedClasses = for {
       cls <- invalidatedClasses.iterator
       file <- relations.definesClass(cls).iterator
@@ -127,7 +127,7 @@ private[inc] class IncrementalNameHashingCommon(
   }
 
   private def invalidateByInheritance(relations: Relations, modified: String): Set[String] = {
-    val inheritanceDeps = relations.inheritance.internal.reverse _
+    val inheritanceDeps = relations.inheritance.internal.reverse
     log.debug(s"Invalidating (transitively) by inheritance from $modified...")
     val transitiveInheritance = transitiveDeps(Set(modified), log)(inheritanceDeps)
     log.debug("Invalidated by transitive inheritance dependency: " + transitiveInheritance)

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/text/FormatCommons.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/text/FormatCommons.scala
@@ -99,7 +99,7 @@ trait FormatCommons {
     val fmtStr = "%%0%dd".format(numDigits)
     // We only use this for relatively short seqs, so creating this extra map won't be a performance hit.
     val m: Map[String, T] = s.zipWithIndex.map(x => fmtStr.format(x._2) -> x._1).toMap
-    writeMap(out)(header, m, identity[String] _, t2s)
+    writeMap(out)(header, m, identity[String], t2s)
   }
 
   protected def writeMap[K, V](

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/text/TextAnalysisFormat.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/text/TextAnalysisFormat.scala
@@ -312,8 +312,8 @@ class TextAnalysisFormat(val mappers: ReadWriteMappers)
       val external = "external apis"
     }
 
-    val stringToAnalyzedClass = ObjectStringifier.stringToObj[AnalyzedClass] _
-    val analyzedClassToString = ObjectStringifier.objToString[AnalyzedClass] _
+    val stringToAnalyzedClass = ObjectStringifier.stringToObj[AnalyzedClass]
+    val analyzedClassToString = ObjectStringifier.objToString[AnalyzedClass]
 
     def write(out: Writer, apis: APIs): Unit = {
       writeMap(out)(
@@ -362,8 +362,8 @@ class TextAnalysisFormat(val mappers: ReadWriteMappers)
       val external = "external companions"
     }
 
-    val stringToCompanions = ObjectStringifier.stringToObj[Companions] _
-    val companionsToString = ObjectStringifier.objToString[Companions] _
+    val stringToCompanions = ObjectStringifier.stringToObj[Companions]
+    val companionsToString = ObjectStringifier.objToString[Companions]
 
     def write(out: Writer, apis: APIs): Unit = {
       val internal = apis.internal map { case (k, v) => k -> v.api }
@@ -405,8 +405,8 @@ class TextAnalysisFormat(val mappers: ReadWriteMappers)
       val infos = "source infos"
     }
 
-    val stringToSourceInfo = ObjectStringifier.stringToObj[SourceInfo] _
-    val sourceInfoToString = ObjectStringifier.objToString[SourceInfo] _
+    val stringToSourceInfo = ObjectStringifier.stringToObj[SourceInfo]
+    val sourceInfoToString = ObjectStringifier.objToString[SourceInfo]
 
     def write(out: Writer, infos: SourceInfos): Unit =
       writeMap(out)(
@@ -426,8 +426,8 @@ class TextAnalysisFormat(val mappers: ReadWriteMappers)
       val compilations = "compilations"
     }
 
-    val stringToCompilation = ObjectStringifier.stringToObj[Compilation] _
-    val compilationToString = ObjectStringifier.objToString[Compilation] _
+    val stringToCompilation = ObjectStringifier.stringToObj[Compilation]
+    val compilationToString = ObjectStringifier.objToString[Compilation]
 
     def write(out: Writer, compilations: Compilations): Unit =
       writeSeq(out)(Headers.compilations, Nil, compilationToString)
@@ -451,8 +451,8 @@ class TextAnalysisFormat(val mappers: ReadWriteMappers)
     private[this] val singleOutputMode = "single"
     private[this] val multipleOutputMode = "multiple"
 
-    val stringToFileHash = ObjectStringifier.stringToObj[FileHash] _
-    val fileHashToString = ObjectStringifier.objToString[FileHash] _
+    val stringToFileHash = ObjectStringifier.stringToObj[FileHash]
+    val fileHashToString = ObjectStringifier.objToString[FileHash]
 
     final val sourceDirMapper = Mapper(
       (str: String) => readMapper.mapSourceDir(Mapper.forPath.read(str)),

--- a/internal/zinc-persist/src/test/scala/sbt/inc/AnalysisGenerators.scala
+++ b/internal/zinc-persist/src/test/scala/sbt/inc/AnalysisGenerators.scala
@@ -147,8 +147,8 @@ object AnalysisGenerators {
       entries <- listOfN(srcs.length, containerOfN[Set, T](n, g))
     } yield Relation.reconstruct(zipMap(srcs, entries))
 
-  val genStringRelation = genVirtualFileRefRelation(unique(identifier)) _
-  val genFileVORefRelation = genVirtualFileRefRelation(unique(genFileVRef)) _
+  val genStringRelation = genVirtualFileRefRelation(unique(identifier))
+  val genFileVORefRelation = genVirtualFileRefRelation(unique(genFileVRef))
 
   def rel[A, B](a: Seq[A], b: Seq[B]): Relation[A, B] =
     Relation.reconstruct(zipMap(a, b).view.mapValues(Set(_)).toMap)


### PR DESCRIPTION
```
Welcome to Scala 3.5.1 (1.8.0_422, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.

scala> identity[Int] _
1 warning found
-- Warning: --------------------------------------------------------------------
1 |identity[Int] _
  |^^^^^^^^^^^^^^^
  |The syntax `<function> _` is no longer supported;
  |you can simply leave out the trailing ` _`
val res0: Int => Int = Lambda$1484/1170482099@6233c6c2
```