### PR TITLE
Avoid calling expensive`.toUri.toString` and other micro-optimizations

### DIFF
--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/PlainVirtualFile.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/PlainVirtualFile.scala
@@ -18,7 +18,7 @@ import java.nio.file.{ Files, Path, Paths }
 import xsbti.{ BasicVirtualFileRef, FileConverter, PathBasedFile, VirtualFileRef, VirtualFile }
 
 class PlainVirtualFile(path: Path) extends BasicVirtualFileRef(path.toString) with PathBasedFile {
-  override def contentHash: Long = HashUtil.farmHash(path)
+  override lazy val contentHash: Long = HashUtil.farmHash(path)
   override def sizeBytes: Long = Files.size(path)
   override lazy val contentHashStr: String = HashUtil.sha256HashStr(input)
   override def name(): String = path.getFileName.toString

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/StringVirtualFile.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/StringVirtualFile.scala
@@ -20,7 +20,7 @@ import xsbti.{ BasicVirtualFileRef, VirtualFile }
 case class StringVirtualFile(path: String, content: String)
     extends BasicVirtualFileRef(path)
     with VirtualFile {
-  override def contentHash: Long = HashUtil.farmHash(content.getBytes("UTF-8"))
+  override lazy val contentHash: Long = HashUtil.farmHash(content.getBytes("UTF-8"))
   override def sizeBytes: Long = content.getBytes("UTF-8").size
   override lazy val contentHashStr: String = HashUtil.sha256HashStr(input)
   override def input: InputStream = new ByteArrayInputStream(content.getBytes("UTF-8"))

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/DummyVirtualFile.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/DummyVirtualFile.scala
@@ -23,7 +23,7 @@ import xsbti.{ BasicVirtualFileRef, VirtualFile }
 class DummyVirtualFile(encodedPath: String, path: Path)
     extends BasicVirtualFileRef(encodedPath)
     with VirtualFile {
-  override def contentHash: Long = HashUtil.farmHash(path)
+  override lazy val contentHash: Long = HashUtil.farmHash(path)
   override def sizeBytes: Long = Files.size(path)
   override lazy val contentHashStr: String = HashUtil.sha256HashStr(input)
   override def input(): InputStream = Files.newInputStream(path)

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/MappedVirtualFile.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/MappedVirtualFile.scala
@@ -125,7 +125,7 @@ class MappedFileConverter(rootPaths: Map[String, Path], allowMachinePath: Boolea
   def toDirectory(path: Path, encodedPath: String) = {
     val list = view.list(Glob(path, RecursiveGlob), IsRegularFile && IsNotHidden)
       .map(_._1)
-      .sortBy(x => x.toUri().toString())
+      .sorted
     val items = list.map(toVirtualFile)
     MappedDirectory(encodedPath, rootPaths, items.toList)
   }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/MappedVirtualFile.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/MappedVirtualFile.scala
@@ -23,7 +23,7 @@ class MappedVirtualFile(encodedPath: String, rootPathsMap: Map[String, Path])
     extends BasicVirtualFileRef(encodedPath)
     with PathBasedFile {
   private def path: Path = MappedVirtualFile.toPath(encodedPath, rootPathsMap)
-  override def contentHash: Long = HashUtil.farmHash(path)
+  override lazy val contentHash: Long = HashUtil.farmHash(path)
   override def sizeBytes: Long = Files.size(path)
   override lazy val contentHashStr: String = HashUtil.sha256HashStr(input)
   override def input(): InputStream = Files.newInputStream(path)
@@ -122,11 +122,25 @@ class MappedFileConverter(rootPaths: Map[String, Path], allowMachinePath: Boolea
     }
   }
 
+  // Optimized version that skips isDirectory check - use when path is known to be a regular file
+  private def toVirtualFileForRegularFile(path: Path): VirtualFile = {
+    rootPaths2.find { case (_, rootPath) => path.startsWith(rootPath) } match {
+      case Some((key, rootPath)) =>
+        val encodedPath = s"$${$key}/${rootPath.relativize(path)}".replace('\\', '/')
+        MappedVirtualFile(encodedPath, rootPaths)
+      case _ =>
+        if (allowMachinePath) {
+          val encodedPath = s"$path".replace('\\', '/')
+          MappedVirtualFile(encodedPath, rootPaths)
+        } else sys.error(s"$path cannot be mapped using the root paths $rootPaths")
+    }
+  }
+
   def toDirectory(path: Path, encodedPath: String) = {
     val list = view.list(Glob(path, RecursiveGlob), IsRegularFile && IsNotHidden)
       .map(_._1)
       .sorted
-    val items = list.map(toVirtualFile)
+    val items = list.map(toVirtualFileForRegularFile)
     MappedDirectory(encodedPath, rootPaths, items.toList)
   }
 }


### PR DESCRIPTION
Fixes https://github.com/sbt/zinc/issues/1628

This PR micro-optimizes the top three hotspots i found in the JProfiler profiles compiling the Netty codebase using Javac in Zinc in Mill

## sortBy 

 `.sortBy(x => x.toUri().toString())`  creates a new URI object and String for every comparison during the sort - that's O(n log n) object allocations, and it's blowing up the profile on the linked issue. `.sorted` instead uses Path's native `Comparable<Path>` implementation which compares paths directly without allocating objects.

Both produce deterministic ordering (which is what's needed for reproducible content hashes). The only semantic difference is the comparison method (lexicographic path comparison vs URI string comparison), but for the purpose of consistent hashing, both work.


## isDirectory

`toVirtualFile` called `Files.isDirectory()` on every file from filtered list. Added `toVirtualFileForRegularFile()` that skips the syscall sys we know it is already a regular file

## Caching contentHash

Changed all our `def contentHash`es to `lazy val`s. Looking at the code it seems to be safe - we re-create the file instances every time, and  when file metadata changes `ClasspathCache` creates a new `VirtualFile`. Furthermore, `contentHashStr` is already a `lazy val`, so it seems the code already assumes the files are re-created when changed and so it should be safe to cache the hashes


Manually tested this via `publishLocal` and manually reproducing the original workload in the linked issue, the performance seems to have gone back to previous levels and the profiler no longer shows `toURI` taking up 34% of CPU time, and the `isDirectory`  and `contentHash` hotspots each taking ~5% of CPU time dropped off the profiles as well. `./mill clean &&  time ./mill __.compile ` in the Netty codebase dropped from ~15s to ~8.5s