### PR TITLE
[2.x] fix: Support alternative Scala lib directories for scalaHome

### DIFF
--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/ScalaInstance.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/ScalaInstance.scala
@@ -268,8 +268,23 @@ object ScalaInstance {
   def allJars(scalaHome: File): Seq[File] =
     IO.listFiles(scalaLib(scalaHome)).toIndexedSeq.filter(f => !excludeList(f.getName))
 
-  private def scalaLib(scalaHome: File): File =
-    new File(scalaHome, "lib")
+  private def scalaLib(scalaHome: File): File = {
+    val candidates = Seq(
+      new File(scalaHome, "lib"),
+      new File(scalaHome, "build/pack/lib"),
+      new File(scalaHome, "dist/target/pack/lib")
+    )
+    candidates.find(d => d.isDirectory && hasScalaLibrary(d))
+      .getOrElse(new File(scalaHome, "lib"))
+  }
+
+  private def hasScalaLibrary(dir: File): Boolean = {
+    val files = Option(dir.listFiles()).getOrElse(Array.empty[File])
+    files.exists { f =>
+      val name = f.getName
+      name == "scala-library.jar" || name.startsWith("scala3-library_3")
+    }
+  }
 
   private val excludeList: Set[String] = Set(
     "scala-actors.jar",
@@ -283,8 +298,17 @@ object ScalaInstance {
   /** Get a scala artifact from a given directory. */
   def scalaJar(scalaHome: File, name: String) =
     new File(scalaLib(scalaHome), name)
-  private def libraryJar(scalaHome: File) =
-    scalaJar(scalaHome, "scala-library.jar")
+
+  private def libraryJar(scalaHome: File): File = {
+    val libDir = scalaLib(scalaHome)
+    val scala2Lib = new File(libDir, "scala-library.jar")
+    if (scala2Lib.exists()) scala2Lib
+    else {
+      val files = Option(libDir.listFiles()).getOrElse(Array.empty[File])
+      files.find(_.getName.startsWith("scala3-library_3"))
+        .getOrElse(scala2Lib)
+    }
+  }
 
   /** Gets the version of Scala in the compiler.properties file from the loader.*/
   private def actualVersion(scalaLoader: ClassLoader)(label: String) = {


### PR DESCRIPTION
# Fix scalaHome support for Scala 2.13/3 build directories

Fixes sbt/sbt#7477

## The Problem

When using `scalaHome` with a Scala checkout (e.g., for testing local Scala changes), sbt fails with:

```
[error] (scalaInstance) sbt.internal.inc.InvalidScalaInstance: Scala instance doesn't exist or is invalid: (library jar /path/to/scala/lib/scala-library.jar)
```

This happens because zinc expects Scala jars in `$scalaHome/lib/`, but:
- **Scala 2.13** builds from source put jars in `$scalaHome/build/pack/lib/` after running `dist/mkPack`
- **Scala 3** builds may put jars in `$scalaHome/dist/target/pack/lib/`

## The Fix

Update `ScalaInstance.scalaLib()` to check multiple candidate directories:
1. `lib/` (traditional/installed Scala)
2. `build/pack/lib/` (Scala 2.13 after `dist/mkPack`)
3. `dist/target/pack/lib/` (Scala 3 builds)

Also update `libraryJar()` to support both:
- Scala 2: `scala-library.jar`
- Scala 3: `scala3-library_3-*.jar`

## Testing

With this fix, the following now works without the symlink workaround:

```scala
scalaVersion := "2.13.12"
scalaHome := Some(file("/path/to/scala213-checkout"))
```

After running `dist/mkPack` in the Scala checkout, `sbt compile` and `sbt run` work correctly.
