### PR TITLE
[1.x] Replace deprecated `mutable.AnyRefMap`

### DIFF
--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/ReflectUtilities.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/ReflectUtilities.scala
@@ -37,7 +37,7 @@ object ReflectUtilities {
     else clazz :: ancestry(clazz.getSuperclass)
 
   def fields(clazz: Class[?]): mutable.Map[String, Field] =
-    mutable.AnyRefMap(ancestry(clazz).flatMap(_.getDeclaredFields).map(f => (f.getName, f)): _*)
+    mutable.HashMap(ancestry(clazz).flatMap(_.getDeclaredFields).map(f => (f.getName, f)): _*)
 
   /**
    * Collects all `val`s of type `T` defined on value `self`.


### PR DESCRIPTION
`mutable.AnyRefMap` is on track top be deprecated in https://github.com/scala/scala/pull/10862. The recommended replacement is `mutable.Hashmap`