### PR TITLE
[2.x] avoid deprecated collection.mutable.MultiMap

### DIFF
--- a/internal/zinc-testing/src/main/scala/xsbti/TestCallback.scala
+++ b/internal/zinc-testing/src/main/scala/xsbti/TestCallback.scala
@@ -175,11 +175,18 @@ object TestCallback {
     }
 
     private def pairsToMultiMap[A, B](pairs: Seq[(A, B)]): Map[A, Set[B]] = {
-      import scala.collection.mutable.{ HashMap, MultiMap }
-      val emptyMultiMap = new HashMap[A, scala.collection.mutable.Set[B]] with MultiMap[A, B]
-      val multiMap = pairs.foldLeft(emptyMultiMap) {
-        case (acc, (key, value)) =>
-          acc.addBinding(key, value)
+      import scala.collection.mutable.HashMap
+      val multiMap = HashMap.empty[A, scala.collection.mutable.Set[B]]
+      pairs.foreach {
+        case (key, value) =>
+          multiMap.get(key) match {
+            case None =>
+              val set = collection.mutable.Set.empty[B]
+              set += value
+              multiMap(key) = set
+            case Some(set) =>
+              set += value
+          }
       }
       // convert all collections to immutable variants
       multiMap.toMap.view.mapValues(_.toSet).toMap.withDefaultValue(Set.empty)


### PR DESCRIPTION
https://github.com/scala/scala/blob/v2.13.15/src/library/scala/collection/mutable/MultiMap.scala