### PR TITLE
[1.x] Surface clear cache method for sbt#7868

### DIFF
--- a/internal/compiler-interface/src/main/java/xsbti/compile/AnalysisStore.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/AnalysisStore.java
@@ -100,6 +100,11 @@ public interface AnalysisStore {
      */
     void set(AnalysisContents analysisContents);
 
+    /**
+     * Resets in memory cached {@link AnalysisContents}
+     */
+    default void clearCache() {}
+
     final class CachedAnalysisStore implements AnalysisStore {
         private AnalysisStore underlying;
         private Optional<AnalysisContents> lastStore = Optional.empty();
@@ -121,6 +126,10 @@ public interface AnalysisStore {
             underlying.set(analysisContents);
             lastStore = Optional.of(analysisContents);
         }
+
+        public void clearCache() {
+            lastStore = Optional.empty();
+        }
     }
 
     final class SyncedAnalysisStore implements AnalysisStore {
@@ -139,6 +148,12 @@ public interface AnalysisStore {
         public void set(AnalysisContents analysisContents) {
             synchronized(this) {
                 underlying.set(analysisContents);
+            }
+        }
+
+        public void clearCache() {
+            if (underlying instanceof CachedAnalysisStore) {
+                underlying.clearCache();
             }
         }
     }


### PR DESCRIPTION
c.c. https://github.com/sbt/sbt/issues/7432#issuecomment-2453137349

> We should provide some mechanism to wipe out the history for previous compilation

This PR adds the necessary method in Zinc side to wipe in memory previous compilation.

The next step is for sbt side to invoke the new method (probably as a part of `sbt clean`?)