### PR TITLE
Make `libraryClassName` relation deterministic under concurrency

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -744,7 +744,7 @@ private final class AnalysisCallback(
     // representative class name is picked for each binary avoiding non-deterministic output
     binaryClassName.updateWith(binary) {
       case Some(existing) if className.compareTo(existing) >= 0 => Some(existing)
-      case None                                                 => Some(className)
+      case _                                                    => Some(className)
     }
     add(libraryDeps, source, binary)
   }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -740,7 +740,14 @@ private final class AnalysisCallback(
       source: VirtualFileRef,
       context: DependencyContext
   ): Unit = {
-    binaryClassName.put(binary, className)
+    // The callback is invoked concurrently; "last write wins" makes output depend on
+    // scheduling and causes nondeterministic analysis serialization. Pick a stable
+    // representative class name per binary instead.
+    binaryClassName.updateWith(binary) {
+      case Some(existing) =>
+        if (className.compareTo(existing) < 0) Some(className) else Some(existing)
+      case None => Some(className)
+    }
     add(libraryDeps, source, binary)
   }
 

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -744,7 +744,7 @@ private final class AnalysisCallback(
     // representative class name is picked for each binary avoiding non-deterministic output
     binaryClassName.updateWith(binary) {
       case Some(existing) if className.compareTo(existing) >= 0 => Some(existing)
-      case None => Some(className)
+      case None                                                 => Some(className)
     }
     add(libraryDeps, source, binary)
   }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -740,12 +740,10 @@ private final class AnalysisCallback(
       source: VirtualFileRef,
       context: DependencyContext
   ): Unit = {
-    // The callback is invoked concurrently; "last write wins" makes output depend on
-    // scheduling and causes nondeterministic analysis serialization. Pick a stable
-    // representative class name per binary instead.
+    // Break ties via lexicographic ordering on the className, which ensures a stable
+    // representative class name is picked for each binary avoiding non-deterministic output
     binaryClassName.updateWith(binary) {
-      case Some(existing) =>
-        if (className.compareTo(existing) < 0) Some(className) else Some(existing)
+      case Some(existing) if className.compareTo(existing) >= 0 => Some(existing)
       case None => Some(className)
     }
     add(libraryDeps, source, binary)


### PR DESCRIPTION

Previously, Zinc could produce nondeterministic analysis output because `binaryClassName` used `put(binary, className)` from concurrent `externalLibraryDependency` callbacks. The final value depended on callback scheduling, so `binaryClassName` stores one representative class per binary JAR in a concurrent map, but representative selection was non-deterministic.

This PR replaces `put` with deterministic merge using `updateWith`, choosing the lexicographically smallest class name for each binary. `libraryClassName` only needs a stable representative class per binary for lookup/stamp checks; selecting a deterministic representative preserves behavior while removing scheduler dependence. This removes one source of nondeterminism in Zinc analysis serialization and downstream build cache hashes, which was blocking attempts at reproducible builds in Mill (e.g. https://github.com/com-lihaoyi/mill/pull/4642)