### PR TITLE
fix ZipCentralDir warning

### DIFF
--- a/internal/zinc-classfile/src/main/java/sbt/internal/inc/zip/ZipCentralDir.java
+++ b/internal/zinc-classfile/src/main/java/sbt/internal/inc/zip/ZipCentralDir.java
@@ -68,7 +68,7 @@ import static sbt.internal.inc.zip.ZipUtils.*;
  * for Straight to Jar but it does not work in place (has to recreate zips) and does
  * not allow to disable compression that makes it not efficient enough.
  */
-public class ZipCentralDir {
+public final class ZipCentralDir {
 
     private final byte[] cen; // CEN & ENDHDR
     private END end;


### PR DESCRIPTION
https://bugs.openjdk.org/browse/JDK-8299995

```
[warn] /home/runner/work/zinc/zinc/internal/zinc-classfile/src/main/java/sbt/internal/inc/zip/ZipCentralDir.java:86:28: possible 'this' escape before subclass is fully initialized
[warn] readEntries()
[warn]              ^
[warn] /home/runner/work/zinc/zinc/internal/zinc-classfile/src/main/java/sbt/internal/inc/zip/ZipCentralDir.java:122:36: previous possible 'this' escape happens here via invocation
[warn] Entry.readCEN(this, inode.pos)
[warn]                               ^
[warn] /home/runner/work/zinc/zinc/internal/zinc-classfile/src/main/java/sbt/internal/inc/zip/ZipCentralDir.java:486:35: previous possible 'this' escape happens here via invocation
[warn] new Entry().cen(zipfs, pos)
[warn]                            ^
[warn] /home/runner/work/zinc/zinc/internal/zinc-classfile/src/main/java/sbt/internal/inc/zip/ZipCentralDir.java:518:27: previous possible 'this' escape happens here via invocation
[warn] zipfs
[warn]      ^
```