### PR TITLE
[1.x] Remove unnecessary `setup-sbt` call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.base.ref }}
-    - name: Setup SBT
-      uses: sbt/setup-sbt@v1
-      if: ${{ github.event_name == 'pull_request' && (matrix.jobtype >= 4 && matrix.jobtype <= 6) }}
     - name: Benchmark (Scalac) against Target Branch (4)
       if: ${{ github.event_name == 'pull_request' && matrix.jobtype == 4 }}
       shell: bash


### PR DESCRIPTION
With https://github.com/sbt/setup-sbt/pull/6 merged, the call is no longer needed