### PR TITLE
Fix warnings. Set explicit scalaVersion

### DIFF
--- a/project/ZincBuildUtil.scala
+++ b/project/ZincBuildUtil.scala
@@ -49,6 +49,7 @@ object ZincBuildUtil {
     ) ++ relaxNon212
 
   def relaxNon212: Seq[Setting[?]] = Seq(
+    scalaVersion := Dependencies.scala212,
     scalacOptions := {
       val old = scalacOptions.value
       scalaBinaryVersion.value match {


### PR DESCRIPTION
```
[warn] scalaVersion for subproject classesDep1 fell back to a default value 2.12.21; declare it explicitly in build.sbt:
[warn]   scalaVersion := "2.12.21"
[warn] scalaVersion for subproject jar1 fell back to a default value 2.12.21; declare it explicitly in build.sbt:
[warn]   scalaVersion := "2.12.21"
[warn] scalaVersion for subproject jar2 fell back to a default value 2.12.21; declare it explicitly in build.sbt:
[warn]   scalaVersion := "2.12.21"
```