### PR TITLE
[2.x] Enable scripted test in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,7 @@ jobs:
       if: ${{ matrix.jobtype == 2 }}
       shell: bash
       run: |
-        sbt -v -Dfile.encoding=UTF-8 -Dsbt.supershell=never "Test/compile" "crossTestBridges" "zincRoot/test" 
-      # "zincScripted/Test/run"
+        sbt -v -Dfile.encoding=UTF-8 -Dsbt.supershell=never "Test/compile" "crossTestBridges" "zincRoot/test" "scripted"
     - name: Build and test (3)
       if: ${{ matrix.jobtype == 3 }}
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   test:
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:

--- a/bin/run-ci.sh
+++ b/bin/run-ci.sh
@@ -11,4 +11,4 @@ sbt -Dfile.encoding=UTF-8 \
   doc \
   crossTestBridges \
   test \
-  # scripted
+  scripted

--- a/build.sbt
+++ b/build.sbt
@@ -653,9 +653,6 @@ lazy val zincScripted = (projectMatrix in internalPath / "zinc-scripted")
     conflictWarning := ConflictWarning.disable,
   )
   .jvmPlatform(scalaVersions = scala3_only)
-  .configure(
-    _.dependsOn(compilerBridge210, compilerBridge211, compilerBridge212, compilerBridge213)
-  )
   .configure(addSbtUtilScripted)
 
 lazy val zincScripted3 = zincScripted.jvm(scala3)
@@ -703,4 +700,4 @@ def scriptedTask: Def.Initialize[InputTask[Unit]] = Def.inputTask {
     scriptedBufferLog.value,
     scriptedCompileToJar.value,
   )
-}
+}.dependsOn(publishBridges)


### PR DESCRIPTION
### Issue

When running `scripted` in sbt shell, the following error shows up

```
[error] stack trace is suppressed; run last zincScripted3 / update for the full output
[error] (zincScripted3 / update) sbt.librarymanagement.ResolveException: Error downloading org.scala-sbt:compiler-bridge_3:2.0.0-M2-SNAPSHOT
[error]   Not found
[error]   Not found
[error]   not found: /Users/jiahuitan/.ivy2/local/org.scala-sbt/compiler-bridge_3/2.0.0-M2-SNAPSHOT/ivys/ivy.xml
[error]   not found: https://repo1.maven.org/maven2/org/scala-sbt/compiler-bridge_3/2.0.0-M2-SNAPSHOT/compiler-bridge_3-2.0.0-M2-SNAPSHOT.pom
```
### Fix

By removing

```
.configure(
    _.dependsOn(compilerBridge210, compilerBridge211, compilerBridge212, compilerBridge213)
 )
```

sbt would no longer fetch nonexistent `org.scala-sbt/compiler-bridge_3`.

Then by letting `scripted` task depends on `publishBridges`, `ConstantBridgeProvider.fetchCompiledBridge` can then access `target` directory of `compilerBridge210, compilerBridge211, compilerBridge212, compilerBridge213`, which then pick the right directory by calling `ConstantBridgeProvider.bridgeOrBoom` and package the directory with the matching scala version as a jar with naming starting with`scriptedCompilerBridge-bin`, which then gets renamed to `target-bridge-$scalaVersion.jar` in `AbstractBridgeProviderTestkit.getCompilerBridge` and be loaded via `AnalyzingCompiler.getDualLoader`. 

### Comment

I actually don't know if this an actual fix or just a workaround as I still don't know why exactly sbt is fetching nonexistent `org.scala-sbt/compiler-bridge_3`. But nonetheless I feel scripted test is very important and even if this is just a workaround, we should merge it to unblock CI.