### PR TITLE
Fix old varargs splice syntax warnings

### DIFF
--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -103,14 +103,14 @@ class IncHandler(directory: Path, cacheDir: Path, scriptedLog: ManagedLogger, co
   val javaHome = Paths.get(sys.props("java.home"))
 
   val localCoursierCache: Map[String, Path] = Map(
-    List(
+    (List(
       "C_CACHE1" -> Paths.get(sys.props("user.home")).resolve(".coursier").resolve("cache"),
       "C_CACHE2" -> Paths.get(sys.props("user.home")).resolve(".cache").resolve("coursier"),
       "C_CACHE3" -> Paths.get(sys.props("user.home"), "Library/Caches/Coursier/v1")
     ) ++ sys.env
       .get("LOCALAPPDATA")
       .map(s => "C_CACHE4" -> Paths.get(s.replace('\\', '/'), "Coursier/cache/v1"))
-      .toList: _*
+      .toList)*
   )
   def rootPaths: Map[String, Path] =
     Map("BASE" -> directory, "SBT_BOOT" -> localBoot, "JAVA_HOME" -> javaHome) ++ localCoursierCache
@@ -610,9 +610,9 @@ case class ProjectStructure(
       if (exportPipelining) {
         // Initiate compilation
         val triggerDeps: Map[ProjectStructure, (Future[Analysis], Future[Boolean])] =
-          Map(dependsOnRef map { dep =>
+          Map(dependsOnRef.map { dep =>
             dep -> dep.startCompilation(i)
-          }: _*)
+          }*)
         val wholeDeps = Future.traverse(dependsOnRef) { dep =>
           triggerDeps(dep)._1.map(_ => dep.output)
         }


### PR DESCRIPTION
https://docs.scala-lang.org/scala3/reference/changed-features/vararg-splices.html

```
[warn] -- Warning: /home/runner/work/zinc/zinc/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala:113:15 
[warn] 113 |      .toList: _*
[warn]     |               ^
[warn]     |The syntax `x: _*` is no longer supported for vararg splices; use `x*` instead
[warn]     |This construct can be rewritten automatically under -rewrite -source 3.4-migration.
[warn] -- Warning: /home/runner/work/zinc/zinc/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala:615:13 
[warn] 615 |          }: _*)
[warn]     |             ^
[warn]     |The syntax `x: _*` is no longer supported for vararg splices; use `x*` instead
[warn]     |This construct can be rewritten automatically under -rewrite -source 3.4-migration.
```