### PR TITLE
fix `scala.reflect.Manifest` warning

### DIFF
--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/text/AnalyzedClassFormats.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/text/AnalyzedClassFormats.scala
@@ -15,15 +15,27 @@ import sbinary.DefaultProtocol._
 import sbinary._
 import sbt.internal.inc.APIs.emptyCompanions
 import sbt.internal.inc.Compilation
+import scala.reflect.ClassTag
 import xsbti.api.{ AnalyzedClass, NameHash, SafeLazyProxy }
 
 object AnalyzedClassFormats {
+  private def arrayFormat[T: ClassTag: Format] = new CollectionFormat[Array[T], T] {
+    def build(length: Int, ts: Iterator[T]) = {
+      val result = new Array[T](length)
+      ts.copyToArray(result, 0)
+      result
+    }
+    def size(a: Array[T]) = a.length
+    def foreach(a: Array[T])(f: T => Unit) = a.foreach(f)
+  }
+
   // This will throw out API information intentionally.
   def analyzedClassFormat(
       implicit
       ev0: Format[Compilation],
       ev1: Format[NameHash]
-  ): Format[AnalyzedClass] =
+  ): Format[AnalyzedClass] = {
+    given Format[Array[NameHash]] = arrayFormat[NameHash]
     wrap[AnalyzedClass, (Long, String, Int, Array[NameHash], Boolean, String)](
       a => (a.compilationTimestamp(), a.name, a.apiHash, a.nameHashes, a.hasMacro, a.provenance),
       (x: (Long, String, Int, Array[NameHash], Boolean, String)) =>
@@ -49,4 +61,5 @@ object AnalyzedClassFormats {
             )
         }
     )
+  }
 }


### PR DESCRIPTION
```
[warn] -- Deprecation Warning: /home/runner/work/zinc/zinc/internal/zinc-persist/src/main/scala/sbt/internal/inc/text/AnalyzedClassFormats.scala:51:5 
[warn] 51 |    )
[warn]    |     ^
[warn]    |Compiler synthesis of Manifest and OptManifest is deprecated, instead
[warn]    |replace with the type `scala.reflect.ClassTag[xsbti.api.NameHash]`.
[warn]    |Alternatively, consider using the new metaprogramming features of Scala 3,
[warn]    |see https://docs.scala-lang.org/scala3/reference/metaprogramming.html
```