### PR TITLE
Ensure macro changes invalidate downstream classes

### DIFF
--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/consistent/ConsistentAnalysisFormat.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/consistent/ConsistentAnalysisFormat.scala
@@ -200,11 +200,7 @@ class ConsistentAnalysisFormat(val mappers: ReadWriteMappers, sort: Boolean) {
 
   private[this] def writeAPIs(out: Serializer, apis: APIs, storeApis: Boolean): Unit = {
     def write(n: String, m: Map[String, AnalyzedClass]): Unit =
-      writeMaybeSortedStringMap(
-        out,
-        n,
-        m.mapValues(_.withCompilationTimestamp(DefaultCompilationTimestamp))
-      ) { ac =>
+      writeMaybeSortedStringMap(out, n, m) { ac =>
         writeAnalyzedClass(out, ac, storeApis)
       }
     write("internal", apis.internal)


### PR DESCRIPTION
Given the following code:

```scala
object A {
  import scala.language.experimental.macros
  import scala.reflect.macros.blackbox.Context
  def a(c: Context)(): c.Tree = {
    import c.universe._
    q"1"
  }
}
class A {
  import scala.language.experimental.macros
  def a(): Int = macro A.a
}

class B {
  def b(): Int = new A().a()
}        
```

If `q"1"` is updated to `q"2"` then both A and B should be invalidated, but because the API of A hasn't changed, we need to rely on the timestamp to trigger a recompilation of B (in `IncrementalCommon.detectAPIChanges`). That means it's not safe to zero the timestamp when writing analysis.