### PR TITLE
[1.x] Let Scala Steward auto-update `com.google.protobuf`

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -2,9 +2,7 @@
 # either. hopefully this is a reasonable compromise value?
 pullRequests.frequency = "14 days"
 
-updates.ignore = [
-  # as per discussion on sbt/zinc#1236, this is
-  # "if it ain't broke don't fix it" territory
-  { groupId = "com.google.protobuf" },
-  { groupId = "org.eclipse.jgit" }
+updates.pin = [
+  { groupId = "com.google.protobuf", artifactId = "protobuf-java", version="3." },
+  { groupId = "org.eclipse.jgit", artifactId = "org.eclipse.jgit", version="6." }
 ]


### PR DESCRIPTION
Due to popularity of `com.google.protobuf`, CVE reports on `com.google.protobuf` are quite common. Sooner or later Zinc's current version of `com.google.protobuf` will be flagged again.

This needs further discussion but I wonder if we should auto update `com.google.protobuf`.

Previously we decided to opt-out of auto update `com.google.protobuf` due to [worry about regression](https://github.com/sbt/zinc/pull/1236#issuecomment-1677549707), but as we have experienced, sticking with the same `com.google.protobuf` version can also inevitably cause Zinc to be [flagged by security software](https://github.com/sbt/zinc/issues/1442) for depending on a vulnerable dependency.

We also have really strong unit tests for serialization / deserialization that minimizes the risk of regression. For instance our CI caught several issues related to Consistent Analysis Format, including an [intermittent deadlock issue](https://github.com/sbt/zinc/pull/1456).