### PR TITLE
Remove enable-beta-ecosystems from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,4 @@
 version: 2
-enable-beta-ecosystems: true
 updates:
   - package-ecosystem: "sbt"
     directory: "/"


### PR DESCRIPTION
- https://github.blog/changelog/2026-05-26-dependabot-version-updates-now-support-the-sbt-ecosystem/
- https://github.com/dependabot/dependabot-core/issues/352#issuecomment-4549083579

> we've released sbt support to general availability! The enable-beta-ecosystems: true flag is no longer required. 