### PR TITLE
Increase protobuf recursion limit to 200 (default is 100)

### DIFF
--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/FileAnalysisStore.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/FileAnalysisStore.scala
@@ -66,6 +66,7 @@ object FileAnalysisStore {
         Using.zipInputStream(new FileInputStream(file)) { inputStream =>
           lookupEntry(inputStream, analysisFileName)
           val reader = CodedInputStream.newInstance(inputStream)
+          reader.setRecursionLimit(200)
           val (analysis, miniSetup) = format.read(reader)
           val analysisWithAPIs = allCatch.opt {
             lookupEntry(inputStream, companionsFileName)


### PR DESCRIPTION
As [discussed on discord](https://discord.com/channels/632150470000902164/922600050989875282/1423706375799836753), I ran into an error that causes a project to always be recompiled after loading a new sbt session:

```
com.google.protobuf.InvalidProtocolBufferException: Protocol message had too many levels of nesting.  May be malicious.  Use setRecursionLimit() to increase the recursion depth limit.
```

The [default recursion limit is 100](https://github.com/protocolbuffers/protobuf/blob/main/java/core/src/main/java/com/google/protobuf/CodedInputStream.java#L43), so I chose to double it to 200.

