### PR TITLE
[2.x] fix: Accept jrt: URLs in ClasspathFilter.onClasspath

### DIFF
--- a/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaders.scala
+++ b/internal/zinc-classpath/src/main/scala/sbt/internal/inc/classpath/ClassLoaders.scala
@@ -94,7 +94,9 @@ final class ClasspathFilter(parent: ClassLoader, root: ClassLoader, classpath: S
     onClasspath(codeSource.getLocation)
   }
   private def onClasspath(src: URL): Boolean =
-    (src eq null) || (
+    // `jrt:` URLs identify JDK platform-module classes/resources (java.sql, etc.),
+    // which are always implicitly available to user code.
+    (src eq null) || src.getProtocol == "jrt" || (
       ClasspathUtil.asFile(src).headOption match {
         case Some(f) =>
           classpath(f) || directories.exists(dir => ClasspathUtil.relativize(dir, f).isDefined)

--- a/internal/zinc-classpath/src/test/scala/sbt/internal/inc/classpath/ClasspathFilterTest.scala
+++ b/internal/zinc-classpath/src/test/scala/sbt/internal/inc/classpath/ClasspathFilterTest.scala
@@ -1,0 +1,24 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package sbt.internal.inc.classpath
+
+import java.net.URLClassLoader
+import verify.BasicTestSuite
+
+object ClasspathFilterTest extends BasicTestSuite {
+  test("loadClass surfaces JDK platform-module classes") {
+    val parent = new URLClassLoader(Array.empty, ClassLoader.getSystemClassLoader)
+    val filter = new ClasspathFilter(parent, parent, Set.empty)
+    val c = filter.loadClass("java.sql.Timestamp")
+    assert(c.getName == "java.sql.Timestamp")
+  }
+}


### PR DESCRIPTION
## Summary

`ClasspathFilter.onClasspath` only recognized `file:` and `jar:` URLs. Since JDK 9 the JDK platform-module classes (`java.sql.*`, `java.scripting.*`, `java.xml.*`, ...) ship in `jrt:/<module>` URLs, so the filter would reject them.

`sbt console` then throws `SecurityException: Prohibited package name: java.sql` because the parent URLClassLoader falls through to `defineClass` on `jrt:` bytes, which the JVM forbids for `java.*` packages from user classloaders.

This change accepts `jrt:` URLs as implicitly on-classpath. Since sbt 2.x mandates JDK 17, the failure case is hit on every `> console` that touches `java.sql`/`java.scripting`/`java.xml`/etc.

Refs sbt/sbt#4328 (the user-visible issue).

## Test plan

- [x] New unit test `ClasspathFilterTest` exercises `loadClass("java.sql.Timestamp")` through a `ClasspathFilter` with an empty user classpath; passes after the change.
- [x] `zincClasspath/test` green.

The end-to-end scripted test in sbt/sbt will follow once this lands and the zinc dep is bumped.