### PR TITLE
[1.x] Remove `generateVersionFile` from `ZincBuildUtil`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -456,10 +456,6 @@ lazy val compilerInterface = (projectMatrix in internalPath / "compiler-interfac
     libraryDependencies ++= Seq(scalaLibrary.value % Test),
     libraryDependencies ++= Seq(scalatest % Test),
     exportJars := true,
-    Compile / resourceGenerators += Def.task {
-      val a = (Compile / compile).value
-      generateVersionFile(version.value, resourceManaged.value, streams.value, a)
-    }.taskValue,
     Compile / generateContrabands / sourceManaged :=
       (internalPath / "compiler-interface" / "src" / "main" / "contraband-java").getAbsoluteFile,
     Compile / managedSourceDirectories += (Compile / generateContrabands / sourceManaged).value,

--- a/project/ZincBuildUtil.scala
+++ b/project/ZincBuildUtil.scala
@@ -1,42 +1,9 @@
 import sbt._
 import Keys._
-import xsbti.compile.CompileAnalysis
 
 object ZincBuildUtil {
   lazy val apiDefinitions = TaskKey[Seq[File]]("api-definitions")
   lazy val genTestResTask = TaskKey[Seq[File]]("gen-test-resources")
-
-  def lastCompilationTime(analysis0: CompileAnalysis): Long = {
-    val analysis = analysis0 match { case a: sbt.internal.inc.Analysis => a }
-    val lastCompilation = analysis.compilations.allCompilations.lastOption
-    lastCompilation.map(_.getStartTime) getOrElse 0L
-  }
-  def generateVersionFile(
-      version: String,
-      dir: File,
-      s: TaskStreams,
-      analysis0: CompileAnalysis
-  ): Seq[File] = {
-    import java.util.{ Date, TimeZone }
-    val analysis = analysis0 match { case a: sbt.internal.inc.Analysis => a }
-    val formatter = new java.text.SimpleDateFormat("yyyyMMdd'T'HHmmss")
-    formatter.setTimeZone(TimeZone.getTimeZone("GMT"))
-    val timestamp = formatter.format(new Date)
-    val content = versionLine(version) + "\ntimestamp=" + timestamp
-    val f = dir / "incrementalcompiler.version.properties"
-    // TODO: replace lastModified() with sbt.io.IO.getModifiedTimeOrZero(), once the build
-    // has been upgraded to a version of sbt that includes that call.
-    if (
-      !f.exists || f.lastModified < lastCompilationTime(analysis) || !containsVersion(f, version)
-    ) {
-      s.log.info("Writing version information to " + f + " :\n" + content)
-      IO.write(f, content)
-    }
-    f :: Nil
-  }
-  def versionLine(version: String): String = "version=" + version
-  def containsVersion(propFile: File, version: String): Boolean =
-    IO.read(propFile).contains(versionLine(version))
 
   def sampleProjectSettings(ext: String) =
     Seq(


### PR DESCRIPTION
### Issue

Currently `compiler-interface` jar on maven central is not reproducible. For example, https://repo1.maven.org/maven2/org/scala-sbt/compiler-interface/1.10.5/compiler-interface-1.10.5.jar contains a file `incrementalcompiler.version.properties`, which contains a build timestamp.

```
version=1.10.5
timestamp=20241130T035052
```

### Fix

We remove the `incrementalcompiler.version.properties` generation logic from Zinc.

### Note

`sbt` does use `incrementalcompiler.version.properties` in https://github.com/sbt/sbt/blob/1.10.x/zinc-lm-integration/src/main/scala/sbt/internal/inc/ZincComponentManager.scala, but since

- Only `sbt` reads from `incrementalcompiler.version.properties`, all other build tools don't
- Creation of `incrementalcompiler.version.properties` uses analysis timestamp, which will be erased by default in zinc 2.x

We should still proceed with the removal of `incrementalcompiler.version.properties` on zinc side, and also remove the usage of  `incrementalcompiler.version.properties` on `sbt` side.