### PR TITLE
[1.x] Local dependency invalidation improvement

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
@@ -506,8 +506,7 @@ private[inc] abstract class IncrementalCommon(
         val firstClassTransitiveInvalidation =
           IncrementalCommon.transitiveDeps(firstClassInvalidation, log)(dependsOnClass)
         log.debug("Invalidate by brute force:\n\t" + firstClassTransitiveInvalidation)
-        firstClassInvalidation ++ firstClassTransitiveInvalidation ++ secondClassInvalidation ++
-          thirdClassInvalidation ++ recompiledClasses
+        firstClassTransitiveInvalidation ++ secondClassInvalidation ++ thirdClassInvalidation ++ recompiledClasses
       } else {
         firstClassInvalidation ++ secondClassInvalidation ++ thirdClassInvalidation
       }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
@@ -98,7 +98,6 @@ private[inc] abstract class IncrementalCommon(
         invalidatedSources,
         classfileManager,
         pruned,
-        previous,
         classesToRecompile,
         profiler.registerCycle(
           invalidatedClasses,
@@ -149,11 +148,11 @@ private[inc] abstract class IncrementalCommon(
         invalidatedSources: Set[VirtualFile],
         classFileManager: XClassFileManager,
         pruned: Analysis,
-        override val previousAnalysis: Analysis,
         classesToRecompile: Set[String],
         registerCycle: (Set[String], APIChanges, Set[String], Boolean) => Unit
     ) extends IncrementalCallback(classFileManager) {
       override val isFullCompilation: Boolean = allSources.subsetOf(invalidatedSources)
+      override val previousAnalysis: Analysis = previous
       override val previousAnalysisPruned: Analysis = pruned
 
       override def mergeAndInvalidate(
@@ -165,10 +164,12 @@ private[inc] abstract class IncrementalCommon(
             partialAnalysis.copy(compilations = pruned.compilations ++ partialAnalysis.compilations)
           else pruned ++ partialAnalysis
 
-        // Represents classes detected as changed externally and internally (by a previous cycle)
+        // Represents all classes that were compiled as a result of external and internal invalidation (by a previous cycle)
         // Maps the changed sources by the user to class names we can count as invalidated
         val getClasses = (a: Analysis) => initialChangedSources.flatMap(a.relations.classNames)
-        val recompiledClasses = classesToRecompile ++ getClasses(previous) ++ getClasses(analysis)
+        val recompiledClasses = classesToRecompile ++
+          getClasses(previous) ++ getClasses(analysis) ++
+          invalidatedSources.flatMap(previous.relations.classNames)
 
         val newApiChanges =
           detectAPIChanges(recompiledClasses, previous.apis.internalAPI, analysis.apis.internalAPI)
@@ -499,13 +500,14 @@ private[inc] abstract class IncrementalCommon(
       Set.empty
     } else {
       if (invalidateTransitively) {
-        val firstClassTransitiveInvalidation = includeTransitiveInitialInvalidations(
-          initial,
-          IncrementalCommon.transitiveDeps(initial, log)(dependsOnClass),
-          dependsOnClass
-        )
+        // NOTE: As member reference relations do not include local relations, this invalidation will fully propagate
+        // thus we can't rely solely on `firstClassTransitiveInvalidation`. Better bet is to try to find transitive
+        // dependencies from result of `firstClassInvalidation`
+        val firstClassTransitiveInvalidation =
+          IncrementalCommon.transitiveDeps(firstClassInvalidation, log)(dependsOnClass)
         log.debug("Invalidate by brute force:\n\t" + firstClassTransitiveInvalidation)
-        firstClassTransitiveInvalidation ++ secondClassInvalidation ++ thirdClassInvalidation ++ recompiledClasses
+        firstClassInvalidation ++ firstClassTransitiveInvalidation ++ secondClassInvalidation ++
+          thirdClassInvalidation ++ recompiledClasses
       } else {
         firstClassInvalidation ++ secondClassInvalidation ++ thirdClassInvalidation
       }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Relations.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Relations.scala
@@ -184,13 +184,14 @@ trait Relations {
   private[inc] def externalDependencies: ExternalDependencies
 
   /**
-   * The class dependency relation between classes introduced by member reference.
+   * The class dependency relation between classes introduced by member reference excluding local references
    *
    * NOTE: All inheritance dependencies are included in this relation because in order to
    * inherit from a member you have to refer to it. If you check documentation of `inheritance`
    * you'll see that there's small oddity related to traits being the first parent of a
    * class/trait that results in additional parents being introduced due to normalization.
-   * This relation properly accounts for that so the invariant that `memberRef` is a superset
+   *
+   * Because `inheritance` includes local relations, `memberRef` is not a superset of `inheritance`
    * of `inheritance` is preserved.
    */
   private[inc] def memberRef: ClassDependencies

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Relations.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Relations.scala
@@ -184,15 +184,15 @@ trait Relations {
   private[inc] def externalDependencies: ExternalDependencies
 
   /**
-   * The class dependency relation between classes introduced by member reference excluding local references
+   * The class dependency relation between classes introduced
+   * by member reference excluding excluding same-source references.
    *
    * NOTE: All inheritance dependencies are included in this relation because in order to
    * inherit from a member you have to refer to it. If you check documentation of `inheritance`
    * you'll see that there's small oddity related to traits being the first parent of a
    * class/trait that results in additional parents being introduced due to normalization.
    *
-   * Because `inheritance` includes local relations, `memberRef` is not a superset of `inheritance`
-   * of `inheritance` is preserved.
+   * Because `inheritance` includes same-source references, `memberRef` is not a superset of `inheritance`
    */
   private[inc] def memberRef: ClassDependencies
 

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -810,7 +810,10 @@ case class ProjectStructure(
     import scala.collection.JavaConverters._
     val map = new java.util.HashMap[String, String]
     properties.asScala foreach { case (k: String, v: String) => map.put(k, v) }
-    val externalHooks = new DefaultExternalHooks(Optional.empty[ExternalHooks.Lookup], Optional.empty[XClassFileManager])
+    val externalHooks = new DefaultExternalHooks(
+      Optional.empty[ExternalHooks.Lookup],
+      Optional.empty[XClassFileManager]
+    )
       .withInvalidationProfiler(profiler)
     val base = IncOptions
       .of()

--- a/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation-trait/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation-trait/A.scala
@@ -1,0 +1,3 @@
+trait A {
+  def buildNonemptyObjects(a: Int): Int = a
+}

--- a/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation-trait/App.scala
+++ b/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation-trait/App.scala
@@ -1,0 +1,4 @@
+object Main extends App {
+  val x: C = new C { }
+  val z: Int = x.x
+}

--- a/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation-trait/B.scala
+++ b/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation-trait/B.scala
@@ -1,0 +1,6 @@
+trait C extends B {
+  def x = something
+}
+trait B extends A {
+  def something = buildNonemptyObjects(5)
+}

--- a/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation-trait/changes/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation-trait/changes/A.scala
@@ -1,0 +1,4 @@
+trait A {
+  // change return type Int => String
+  def buildNonemptyObjects(a: Int): String = ""
+}

--- a/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation-trait/changes/OriginalA.scala
+++ b/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation-trait/changes/OriginalA.scala
@@ -1,0 +1,3 @@
+trait A {
+  def buildNonemptyObjects(a: Int): Int = a
+}

--- a/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation-trait/changes/incOptions.properties
+++ b/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation-trait/changes/incOptions.properties
@@ -1,0 +1,1 @@
+transitiveStep = 3

--- a/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation-trait/incOptions.properties
+++ b/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation-trait/incOptions.properties
@@ -1,0 +1,1 @@
+transitiveStep = 1

--- a/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation-trait/test
+++ b/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation-trait/test
@@ -1,0 +1,21 @@
+#####################  FAILURE  ############################
+# clean build that compiles with transitiveStep = 1
+> compile
+
+# incremental build that should fail with transitiveStep = 1
+$ copy-file changes/A.scala A.scala
+-> compile
+
+#####################  FAILURE  ############################
+
+# rerun the test with transitiveStep = 3
+> clean
+$ copy-file changes/OriginalA.scala A.scala
+$ copy-file changes/incOptions.properties incOptions.properties
+
+# clean build that compiles with transitiveStep = 3
+> compile
+
+# incremental build that should fail with transitiveStep = 3
+$ copy-file changes/A.scala A.scala
+-> compile

--- a/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation/A.scala
@@ -1,0 +1,3 @@
+object A {
+  def buildNonemptyObjects(a: Int): Int = a
+}

--- a/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation/App.scala
+++ b/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation/App.scala
@@ -1,0 +1,3 @@
+object Main extends App {
+  val z: Int = C.x
+}

--- a/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation/B.scala
+++ b/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation/B.scala
@@ -1,0 +1,7 @@
+object C {
+  def x = B.something
+}
+
+object B {
+  def something = A.buildNonemptyObjects(5)
+}

--- a/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation/changes/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation/changes/A.scala
@@ -1,0 +1,4 @@
+object A {
+  // change return type Int => String
+  def buildNonemptyObjects(a: Int): String = ""
+}

--- a/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation/changes/OriginalA.scala
+++ b/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation/changes/OriginalA.scala
@@ -1,0 +1,3 @@
+object A {
+  def buildNonemptyObjects(a: Int): Int = a
+}

--- a/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation/changes/WorkingA.scala
+++ b/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation/changes/WorkingA.scala
@@ -1,0 +1,4 @@
+object A {
+  // add default param
+  def buildNonemptyObjects(a: Int, b: Int = 5): Int = a
+}

--- a/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation/changes/incOptions.properties
+++ b/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation/changes/incOptions.properties
@@ -1,0 +1,1 @@
+transitiveStep = 3

--- a/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation/incOptions.properties
+++ b/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation/incOptions.properties
@@ -1,0 +1,1 @@
+transitiveStep = 1

--- a/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation/test
+++ b/zinc/src/sbt-test/source-dependencies/same-source-transitive-invalidation/test
@@ -1,0 +1,33 @@
+#####################  SUCCESS  ############################
+# clean build that compiles with transitiveStep = 1
+> compile
+
+# incremental build that should work with transitiveStep = 1
+$ copy-file changes/WorkingA.scala A.scala
+> compile
+# > checkIterations 2 this is not yet working, but it should be 2
+
+#####################  FAILURE  ############################
+
+# clean build that compiles with transitiveStep = 1
+> clean
+$ copy-file changes/OriginalA.scala A.scala
+> compile
+
+# incremental build that should fail with transitiveStep = 1
+$ copy-file changes/A.scala A.scala
+-> compile
+
+#####################  FAILURE  ############################
+
+# rerun the test with transitiveStep = 3
+> clean
+$ copy-file changes/OriginalA.scala A.scala
+$ copy-file changes/incOptions.properties incOptions.properties
+
+# clean build that compiles with transitiveStep = 3
+> compile
+
+# incremental build that should fail with transitiveStep = 3
+$ copy-file changes/A.scala A.scala
+-> compile


### PR DESCRIPTION
Hello,
This is an attempt to fix undercompilation which can happen with local dependencies.

This PR is basically trying to solve 2 separate issues:
1. The invariant that `Relations.memberRef` is a superset of `Relations.inheritance` is no longer valid. https://github.com/sbt/zinc/blob/ea947ab20f4660f4e2acec541683bd05b34bd2eb/internal/zinc-core/src/main/scala/sbt/internal/inc/Relations.scala#L193-L194
https://github.com/sbt/zinc/blob/ea947ab20f4660f4e2acec541683bd05b34bd2eb/internal/compiler-bridge/src/main/scala/xsbt/Dependency.scala#L110-L125
Basically, since we don't include local dependencies in member references any more, we won't include local inheritance either, so the assumption is no longer true.
This leads to both local inheritance and local member reference to not invalidate correctly, which can be seen in both added test cases.
My attempt at solving this is to actually include all recompiled classes coming from the compilation unit at https://github.com/rochala/zinc/blob/8e6861fc77750b8acf484234ff07082a9785f940/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala#L170-L176
This allows us to include API changes for local dependencies and solves the first issue.
2. Because we don't include local dependencies in `Relations.memberRef` our logic for https://github.com/sbt/zinc/blob/ea947ab20f4660f4e2acec541683bd05b34bd2eb/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala#L502-L508 is not invalidating whole dependency tree. This can be improved a little by computing transitive dependencies based on `firstClassInvalidations` instead of `initialInvalidations`. This will be a bit more heavy to compute, but the result will be something that was in my intended in the first place. 
  Side note: We've actually identified infinite compilation happening, because it turns out that `firstClassTransitiveInvalidations` was not a subset of `firstClassInvalidations`, the reason why is the same as in point 1. The latter includes local inheritance, whereas the former does not.

After some internal testing, we've gone from 12 cycles to 4 in one problematic module. The reason of such high number of cycles was that we did not include local dependencies (and we had a lot of classes defined in a single source) thus they were not considered recompiled, while in fact they were.

Now the question time:
Q1. I see also another solution to those problems, we could try to meet the `membersRef` requirement and include local dependencies. This would also solve the issue with transitive invalidations. Do you know the reason why we ignored these kinds of dependencies ?
Q2. Right now, transitive invalidation may actually result in a lot more compilation happening (it actually recompiles all sources once again). Maybe a whole different approach should be considered, e.g. invalidate everything after 4th cycle or something.