### PR TITLE
[1.x] Switch console to the allJars loader (Scala 3.8 REPL support)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ ThisBuild / version := {
   nightlyVersion match {
     case Some(v) => v
     case _ =>
-      if ((ThisBuild / isSnapshot).value) "1.11.0-SNAPSHOT"
+      if ((ThisBuild / isSnapshot).value) "1.12.0-SNAPSHOT"
       else old
   }
 }

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala
@@ -145,7 +145,7 @@ final class AnalyzingCompiler(
     val cp = classpath.map(converter.toPath)
     // hold reference to compiler bridge class loader to prevent its being evicted
     // from the compiler cache (sbt/zinc#914)
-    val loader = getDocLoader(log)
+    val loader = getAllJarLoader(log)
     loadService(classOf[ScaladocInterface2], loader) match {
       case Some(intf) =>
         val arguments =
@@ -192,7 +192,7 @@ final class AnalyzingCompiler(
     val values = values0.toArray[Any].asInstanceOf[Array[AnyRef]]
     // hold reference to compiler bridge class loader to prevent its being evicted
     // from the compiler cache (sbt/zinc#914)
-    val classLoader = getCompilerLoader(log)
+    val classLoader = getAllJarLoader(log)
 
     loadService(classOf[ConsoleInterface1], classLoader) match {
       case Some(intf) =>
@@ -343,7 +343,7 @@ final class AnalyzingCompiler(
     getDualLoader(scalaInstance.compilerJars.toList, scalaInstance.loaderCompilerOnly, log)
   }
 
-  private[this] def getDocLoader(log: Logger): ClassLoader =
+  private[this] def getAllJarLoader(log: Logger): ClassLoader =
     getDualLoader(scalaInstance.allJars.toList, scalaInstance.loader, log)
 
   private[this] def getDualLoader(


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/issues/8348

## Problem
Currently console entry point uses the compiler classloader for JIT optimization. Scala 3.8 split the repl into a different artifact, so we can no longer use the compiler classloader.

## Solution
Switch to using the full classloader.

## Test (with other changes)
<img width="870" height="98" alt="1__java" src="https://github.com/user-attachments/assets/9b607cfe-a4c2-4d05-840d-9d3c3b012898" />

cc @hamzaremmal
