### PR TITLE
Fix NoClassDefFoundError during analysis of inner classes

### DIFF
--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
@@ -213,7 +213,7 @@ object ClassToAPI {
         c.getConstructors.toIndexedSeq,
         constructorToDef(enclPkg)
       )
-    val classes = innerClassesOf(c, cf, cmap)
+    val classes = innerClassesFromClassfile(c, cf, cmap)
     val all = methods ++ fields ++ constructors ++ classes
     val parentJavaTypes = allSuperTypes(c)
     if (!Modifier.isPrivate(c.getModifiers))
@@ -229,28 +229,7 @@ object ClassToAPI {
     (staticStructure, instanceStructure)
   }
 
-  /** Uses reflection for inner classes, falling back to classfile parsing on error. sbt/sbt#117 */
-  private def innerClassesOf(
-      c: Class[?],
-      cf: => ClassFile,
-      cmap: ClassMap
-  ): Defs =
-    try
-      merge[Class[?]](
-        c,
-        c.getDeclaredClasses.toIndexedSeq,
-        c.getClasses.toIndexedSeq,
-        toDefinitions(cmap),
-        (_: Seq[Class[?]]).partition(isStatic),
-        _.getEnclosingClass != c
-      )
-    catch {
-      case e: (NoClassDefFoundError) =>
-        cmap.log.warn(s"Could not reflect on inner classes of ${c.getName}: $e")
-        cmap.log.warn(s"Falling back to classfile parsing")
-        innerClassesFromClassfile(c, cf, cmap)
-    }
-
+  /** Enumerates inner classes from the classfile instead of reflection. sbt/sbt#117 */
   private def innerClassesFromClassfile(
       c: Class[?],
       cf: => ClassFile,
@@ -259,30 +238,40 @@ object ClassToAPI {
     val cl = c.getClassLoader
     val name = c.getName
     val declaredClasses = new mutable.ArrayBuffer[Class[?]]()
-    val publicClasses = new mutable.ArrayBuffer[Class[?]]()
-    for (info <- cf.innerClasses) {
-      if (info.outerClassName == name) {
-        try {
-          val innerClass = cl.loadClass(info.innerClassName)
-          declaredClasses += innerClass
-          if (info.isPublic) {
-            publicClasses += innerClass
-          }
-        } catch {
-          case e: (ClassNotFoundException | NoClassDefFoundError) =>
-            cmap.log.warn(s"Could not load inner class ${info.innerClassName} of $name: $e")
-        }
-      }
+    val inheritedClasses = new mutable.ArrayBuffer[Class[?]]()
+    // direct inner classes from this class's classfile
+    for (info <- cf.innerClasses if info.outerClassName == name) {
+      loadInnerClass(cl, info, cmap.log).foreach(declaredClasses += _)
+    }
+    // inherited public inner classes from parent classfiles
+    for {
+      parent <- allSuperTypes(c).collect { case c: Class[?] => c }
+      parentCf = classFileForClass(parent)
+      info <- parentCf.innerClasses if info.outerClassName == parent.getName && info.isPublic
+    } {
+      loadInnerClass(cl, info, cmap.log).foreach(inheritedClasses += _)
     }
     merge[Class[?]](
       c,
       declaredClasses.toIndexedSeq,
-      publicClasses.toIndexedSeq,
+      (declaredClasses.filter(cls => Modifier.isPublic(cls.getModifiers)) ++ inheritedClasses).toIndexedSeq,
       toDefinitions(cmap),
       (_: Seq[Class[?]]).partition(isStatic),
       _.getEnclosingClass != c
     )
   }
+
+  private def loadInnerClass(
+      cl: ClassLoader,
+      info: classfile.InnerClassInfo,
+      log: Logger
+  ): Option[Class[?]] =
+    try Some(cl.loadClass(info.innerClassName))
+    catch {
+      case e: (ClassNotFoundException | NoClassDefFoundError) =>
+        log.warn(s"Could not load inner class ${info.innerClassName}: $e")
+        None
+    }
 
   /** TODO: over time, ClassToAPI should switch the majority of access to the classfile parser */
   private def classFileForClass(c: Class[?]): ClassFile =

--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
@@ -28,9 +28,10 @@ object ClassToAPI {
 
   // (api, public inherited classes)
   def process(
-      classes: Seq[Class[?]]
+      classes: Seq[Class[?]],
+      log: Logger = Logger.Null
   ): (Seq[api.ClassLike], Seq[String], Set[(Class[?], Class[?])]) = {
-    val cmap = emptyClassMap
+    val cmap = emptyClassMap(log)
     classes.foreach(toDefinitions(cmap)) // force recording of class definitions
     cmap.lz.toList
       .foreach(_.get()) // force thunks to ensure all inherited dependencies are recorded
@@ -66,7 +67,8 @@ object ClassToAPI {
       private[sbt] val inherited: mutable.Set[(Class[?], Class[?])],
       private[sbt] val lz: mutable.Buffer[xsbti.api.Lazy[?]],
       private[sbt] val allNonLocalClasses: mutable.Set[api.ClassLike],
-      private[sbt] val mainClasses: mutable.Set[String]
+      private[sbt] val mainClasses: mutable.Set[String],
+      private[sbt] val log: Logger
   ) {
     def clear(): Unit = {
       memo.clear()
@@ -74,13 +76,14 @@ object ClassToAPI {
       lz.clear()
     }
   }
-  def emptyClassMap: ClassMap =
+  def emptyClassMap(log: Logger = Logger.Null): ClassMap =
     new ClassMap(
       new mutable.HashMap,
       new mutable.HashSet,
       new mutable.ListBuffer,
       new mutable.HashSet,
-      new mutable.HashSet
+      new mutable.HashSet,
+      log
     )
 
   /**
@@ -210,14 +213,7 @@ object ClassToAPI {
         c.getConstructors.toIndexedSeq,
         constructorToDef(enclPkg)
       )
-    val classes = merge[Class[?]](
-      c,
-      c.getDeclaredClasses.toIndexedSeq,
-      c.getClasses.toIndexedSeq,
-      toDefinitions(cmap),
-      (_: Seq[Class[?]]).partition(isStatic),
-      _.getEnclosingClass != c
-    )
+    val classes = innerClassesOf(c, cf, cmap)
     val all = methods ++ fields ++ constructors ++ classes
     val parentJavaTypes = allSuperTypes(c)
     if (!Modifier.isPrivate(c.getModifiers))
@@ -231,6 +227,61 @@ object ClassToAPI {
       lzyS(all.staticInherited.toArray)
     )
     (staticStructure, instanceStructure)
+  }
+
+  /** Uses reflection for inner classes, falling back to classfile parsing on error. sbt/sbt#117 */
+  private def innerClassesOf(
+      c: Class[?],
+      cf: => ClassFile,
+      cmap: ClassMap
+  ): Defs =
+    try
+      merge[Class[?]](
+        c,
+        c.getDeclaredClasses.toIndexedSeq,
+        c.getClasses.toIndexedSeq,
+        toDefinitions(cmap),
+        (_: Seq[Class[?]]).partition(isStatic),
+        _.getEnclosingClass != c
+      )
+    catch {
+      case e: (NoClassDefFoundError) =>
+        cmap.log.warn(s"Could not reflect on inner classes of ${c.getName}: $e")
+        cmap.log.warn(s"Falling back to classfile parsing")
+        innerClassesFromClassfile(c, cf, cmap)
+    }
+
+  private def innerClassesFromClassfile(
+      c: Class[?],
+      cf: => ClassFile,
+      cmap: ClassMap
+  ): Defs = {
+    val cl = c.getClassLoader
+    val name = c.getName
+    val declaredClasses = new mutable.ArrayBuffer[Class[?]]()
+    val publicClasses = new mutable.ArrayBuffer[Class[?]]()
+    for (info <- cf.innerClasses) {
+      if (info.outerClassName == name) {
+        try {
+          val innerClass = cl.loadClass(info.innerClassName)
+          declaredClasses += innerClass
+          if (info.isPublic) {
+            publicClasses += innerClass
+          }
+        } catch {
+          case e: (ClassNotFoundException | NoClassDefFoundError) =>
+            cmap.log.warn(s"Could not load inner class ${info.innerClassName} of $name: $e")
+        }
+      }
+    }
+    merge[Class[?]](
+      c,
+      declaredClasses.toIndexedSeq,
+      publicClasses.toIndexedSeq,
+      toDefinitions(cmap),
+      (_: Seq[Class[?]]).partition(isStatic),
+      _.getEnclosingClass != c
+    )
   }
 
   /** TODO: over time, ClassToAPI should switch the majority of access to the classfile parser */

--- a/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/ClassToAPISpecification.scala
+++ b/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/ClassToAPISpecification.scala
@@ -13,7 +13,9 @@ package sbt
 package internal
 package inc
 
+import java.io.File
 import sbt.internal.inc.classfile.JavaCompilerForUnitTesting
+import sbt.io.IO
 import xsbti.{ AnalysisCallback, VirtualFileRef }
 import xsbti.api.{ ClassLike, ClassLikeDef, DefinitionType }
 
@@ -50,6 +52,52 @@ class ClassToAPISpecification extends UnitSpec {
       """.stripMargin
     val apis = extractApisFromSrc("A.java" -> src).map(c => c.name -> c).toMap
     assert(apis.keySet === Set("A", "A.B"))
+  }
+
+  // sbt/sbt#117
+  it should "not throw NoClassDefFoundError when inner class references missing type" in {
+    IO.withTemporaryDirectory { temp =>
+      val libDir = new File(temp, "lib")
+      val srcDir = new File(temp, "src")
+      libDir.mkdir()
+      srcDir.mkdir()
+
+      val missingFile = new File(temp, "Missing.java")
+      IO.write(missingFile, "public class Missing {}")
+      compileJava(Seq(missingFile), libDir, Seq.empty)
+
+      val outerFile = new File(temp, "Outer.java")
+      IO.write(
+        outerFile,
+        """|public class Outer {
+           |  public class Inner extends Missing {}
+           |  public void hello() {}
+           |}
+           |""".stripMargin
+      )
+      compileJava(Seq(outerFile), srcDir, Seq(libDir))
+
+      val classloader = new java.net.URLClassLoader(Array(srcDir.toURI.toURL), null)
+      val outerClass = classloader.loadClass("Outer")
+      val (apis, _, _) = ClassToAPI.process(Seq(outerClass))
+
+      val names = apis.map(_.name).toSet
+      assert(names.contains("Outer"))
+      assert(!names.contains("Outer.Inner"))
+    }
+  }
+
+  private def compileJava(files: Seq[File], outputDir: File, classpath: Seq[File]): Unit = {
+    import javax.tools.{ StandardLocation, ToolProvider }
+    import scala.jdk.CollectionConverters._
+    val compiler = ToolProvider.getSystemJavaCompiler()
+    val fileManager = compiler.getStandardFileManager(null, null, null)
+    fileManager.setLocation(StandardLocation.CLASS_OUTPUT, Seq(outputDir).asJava)
+    if (classpath.nonEmpty)
+      fileManager.setLocation(StandardLocation.CLASS_PATH, classpath.asJava)
+    val units = fileManager.getJavaFileObjectsFromFiles(files.asJava)
+    compiler.getTask(null, fileManager, null, null, null, units).call()
+    fileManager.close()
   }
 
   /**

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/ClassFile.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/ClassFile.scala
@@ -28,6 +28,7 @@ private[sbt] trait ClassFile {
   val methods: Array[FieldOrMethodInfo]
   val attributes: Array[AttributeInfo]
   def sourceFile: Option[String]
+  def innerClasses: Array[InnerClassInfo]
   def types: Set[String]
   def stringValue(a: AttributeInfo): String
 
@@ -95,8 +96,18 @@ private[sbt] final case class AttributeInfo(name: Option[String], value: Array[B
   def isNamed(s: String) = name.exists(s == _)
   def isSignature = isNamed("Signature")
   def isSourceFile = isNamed("SourceFile")
+  def isInnerClasses = isNamed("InnerClasses")
   def isRuntimeVisibleAnnotations = isNamed("RuntimeVisibleAnnotations")
   def isRuntimeInvisibleAnnotations = isNamed("RuntimeInvisibleAnnotations")
+}
+private[sbt] final case class InnerClassInfo(
+    accessFlags: Int,
+    innerName: Option[String],
+    innerClassName: String,
+    outerClassName: String
+) {
+  def isStatic = (accessFlags & ACC_STATIC) == ACC_STATIC
+  def isPublic = (accessFlags & ACC_PUBLIC) == ACC_PUBLIC
 }
 private[sbt] object Constants {
   final val ACC_STATIC = 0x0008

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Parser.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Parser.scala
@@ -17,7 +17,7 @@ package classfile
 import java.net.URL
 import java.nio.file.Files
 import java.nio.file.Path
-import java.io.{ BufferedInputStream, InputStream, File, DataInputStream }
+import java.io.{ BufferedInputStream, ByteArrayInputStream, InputStream, File, DataInputStream }
 
 import sbt.internal.io.ErrorHandling
 
@@ -79,6 +79,33 @@ private[sbt] object Parser {
       val methods = readFieldsOrMethods()
 
       val attributes = array(in.readUnsignedShort())(parseAttribute())
+
+      lazy val innerClasses: Array[InnerClassInfo] = {
+        attributes
+          .find(_.isInnerClasses)
+          .map(parseInnerClasses)
+          .getOrElse(Array.empty)
+      }
+
+      private def parseInnerClasses(a: AttributeInfo): Array[InnerClassInfo] = {
+        val bais = new ByteArrayInputStream(a.value)
+        val data = new DataInputStream(bais)
+        val numberOfClasses = data.readUnsignedShort()
+        Array.tabulate(numberOfClasses) { _ =>
+          val innerClassInfoIndex = data.readUnsignedShort()
+          val outerClassInfoIndex = data.readUnsignedShort()
+          val innerNameIndex = data.readUnsignedShort()
+          val innerClassAccessFlags = data.readUnsignedShort()
+          val innerName = if (innerNameIndex == 0) None else Some(toUTF8(innerNameIndex))
+          val innerCN =
+            if (innerClassInfoIndex == 0) ""
+            else getClassConstantName(innerClassInfoIndex)
+          val outerCN =
+            if (outerClassInfoIndex == 0) ""
+            else getClassConstantName(outerClassInfoIndex)
+          InnerClassInfo(innerClassAccessFlags, innerName, innerCN, outerCN)
+        }
+      }
 
       override lazy val sourceFile: Option[String] =
         for (sourceFileAttribute <- attributes.find(_.isSourceFile))

--- a/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/ParserSpecification.scala
+++ b/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/ParserSpecification.scala
@@ -42,4 +42,26 @@ class ParserSpecification extends UnitSpec {
       assert(classfile.types.nonEmpty)
     }
 
+  it should "parse InnerClasses attribute for AbstractMap.SimpleEntry" in {
+    val logger = ConsoleLogger()
+    val c = classOf[java.util.AbstractMap.SimpleEntry[String, String]]
+    val cf = Parser(sbt.io.IO.classfileLocation(c), logger)
+    val innerClasses = cf.innerClasses
+    assert(innerClasses.nonEmpty)
+    val self = innerClasses.find(_.innerClassName == "java.util.AbstractMap$SimpleEntry")
+    assert(self.isDefined)
+    assert(self.get.outerClassName == "java.util.AbstractMap")
+  }
+
+  it should "parse InnerClasses attribute for AbstractMap" in {
+    val logger = ConsoleLogger()
+    val c = classOf[java.util.AbstractMap[?, ?]]
+    val cf = Parser(sbt.io.IO.classfileLocation(c), logger)
+    val innerClasses = cf.innerClasses
+    val entry = innerClasses.find(_.innerClassName == "java.util.AbstractMap$SimpleEntry")
+    assert(entry.isDefined)
+    assert(entry.get.outerClassName == "java.util.AbstractMap")
+    assert(entry.get.isPublic)
+  }
+
 }

--- a/zinc/src/main/scala/sbt/internal/inc/javac/AnalyzingJavaCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/javac/AnalyzingJavaCompiler.scala
@@ -184,7 +184,7 @@ final class AnalyzingJavaCompiler private[sbt] (
 
       // Read the API information from [[Class]] to analyze dependencies.
       def readAPI(source: VirtualFileRef, classes: Seq[Class[?]]): Set[(String, String)] = {
-        val (apis, mainClasses, inherits) = ClassToAPI.process(classes)
+        val (apis, mainClasses, inherits) = ClassToAPI.process(classes, log)
         apis.foreach(callback.api(source, _))
         mainClasses.foreach(callback.mainClass(source, _))
         inherits.map {


### PR DESCRIPTION
## Summary

Fixes sbt/sbt#117 — the oldest open bug in sbt, filed July 22, 2011.

- **Problem**: `ClassToAPI` used Java reflection (`c.getClasses`, `c.getDeclaredClasses`) to discover inner classes during post-compile analysis. When an inner class references types not on the classpath (e.g., optional dependencies like JBoss VFS in Spring), these reflection calls throw `NoClassDefFoundError`, crashing compilation.
- **Fix**: Parse the classfile's `InnerClasses` attribute directly from bytecode instead of using reflection, and gracefully skip any inner classes that can't be loaded via the classloader.
- **Tests**: Added regression test that compiles a class with an inner class extending a type that's then removed from the classpath, verifying `ClassToAPI.process` succeeds. Also added parser-level tests for `InnerClasses` attribute parsing.

This is a revival of #516 by @eed3si9n, rebased onto the current codebase with the tests that were requested at the time.

## Changes

| File | What |
|------|------|
| `ClassFile.scala` | Add `innerClasses` to trait, `InnerClassInfo` case class, `isInnerClasses` on `AttributeInfo` |
| `Parser.scala` | Parse `InnerClasses` classfile attribute into `Array[InnerClassInfo]` |
| `ClassToAPI.scala` | Replace reflection-based inner class discovery with classfile-based approach + try-catch |
| `ParserSpecification.scala` | Tests for `InnerClasses` attribute parsing |
| `ClassToAPISpecification.scala` | Regression test for sbt/sbt#117 |

## Test plan

- [x] All existing `zincClassfile3/test` tests pass (26/26)
- [x] All existing `zincApiInfo3/test` tests pass (42/42), including existing inner class extraction tests
- [x] New regression test verifies `ClassToAPI.process` doesn't throw when inner class references a missing type
- [x] New parser tests verify correct extraction of `InnerClasses` attribute from JDK classes

🤖 Generated with [Claude Code](https://claude.com/claude-code)