### PR TITLE
[1.x] Handle parsing of non-problems in `JavaErrorParser`

### DIFF
--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavaErrorParser.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavaErrorParser.scala
@@ -270,10 +270,17 @@ class JavaErrorParser(relativeDir: File = new File(new File(".").getAbsolutePath
         ()
     }
 
+  val nonProblem: Parser[Unit] = {
+    val skipLine =
+      ("Loading source file" | "Constructing Javadoc information") ~ """[^\r\n]*(\r\n|\n)?""".r
+    rep(skipLine) ^^ (_ => ())
+  }
+
   val potentialProblem: Parser[Problem] =
     warningMessage | errorMessage | noteMessage | javacError | javacWarning
 
-  val javacOutput: Parser[Seq[Problem]] = rep(potentialProblem) <~ opt(outputSumamry)
+  val javacOutput: Parser[Seq[Problem]] =
+    nonProblem ~> rep(potentialProblem) <~ opt(outputSumamry)
 
   /**
    * Example:

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavaErrorParser.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/JavaErrorParser.scala
@@ -280,7 +280,7 @@ class JavaErrorParser(relativeDir: File = new File(new File(".").getAbsolutePath
     warningMessage | errorMessage | noteMessage | javacError | javacWarning
 
   val javacOutput: Parser[Seq[Problem]] =
-    nonProblem ~> rep(potentialProblem) <~ opt(outputSumamry)
+    opt(nonProblem) ~> rep(potentialProblem) <~ opt(outputSumamry)
 
   /**
    * Example:

--- a/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/javac/JavaErrorParserSpec.scala
+++ b/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/javac/JavaErrorParserSpec.scala
@@ -23,6 +23,7 @@ class JavaErrorParserSpec extends UnitSpec with Diagrams {
   "The JavaErrorParser" should "be able to parse Linux errors" in parseSampleLinux()
   it should "be able to parse windows file names" in parseWindowsFile()
   it should "be able to parse windows errors" in parseSampleWindows()
+  it should "be able to parse javac non-problems" in parseSampleNonProblem()
   it should "be able to parse javac warnings" in parseJavacWarning()
   it should "be able to parse javac errors" in parseSampleJavac()
   it should "register the position of errors" in parseErrorPosition()
@@ -45,6 +46,14 @@ class JavaErrorParserSpec extends UnitSpec with Diagrams {
 
     assert(problems.size == 1)
     problems(0).position.sourcePath.get shouldBe (windowsFile)
+  }
+
+  def parseSampleNonProblem() = {
+    val parser = new JavaErrorParser()
+    val logger = ConsoleLogger()
+    val problems = parser.parseProblems(sampleNonProblemMessage, logger)
+
+    assert(problems.size == 2)
   }
 
   def parseWindowsFile() = {
@@ -197,6 +206,21 @@ class JavaErrorParserSpec extends UnitSpec with Diagrams {
       |location: class Foo
       |return baz();
     """.stripMargin
+
+  def sampleNonProblemMessage =
+    raw"""
+       |Loading source file D:\Repos\zinc\internal\zinc-compile-core\target\jvm-2.13\test-classes\sbt\internal\inc\javac\test1.java...
+       |Constructing Javadoc information...
+       |D:\Repos\zinc\internal\zinc-compile-core\target\jvm-2.13\test-classes\sbt\internal\inc\javac\test1.java:14: error: class Test is public, should be declared in a file named Test.java
+       |public class Test {
+       |       ^
+       |D:\Repos\zinc\internal\zinc-compile-core\target\jvm-2.13\test-classes\sbt\internal\inc\javac\test1.java:15: error: cannot find symbol
+       |    public NotFound foo() { return 5; }
+       |           ^
+       |  symbol:   class NotFound
+       |  location: class Test
+       |2 errors
+    """.stripMargin.trim
 
   def sampleJavacWarning =
     "warning: [options] system modules path not set in conjunction with -source 17"


### PR DESCRIPTION
### Issue

`JavaErrorParser` assumes `javac` outputs start with a list of problems or notes. However in certain situations `javac` emits the following lines first

```
Loading source file D:\Repos\zinc\internal\zinc-compile-core\target\jvm-2.13\test-classes\sbt\internal\inc\javac\test1.java...
Constructing Javadoc information...
```

which is neither problems nor notes. The parser then gives up and parse nothing. Hence `JavaCompilerSpec` fails.

### Fix

We explicitly match for lines that start with "Loading source file" or "Constructing Javadoc information" and skip these lines before parsing problems / notes.

### Validating the fix

I tested on a Java 17 windows machine that emits the below during `JavaCompilerSpec` 

```
Loading source file D:\Repos\zinc\internal\zinc-compile-core\target\jvm-2.13\test-classes\sbt\internal\inc\javac\test1.java...
Constructing Javadoc information...
D:\Repos\zinc\internal\zinc-compile-core\target\jvm-2.13\test-classes\sbt\internal\inc\javac\test1.java:14: error: class Test is public, should be declared in a file named Test.java
public class Test {
       ^
D:\Repos\zinc\internal\zinc-compile-core\target\jvm-2.13\test-classes\sbt\internal\inc\javac\test1.java:15: error: cannot find symbol
    public NotFound foo() { return 5; }
           ^
  symbol:   class NotFound
  location: class Test
2 errors
```

The test passed locally.

Closes #1451