### PR TITLE
[1.x] Use provided logger instead of `xsbt.Log.debug`

### DIFF
--- a/zinc/src/main/scala/sbt/internal/inc/javac/AnalyzingJavaCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/javac/AnalyzingJavaCompiler.scala
@@ -32,7 +32,6 @@ import xsbti.{
 
 import sbt.util.InterfaceUtil
 import sbt.util.Logger
-import xsbt.Log.debug
 
 /**
  * Define a Java compiler that reports on any discovered source dependencies or
@@ -169,7 +168,7 @@ final class AnalyzingJavaCompiler private[sbt] (
         ).toArray
         val javaSources: Array[VirtualFile] =
           sources.sortBy(_.id).toArray
-        debug(log, prettyPrintCompilationArguments(args))
+        log.debug(InterfaceUtil.toSupplier(prettyPrintCompilationArguments(args)))
         val success =
           javac.run(javaSources, args, output, incToolOptions, reporter, log)
         if (!success) {


### PR DESCRIPTION
Addresses https://github.com/sbt/zinc/pull/1497#discussion_r1886437745