### PR TITLE
[2.x] fix: Directory support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ ThisBuild / version := {
   nightlyVersion match {
     case Some(v) => v
     case _ =>
-      if ((ThisBuild / isSnapshot).value) "2.0.0-M3-SNAPSHOT"
+      if ((ThisBuild / isSnapshot).value) "2.0.0-M6-SNAPSHOT"
       else old
   }
 }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/MappedVirtualFile.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/MappedVirtualFile.scala
@@ -13,9 +13,11 @@ package sbt
 package internal
 package inc
 
-import java.io.InputStream
+import java.io.{ ByteArrayInputStream, InputStream }
+import java.nio.ByteBuffer
 import java.nio.file.{ Files, Path, Paths }
 import xsbti.{ BasicVirtualFileRef, FileConverter, PathBasedFile, VirtualFile, VirtualFileRef }
+import sbt.nio.file.{ FileTreeView, Glob, IsNotHidden, IsRegularFile, RecursiveGlob }
 
 class MappedVirtualFile(encodedPath: String, rootPathsMap: Map[String, Path])
     extends BasicVirtualFileRef(encodedPath)
@@ -40,8 +42,47 @@ object MappedVirtualFile {
   }
 }
 
+class MappedDirectory(
+    encodedPath: String,
+    rootPathsMap: Map[String, Path],
+    items: List[VirtualFile]
+) extends BasicVirtualFileRef(encodedPath)
+    with PathBasedFile {
+  private def path: Path = MappedVirtualFile.toPath(encodedPath, rootPathsMap)
+  override lazy val contentHash: Long = {
+    val buffer = ByteBuffer.allocate(java.lang.Long.BYTES * items.size)
+    val hashes = items.foreach { item =>
+      buffer.putLong(item.contentHash)
+    }
+    HashUtil.farmHash(buffer.array())
+  }
+  override lazy val sizeBytes: Long = items.map(_.sizeBytes).sum
+  override lazy val contentHashStr: String = {
+    val sb = new StringBuilder
+    val hashes = items.foreach { item =>
+      sb.append(item.contentHashStr)
+    }
+    val stream = new ByteArrayInputStream(hashes.toString.getBytes("UTF-8"))
+    HashUtil.sha256HashStr(stream)
+  }
+  override def input(): InputStream = ???
+  override def toPath: Path = path
+}
+
+object MappedDirectory {
+  def apply(
+      encodedPath: String,
+      rootPaths: Map[String, Path],
+      items: List[VirtualFile]
+  ): MappedDirectory =
+    new MappedDirectory(encodedPath, rootPaths, items)
+}
+
 class MappedFileConverter(rootPaths: Map[String, Path], allowMachinePath: Boolean)
     extends FileConverter {
+
+  import MappedFileConverter.view
+
   val rootPaths2: Seq[(String, Path)] = rootPaths.toSeq.flatMap {
     case (key, rootPath) =>
       if (rootPath.startsWith("/var/") || rootPath.startsWith("/tmp/")) {
@@ -56,9 +97,15 @@ class MappedFileConverter(rootPaths: Map[String, Path], allowMachinePath: Boolea
   }
 
   def toVirtualFile(path: Path): VirtualFile = {
+    def isDirectory: Boolean =
+      Files.isDirectory(path) || (!Files.exists(path) && path.getFileName.toString().endsWith(
+        "classes"
+      ))
     rootPaths2.find { case (_, rootPath) => path.startsWith(rootPath) } match {
       case Some((key, rootPath)) =>
-        MappedVirtualFile(s"$${$key}/${rootPath.relativize(path)}".replace('\\', '/'), rootPaths)
+        val encodedPath = s"$${$key}/${rootPath.relativize(path)}".replace('\\', '/')
+        if (isDirectory) toDirectory(path, encodedPath)
+        else MappedVirtualFile(encodedPath, rootPaths)
       case _ =>
         def isCtSym =
           path.getFileSystem
@@ -67,13 +114,26 @@ class MappedFileConverter(rootPaths: Map[String, Path], allowMachinePath: Boolea
         def isJrt = path.getFileSystem.provider().getScheme == "jrt"
         if (isJrt || path.getFileName.toString == "rt.jar" || isCtSym)
           DummyVirtualFile("rt.jar", path)
-        else if (allowMachinePath) MappedVirtualFile(s"$path".replace('\\', '/'), rootPaths)
-        else sys.error(s"$path cannot be mapped using the root paths $rootPaths")
+        else if (allowMachinePath) {
+          val encodedPath = s"$path".replace('\\', '/')
+          if (isDirectory) toDirectory(path, encodedPath)
+          else MappedVirtualFile(encodedPath, rootPaths)
+        } else sys.error(s"$path cannot be mapped using the root paths $rootPaths")
     }
+  }
+
+  def toDirectory(path: Path, encodedPath: String) = {
+    val list = view.list(Glob(path, RecursiveGlob), IsRegularFile && IsNotHidden)
+      .map(_._1)
+      .sortBy(x => x.toUri().toString())
+    val items = list.map(toVirtualFile)
+    MappedDirectory(encodedPath, rootPaths, items.toList)
   }
 }
 
 object MappedFileConverter {
+  private[sbt] lazy val view = FileTreeView.Ops(FileTreeView.default)
+
   def empty: MappedFileConverter = new MappedFileConverter(Map(), true)
   def apply(rootPaths: Map[String, Path], allowMachinePath: Boolean): MappedFileConverter =
     new MappedFileConverter(rootPaths, allowMachinePath)


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/issues/8244

## Problem
While it might be inefficient, we might need to set exportJars to false, and pass directories between the subprojects and Compile/Test configurations. Currently this fails at calculation of the input hash.

## Solution
This adds MappedDirectory to recursively calculate the file content hash and aggregate them.