### PR TITLE
[1.x] Fix CI `sbt: command not found`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
         distribution: temurin
         java-version: ${{ matrix.java }}
         cache: sbt
+    - name: Setup SBT
+      uses: sbt/setup-sbt@v1
     - name: Build and test (1)
       if: ${{ matrix.jobtype == 1 }}
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,9 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.base.ref }}
+    - name: Setup SBT
+      uses: sbt/setup-sbt@v1
+      if: ${{ github.event_name == 'pull_request' && (matrix.jobtype >= 4 && matrix.jobtype <= 6) }}
     - name: Benchmark (Scalac) against Target Branch (4)
       if: ${{ github.event_name == 'pull_request' && matrix.jobtype == 4 }}
       shell: bash

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -13,4 +13,5 @@ jobs:
     runs-on: ubuntu-latest # or windows-latest, or macOS-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: sbt/setup-sbt@v1
       - uses: scalacenter/sbt-dependency-submission@v3

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -2,7 +2,7 @@
 name: Submit Dependency Graph
 on:
   push:
-    branches: [1.10.x] # default branch of the project
+    branches: [1.10.x, develop] # default branch of the project
 permissions: {}
 jobs:
   submit-graph:


### PR DESCRIPTION
[Jobs](https://github.com/sbt/zinc/actions/runs/11260318815/job/31311247166) are failing with message

> bin/run-ci.sh: line 5: sbt: command not found

This PR manually installs sbt to address the issue.