### PR TITLE
[1.x] Add check contraband sources consistency job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,8 @@ jobs:
       if: ${{ matrix.jobtype == 3 }}
       shell: bash
       run: |
-        sbt -v -Dfile.encoding=UTF-8 scalafmtCheckAll scalafmtSbtCheck
+        sbt -v -Dfile.encoding=UTF-8 scalafmtCheckAll scalafmtSbtCheck generateContrabands
+        git diff --exit-code
     - name: Benchmark (Scalac) (4)
       if: ${{ matrix.jobtype == 4 }}
       shell: bash


### PR DESCRIPTION
Ports https://github.com/sbt/sbt/pull/7778

### Validating the PR

I spawned a [CI job](https://github.com/Friendseeker/zinc/actions/runs/11420670104/job/31776641810) against a branch with inconsistent contraband sources. The job failed.