### PR TITLE
Tighter scoping for virtual path replacement

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/MappedVirtualFile.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/MappedVirtualFile.scala
@@ -34,12 +34,17 @@ object MappedVirtualFile {
   def apply(encodedPath: String, rootPaths: Map[String, Path]): MappedVirtualFile =
     new MappedVirtualFile(encodedPath, rootPaths)
 
-  def toPath(encodedPath: String, rootPaths: Map[String, Path]): Path = {
+  private[inc] def toPathMapped[A](encodedPath: String, rootPaths: Map[String, Path])(
+      modifyResolvedPath: Path => A,
+      modifyOrigPath: String => A
+  ): A =
     rootPaths.toSeq.find { case (key, _) => encodedPath.startsWith(s"$${$key}/") } match {
-      case Some((key, p)) => p.resolve(encodedPath.stripPrefix(s"$${$key}/"))
-      case None           => Paths.get(encodedPath)
+      case Some((key, p)) => modifyResolvedPath(p.resolve(encodedPath.stripPrefix(s"$${$key}/")))
+      case None           => modifyOrigPath(encodedPath)
     }
-  }
+
+  def toPath(encodedPath: String, rootPaths: Map[String, Path]): Path =
+    toPathMapped(encodedPath, rootPaths)(identity, Paths.get(_))
 }
 
 class MappedDirectory(
@@ -78,7 +83,7 @@ object MappedDirectory {
     new MappedDirectory(encodedPath, rootPaths, items)
 }
 
-class MappedFileConverter(rootPaths: Map[String, Path], allowMachinePath: Boolean)
+class MappedFileConverter(val rootPaths: Map[String, Path], allowMachinePath: Boolean)
     extends FileConverter {
 
   import MappedFileConverter.view

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -147,11 +147,11 @@ final class MixedAnalyzingCompiler(
       Incremental.isPickleJava(config.currentSetup.options.scalacOptions.toIndexedSeq)
 
     def convertToPath(value: String): String =
-      if (!value.contains("$")) value
-      else {
-        val vf = VirtualFileRef.of(value)
-        val p = config.converter.toPath(vf)
-        p.toString()
+      config.converter match {
+        case c: MappedFileConverter =>
+          MappedVirtualFile.toPathMapped(value, c.rootPaths)(_.toString(), identity)
+
+        case _ => value
       }
 
     // Compile Scala sources.


### PR DESCRIPTION
This is a follow up to #1545, prompted by sbt/sbt#9101.

It updates `def convertToPath` in `MixedAnalyzingCompiler.scala` to:

1. Only perform virtual path replacement if `config.converter` is a `MappedFileConverter`
2. Use the same logic as `MappedVirtualFile.toPath`, which ensures that a virtual path is replaced only if it is the prefix of the given `String`