### PR TITLE
[1.x] Remove unused `java.util.zip.ZipError` import

### DIFF
--- a/internal/zinc-classfile/src/main/java/sbt/internal/inc/zip/ZipCentralDir.java
+++ b/internal/zinc-classfile/src/main/java/sbt/internal/inc/zip/ZipCentralDir.java
@@ -47,7 +47,6 @@ import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
-import java.util.zip.ZipError;
 import java.util.zip.ZipException;
 
 import static java.nio.file.StandardOpenOption.READ;


### PR DESCRIPTION
Closes #1385

In long term we probably need CI linting rule to deal with it. Maybe pass some arg to Scala compiler to tell it to warn / throw when encountering unused import.