### PR TITLE
[1.x] Add 25 minute timeout for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   test:
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
A CI run ran for 4 hours due to `ParallelGZIPOutputStream` getting stuck.

This PR adds a limit that kills a run after 25 minutes.