### PR TITLE
avoid deprecated `AnyRefMap`

### DIFF
--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/ReflectUtilities.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/ReflectUtilities.scala
@@ -37,7 +37,7 @@ object ReflectUtilities {
     else clazz :: ancestry(clazz.getSuperclass)
 
   def fields(clazz: Class[?]): mutable.Map[String, Field] =
-    mutable.AnyRefMap(ancestry(clazz).flatMap(_.getDeclaredFields).map(f => (f.getName, f))*)
+    mutable.HashMap(ancestry(clazz).flatMap(_.getDeclaredFields).map(f => (f.getName, f))*)
 
   /**
    * Collects all `val`s of type `T` defined on value `self`.


### PR DESCRIPTION
- https://github.com/scala/scala/blob/98a15e637d5e8a5f14c8a0d6ee700cac0cfb6e29/src/library/scala/collection/mutable/AnyRefMap.scala#L45-L46
- https://github.com/scala/scala/commit/18eecfa8e9def4d41abaf8682bd25728bd478799