### PR TITLE
[2.x] Remove `compilerVersionDependentScalacOptions`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,6 @@ def baseSettings: Seq[Setting[?]] = Seq(
   testFrameworks += new TestFramework("verify.runner.Framework"),
   compile / javacOptions ++= Seq("-Xlint", "-Xlint:-serial"),
   Test / publishArtifact := false,
-  scalacOptions ++= Seq("-YdisableFlatCpCaching"),
   scalacOptions += {
     scalaBinaryVersion.value match {
       case "2.10" | "2.11" =>
@@ -101,27 +100,6 @@ def baseSettings: Seq[Setting[?]] = Seq(
       .cross(CrossVersion.full)
   },
   ideSkipProject := scalaVersion.value != defaultScalaVersion,
-)
-
-def compilerVersionDependentScalacOptions: Seq[Setting[?]] = Seq(
-  scalacOptions := {
-    scalaBinaryVersion.value match {
-      case "2.12" | "2.13" =>
-        scalacOptions.value ++ List(
-          "-opt-inline-from:<sources>",
-          "-opt:l:inline",
-          "-Yopt-inline-heuristics:at-inline-annotated"
-        )
-      case _ =>
-        scalacOptions.value.filterNot(
-          Set(
-            "-Xfatal-warnings",
-            "-deprecation",
-            "-YdisableFlatCpCaching",
-          )
-        )
-    }
-  }
 )
 
 def addBaseSettingsAndTestDeps(p: Project): Project =
@@ -261,21 +239,11 @@ lazy val zincPersist = (projectMatrix in internalPath / "zinc-persist")
   .dependsOn(zincCore, zincCompileCore, zincCore % "test->test")
   .settings(
     name := "zinc Persist",
-    libraryDependencies += sbinary,
-    libraryDependencies ++= {
-      scalaPartialVersion.value match {
-        case Some((major, minor)) if major == 3 || minor >= 13 =>
-          List("org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4")
-        case _ =>
-          List()
-      }
-    },
+    libraryDependencies ++= List(
+      sbinary,
+      "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4",
+    ),
     compileOrder := sbt.CompileOrder.Mixed,
-    Compile / scalacOptions ++= (scalaVersion.value match {
-      case VersionNumber(Seq(2, 12, _*), _, _) =>
-        List("-Ywarn-unused:-imports,-locals,-implicits,-explicits,-privates")
-      case _ => Nil
-    }),
     Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat,
     mimaSettings,
     mimaBinaryIssueFilters ++= ZincBuildUtil.excludeInternalProblems,
@@ -319,17 +287,10 @@ lazy val zincCore = (projectMatrix in internalPath / "zinc-core")
       exclude[ReversedMissingMethodProblem]("xsbti.*"),
       exclude[MissingClassProblem]("xsbti.*"),
     ),
-    libraryDependencies ++= {
-      scalaPartialVersion.value match {
-        case Some((major, minor)) if major == 3 || minor >= 13 =>
-          List(
-            "org.scala-lang" % "scala-reflect" % scala213,
-            "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4"
-          )
-        case _ =>
-          List()
-      }
-    },
+    libraryDependencies ++= List(
+      "org.scala-lang" % "scala-reflect" % scala213,
+      "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4"
+    ),
   )
   .jvmPlatform(scalaVersions = scala3_only)
   .configure(addBaseSettingsAndTestDeps, addSbtIO, addSbtUtilLogging, addSbtUtilRelation)
@@ -397,8 +358,6 @@ lazy val compilerInterface = (projectMatrix in internalPath / "compiler-interfac
     baseSettings,
     name := "Compiler Interface",
     scalaVersion := scala3,
-    crossScalaVersions := Seq(scala3),
-    compilerVersionDependentScalacOptions,
     libraryDependencies ++= Seq(scalatest % Test),
     exportJars := true,
     Compile / resourceGenerators += Def.task {
@@ -466,7 +425,6 @@ lazy val compilerBridge = (projectMatrix in internalPath / "compiler-bridge")
       semanticdbEnabled.value && !scalaVersion.value.startsWith("2.10")
     },
     baseSettings,
-    compilerVersionDependentScalacOptions,
     // We need this for import Compat._
     Compile / scalacOptions --= Seq("-Ywarn-unused-import", "-Xfatal-warnings"),
     Compile / scalacOptions ++= (scalaVersion.value match {
@@ -520,7 +478,6 @@ lazy val compilerBridgeTest = (projectMatrix in internalPath / "compiler-bridge-
     name := "Compiler Bridge Test",
     baseSettings,
     scalaVersion := scala3,
-    compilerVersionDependentScalacOptions,
     // we need to fork because in unit tests we set usejavacp = true which means
     // we are expecting all of our dependencies to be on classpath so Scala compiler
     // can use them while constructing its own classpath for compilation
@@ -547,7 +504,6 @@ lazy val zincApiInfo = (projectMatrix in internalPath / "zinc-apiinfo")
   )
   .settings(
     name := "zinc ApiInfo",
-    compilerVersionDependentScalacOptions,
     mimaSettings,
     mimaBinaryIssueFilters ++= Seq(
       exclude[IncompatibleMethTypeProblem]("xsbt.api.HashAPI.hashTypeParameters"),
@@ -581,7 +537,6 @@ lazy val zincClasspath = (projectMatrix in internalPath / "zinc-classpath")
   .dependsOn(compilerInterface)
   .settings(
     name := "zinc Classpath",
-    compilerVersionDependentScalacOptions,
     libraryDependencies ++= Seq(
       // scalaCompiler.value,
       launcherInterface
@@ -614,7 +569,6 @@ lazy val zincClassfile = (projectMatrix in internalPath / "zinc-classfile")
   .dependsOn(compilerInterface, zincTesting % Test)
   .settings(
     name := "zinc Classfile",
-    compilerVersionDependentScalacOptions,
     Compile / headerSources ~= { xs =>
       val excluded = Set("ZipCentralDir.java", "ZipConstants.java", "ZipUtils.java")
       xs filter { x =>


### PR DESCRIPTION
This PR removes `compilerVersionDependentScalacOptions` from `build.sbt` as Zinc 2.x no longer needs to cross build against Scala 2.

As result a bunch more compiler deprecation warnings are surfaced in CI. For example

```
[warn] -- Deprecation Warning: /home/runner/work/zinc/zinc/internal/zinc-classpath/src/main/scala/sbt/internal/inc/ReflectUtilities.scala:38:29 
[warn] 38 |  def fields(clazz: Class[?]) =
[warn]    |                             ^
[warn]    |class OpenHashMap in package scala.collection.mutable is deprecated since 2.13.0: Use HashMap or one of the specialized versions (LongMap, AnyRefMap) instead of OpenHashMap
```
(https://github.com/sbt/zinc/actions/runs/11399506018/job/31718419535)

Is not seen in the latest `develop` [CI run](https://github.com/sbt/zinc/actions/runs/11351881814/job/31573430378).

Closes #1467
