### PR TITLE
[1.x] Add scripted test for #1507

### DIFF
--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -225,6 +225,9 @@ class IncHandler(directory: Path, cacheDir: Path, scriptedLog: ManagedLogger, co
     onArgs("checkIterations") {
       case (p, x :: Nil, i) => p.checkNumberOfCompilerIterations(i, x.toInt)
     },
+    onArgs("checkNumberOfLibraries") {
+      case (p, x :: Nil, i) => p.checkNumberOfLibraries(i, x.toInt)
+    },
     onArgs("checkCycles") {
       case (p, x :: Nil, i) => p.checkNumberOfCycles(i, x.toInt)
     },
@@ -522,6 +525,14 @@ case class ProjectStructure(
   def checkNameExistsInClass(i: IncState, className: String, name: String): Future[Unit] =
     compile(i).map[Unit] { analysis =>
       assert(analysis.apis.externalAPI(className).nameHashes.exists(_.name == name))
+      ()
+    }
+
+  def checkNumberOfLibraries(i: IncState, expected: Int): Future[Unit] =
+    compile(i).map { analysis =>
+      val count = analysis.stamps.libraries.size
+      val msg = s"analysis.stamps.libraries.size = $count (expected $expected)"
+      assert(count == expected, msg)
       ()
     }
 

--- a/zinc/src/sbt-test/source-dependencies/anon-class-dep/A/Refined.scala
+++ b/zinc/src/sbt-test/source-dependencies/anon-class-dep/A/Refined.scala
@@ -1,0 +1,8 @@
+package A
+
+class SRC[_]
+class Refined {
+  def select() = new {
+    def using(opt: Option[SRC[_]] => Some[SRC[_]]) = opt
+  }
+}

--- a/zinc/src/sbt-test/source-dependencies/anon-class-dep/B/Client.scala
+++ b/zinc/src/sbt-test/source-dependencies/anon-class-dep/B/Client.scala
@@ -1,0 +1,7 @@
+package B
+
+import A.Refined
+
+class Client {
+  def temp = new Refined().select().using(null)
+}

--- a/zinc/src/sbt-test/source-dependencies/anon-class-dep/build.json
+++ b/zinc/src/sbt-test/source-dependencies/anon-class-dep/build.json
@@ -1,0 +1,15 @@
+{
+  "projects": [
+    {
+      "name": "B",
+      "dependsOn": [
+        "A"
+      ],
+      "scalaVersion": "2.13.x"
+    },
+    {
+      "name": "A",
+      "scalaVersion": "2.13.x"
+    }
+  ]
+}

--- a/zinc/src/sbt-test/source-dependencies/anon-class-dep/test
+++ b/zinc/src/sbt-test/source-dependencies/anon-class-dep/test
@@ -1,0 +1,2 @@
+> B/compile
+> B/checkNumberOfLibraries 1


### PR DESCRIPTION
Without #1507

```
[error] x source-dependencies/anon-class-dep
[error] sbt.internal.inc.BatchScriptRunner$PreciseScriptedError: {line 2} Command failed: 'B/checkNumberOfLibraries 1'
[error] Caused by: org.scalatest.exceptions.TestFailedException: 2 did not equal 1 analysis.stamps.libraries.size = 2 (expected 1)
```

With #1507
```
About to run tests:
 * source-dependencies/anon-class-dep

[info] + source-dependencies/anon-class-dep
```

