### PR TITLE
fix: Filter compiler plugin options from Scaladoc invocations

### DIFF
--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala
@@ -143,13 +143,15 @@ final class AnalyzingCompiler(
       reporter: Reporter
   ): Unit = {
     val cp = classpath.map(converter.toPath)
+    // Filter out compiler plugin options that are not understood by Scaladoc (sbt/sbt#8740)
+    val docOptions = AnalyzingCompiler.filterPluginOptions(options)
     // hold reference to compiler bridge class loader to prevent its being evicted
     // from the compiler cache (sbt/zinc#914)
     val loader = getAllJarLoader(log)
     loadService(classOf[ScaladocInterface2], loader) match {
       case Some(intf) =>
         val arguments =
-          compArgs.makeArguments(Nil, cp, Some(outputDirectory), options)
+          compArgs.makeArguments(Nil, cp, Some(outputDirectory), docOptions)
         onArgsHandler(arguments)
         intf.run(sources.toArray, arguments.toArray[String], log, reporter)
       case _ =>
@@ -157,7 +159,7 @@ final class AnalyzingCompiler(
           case Some(intf) =>
             val fileSources: Seq[Path] = sources.map(converter.toPath(_))
             val arguments =
-              compArgs.makeArguments(fileSources, cp, Some(outputDirectory), options)
+              compArgs.makeArguments(fileSources, cp, Some(outputDirectory), docOptions)
             onArgsHandler(arguments)
             intf.run(arguments.toArray[String], log, reporter)
           case _ =>
@@ -166,7 +168,7 @@ final class AnalyzingCompiler(
             val (bridge, bridgeClass) = bridgeInstance(scaladocBridgeClassName, loader)
             val fileSources: Seq[Path] = sources.map(converter.toPath(_))
             val arguments =
-              compArgs.makeArguments(fileSources, cp, Some(outputDirectory), options)
+              compArgs.makeArguments(fileSources, cp, Some(outputDirectory), docOptions)
             onArgsHandler(arguments)
             invoke(bridge, bridgeClass, "run", log)(
               classOf[Array[String]],
@@ -468,6 +470,14 @@ object AnalyzingCompiler {
 
   private def isSourceName(name: String): Boolean =
     name.endsWith(".scala") || name.endsWith(".java")
+
+  /** Filter out compiler plugin options not understood by Scaladoc. See sbt/sbt#8740. */
+  private[inc] def filterPluginOptions(options: Seq[String]): Seq[String] =
+    options.filterNot { opt =>
+      opt.startsWith("-Xplugin:") ||
+      opt.startsWith("-Xplugin-require:") ||
+      opt.startsWith("-P:")
+    }
 }
 
 private object IgnoreProgress extends CompileProgress

--- a/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/AnalyzingCompilerSpec.scala
+++ b/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/AnalyzingCompilerSpec.scala
@@ -1,0 +1,54 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package sbt.internal.inc
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class AnalyzingCompilerSpec extends AnyFlatSpec with Matchers {
+  "filterPluginOptions" should "remove -Xplugin: options" in {
+    val options = Seq("-deprecation", "-Xplugin:/path/to/semanticdb.jar", "-feature")
+    AnalyzingCompiler.filterPluginOptions(options) shouldBe Seq("-deprecation", "-feature")
+  }
+
+  it should "remove -Xplugin-require: options" in {
+    val options = Seq("-deprecation", "-Xplugin-require:semanticdb", "-feature")
+    AnalyzingCompiler.filterPluginOptions(options) shouldBe Seq("-deprecation", "-feature")
+  }
+
+  it should "remove -P: plugin options" in {
+    val options = Seq("-deprecation", "-P:semanticdb:targetroot:/tmp/target", "-feature")
+    AnalyzingCompiler.filterPluginOptions(options) shouldBe Seq("-deprecation", "-feature")
+  }
+
+  it should "remove all plugin-related options at once" in {
+    val options = Seq(
+      "-deprecation",
+      "-Xplugin:/path/to/semanticdb.jar",
+      "-Xplugin-require:semanticdb",
+      "-P:semanticdb:targetroot:/tmp/target",
+      "-feature",
+      "-Xplugin:/path/to/other-plugin.jar",
+      "-P:other-plugin:setting:value"
+    )
+    AnalyzingCompiler.filterPluginOptions(options) shouldBe Seq("-deprecation", "-feature")
+  }
+
+  it should "keep all options when no plugin options are present" in {
+    val options = Seq("-deprecation", "-feature", "-unchecked", "-Xlint")
+    AnalyzingCompiler.filterPluginOptions(options) shouldBe options
+  }
+
+  it should "handle empty options" in {
+    AnalyzingCompiler.filterPluginOptions(Seq.empty) shouldBe Seq.empty
+  }
+}


### PR DESCRIPTION
## Summary

- Filter out compiler plugin options (`-Xplugin:`, `-Xplugin-require:`, `-P:`) in `AnalyzingCompiler.doc()` before passing them to the Scaladoc bridge
- Fixes the root cause of scaladoc failures when compiler plugins (like semanticdb) are enabled
- Handles **all** compiler plugins generically, not just semanticdb

## Problem

When compiler plugins are active (e.g. `semanticdbEnabled := true`), their options leak into `scaladoc` invocations. Scaladoc does not understand these options and fails with errors like:

```
bad option: '-Xplugin:/path/to/semanticdb-scalac.jar'
```

This was reported in sbt/sbt#8740. The initial fix attempt in sbt/sbt#8760 filtered only semanticdb-specific options in `SemanticdbPlugin`, but as @eed3si9n pointed out, this should be fixed at the root cause in Zinc's `AnalyzingCompiler` to handle all compiler plugins.

## Solution

Added `AnalyzingCompiler.filterPluginOptions()` that strips compiler plugin options before they reach Scaladoc:
- `-Xplugin:` — plugin JAR paths
- `-Xplugin-require:` — plugin requirements
- `-P:` — plugin-specific options

This is similar in spirit to #1545 which also modified `MixedAnalyzingCompiler` to process `scalacOptions`.

## Test plan

- [x] Unit tests for `filterPluginOptions` covering all plugin option patterns
- [ ] Integration: `sbt doc` with `semanticdbEnabled := true` on Scala 2.12 and 3.x

Ref sbt/sbt#8740, sbt/sbt#8760

🤖 Generated with [Claude Code](https://claude.com/claude-code)