### PR TITLE
[1.x] avoid deprecated `mutable.OpenHashMap`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,9 @@ def mimaSettings: Seq[Setting[?]] = Seq(
       "1.5.0",
       "1.6.0",
       "1.7.0",
+      "1.8.0",
+      "1.9.0",
+      "1.10.0",
     )
     val versions =
       if (scalaVersion.value.startsWith("2.12.")) pre140 ++ post140

--- a/build.sbt
+++ b/build.sbt
@@ -641,6 +641,9 @@ lazy val zincClasspath = (projectMatrix in internalPath / "zinc-classpath")
       exclude[IncompatibleResultTypeProblem](
         "sbt.internal.inc.classpath.NativeCopyConfig.*"
       ),
+      exclude[IncompatibleResultTypeProblem](
+        "sbt.internal.inc.ReflectUtilities.fields"
+      ),
       exclude[IncompatibleSignatureProblem](
         "sbt.internal.inc.classpath.NativeCopyConfig.*"
       ),

--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/ReflectUtilities.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/ReflectUtilities.scala
@@ -13,6 +13,7 @@ package sbt
 package internal
 package inc
 
+import java.lang.reflect.Field
 import scala.collection._
 
 object ReflectUtilities {
@@ -33,10 +34,10 @@ object ReflectUtilities {
 
   def ancestry(clazz: Class[?]): List[Class[?]] =
     if (clazz == classOf[AnyRef] || !classOf[AnyRef].isAssignableFrom(clazz)) List(clazz)
-    else clazz :: ancestry(clazz.getSuperclass);
+    else clazz :: ancestry(clazz.getSuperclass)
 
-  def fields(clazz: Class[?]) =
-    mutable.OpenHashMap(ancestry(clazz).flatMap(_.getDeclaredFields).map(f => (f.getName, f)): _*)
+  def fields(clazz: Class[?]): mutable.Map[String, Field] =
+    mutable.AnyRefMap(ancestry(clazz).flatMap(_.getDeclaredFields).map(f => (f.getName, f)): _*)
 
   /**
    * Collects all `val`s of type `T` defined on value `self`.


### PR DESCRIPTION
https://www.scala-lang.org/api/2.13.15/scala/collection/mutable/OpenHashMap.html