### PR TITLE
[2.x] fix: Fix NPE in loadInnerClass

### DIFF
--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
@@ -265,13 +265,17 @@ object ClassToAPI {
       cl: ClassLoader,
       info: classfile.InnerClassInfo,
       log: Logger
-  ): Option[Class[?]] =
-    try Some(cl.loadClass(info.innerClassName))
+  ): Option[Class[?]] = {
+    // Bootstrap-loaded classes (e.g. java.lang.Thread.Builder on JDK 21+)
+    // report a null ClassLoader; fall back to the system class loader.
+    val loader = if (cl == null) ClassLoader.getSystemClassLoader else cl
+    try Some(loader.loadClass(info.innerClassName))
     catch {
       case e: (ClassNotFoundException | NoClassDefFoundError) =>
         log.warn(s"Could not load inner class ${info.innerClassName}: $e")
         None
     }
+  }
 
   /** TODO: over time, ClassToAPI should switch the majority of access to the classfile parser */
   private def classFileForClass(c: Class[?]): ClassFile =

--- a/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/ClassToAPISpecification.scala
+++ b/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/ClassToAPISpecification.scala
@@ -55,6 +55,26 @@ class ClassToAPISpecification extends UnitSpec {
     assert(apis.keySet === Set("A", "A.B"))
   }
 
+  // Regression: NPE in loadInnerClass when a JDK ancestor is bootstrap-loaded
+  // and has a public InnerClasses entry (e.g. java.lang.Thread.Builder on JDK 21+).
+  it should "not throw NPE when a parent JDK class is bootstrap-loaded" in {
+    IO.withTemporaryDirectory { temp =>
+      val outDir = new File(temp, "out")
+      outDir.mkdir()
+      val src = new File(temp, "MyThread.java")
+      IO.write(src, "public class MyThread extends Thread {}")
+      compileJava(Seq(src), outDir, Seq.empty)
+
+      Using.resource(new java.net.URLClassLoader(Array(outDir.toURI.toURL))) { classloader =>
+        val myThread = classloader.loadClass("MyThread")
+        val (apis, _, _) = ClassToAPI.process(Seq(myThread))
+        // Force the lazy structure so the inner-class walk runs.
+        apis.foreach(_.structure.declared.toIndexedSeq)
+        assert(apis.map(_.name).toSet.contains("MyThread"))
+      }
+    }
+  }
+
   // sbt/sbt#117
   it should "not throw NoClassDefFoundError when inner class references missing type" in {
     IO.withTemporaryDirectory { temp =>


### PR DESCRIPTION
Fixes https://github.com/sbt/zinc/issues/1697. Vibe coded, but seems to work. In particular I spot checked the upstream PR that surfaced this issue https://github.com/com-lihaoyi/mill/pull/7103 and it seems to fix the original broken test. Covered by a unit test