### PR TITLE
fix: Use strict matching for scala-library jar detection

### DIFF
--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala
@@ -159,7 +159,8 @@ final class CompilerArguments(
 
   private val isScalaLibrary: Path => Boolean = file => {
     val name = file.getFileName.toString
-    name.contains(ArtifactInfo.ScalaLibraryID) ||
+    name == s"${ArtifactInfo.ScalaLibraryID}.jar" ||
+    name.startsWith(s"${ArtifactInfo.ScalaLibraryID}-") ||
     scalaInstance.libraryJars.exists(_.getName == name)
   }
 }


### PR DESCRIPTION
The previous check used contains("scala-library") which incorrectly matched any jar with that substring anywhere in the filename, causing user libraries named like "my-scala-library-foo" to be misclassified as the Scala standard library and filtered from the classpath.

Changed to use exact match (scala-library.jar) or prefix match (scala-library-*) to only match the actual Scala library jars.

Ref sbt/sbt#7511