### PR TITLE
[2.x] fix: Classfile fallback for the remaining ClassToAPI reflection sites

### DIFF
--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
@@ -16,7 +16,7 @@ package inc
 import java.lang.reflect.{ Array => _, _ }
 import java.lang.annotation.Annotation
 import annotation.tailrec
-import inc.classfile.ClassFile
+import inc.classfile.{ ClassFile, FieldOrMethodInfo, ParsedAnnotation, Constants => CF }
 import xsbti.api
 import xsbti.api.SafeLazyProxy
 import collection.mutable
@@ -132,11 +132,12 @@ object ClassToAPI {
     val enclPkg = packageName(c)
     val mods = modifiers(c.getModifiers)
     val acc = access(c.getModifiers, enclPkg)
-    val annots = annotations(c.getAnnotations)
+    val annots = classAnnotationsSafe(c, cmap)
     val children = childrenOfSealedClass(c)
     val topLevel = c.getEnclosingClass == null
     val name = classCanonicalName(c)
     val tpe = if (Modifier.isInterface(c.getModifiers)) Trait else ClassDef
+    val tparams = classTypeParametersSafe(c, cmap)
     lazy val (static, instance) = structure(c, enclPkg, cmap)
     val cls = api.ClassLike.of(
       name,
@@ -149,10 +150,10 @@ object ClassToAPI {
       emptyStringArray,
       children.toArray,
       topLevel,
-      typeParameters(typeParameterTypes(c))
+      tparams
     )
     val clsDef =
-      api.ClassLikeDef.of(name, acc, mods, annots, typeParameters(typeParameterTypes(c)), tpe)
+      api.ClassLikeDef.of(name, acc, mods, annots, tparams, tpe)
     val stat = api.ClassLike.of(
       name,
       acc,
@@ -172,23 +173,38 @@ object ClassToAPI {
     cmap.memo(name) = defsEmptyMembers
     cmap.allNonLocalClasses ++= defs
 
-    if (
-      c.getMethods.exists(meth =>
-        meth.getName == "main" &&
-          Modifier.isStatic(meth.getModifiers) &&
-          meth.getParameterTypes.length == 1 &&
-          meth.getParameterTypes.head == classOf[Array[String]] &&
-          meth.getReturnType == java.lang.Void.TYPE
-      )
-    ) {
+    if (classFileForClass(c).methods.exists(_.isMain)) {
       cmap.mainClasses += name
     }
 
     defsEmptyMembers
   }
 
-  /** Returns the (static structure, instance structure, inherited classes) for `c`. */
+  /**
+   * Returns the (static structure, instance structure) for `c`.
+   *
+   * Reflection is the primary path. If the JVM can't resolve a referenced type
+   * (typically a transitive dependency marked optional/provided that isn't on
+   * the analysis classpath), we fall back to parsing the classfile directly.
+   * The classfile fallback produces lower-fidelity output (no generic type
+   * parameters; see DescriptorParser for the erased-type substitution).
+   */
   def structure(
+      c: Class[?],
+      enclPkg: Option[String],
+      cmap: ClassMap
+  ): (api.Structure, api.Structure) =
+    try structureReflective(c, enclPkg, cmap)
+    catch {
+      case e: (LinkageError | TypeNotPresentException | ClassNotFoundException) =>
+        cmap.log.warn(
+          s"Reflection failed introspecting ${c.getName} " +
+            s"(${e.getClass.getSimpleName}: ${e.getMessage}); falling back to classfile parser"
+        )
+        structureFromClassfile(c, enclPkg, cmap)
+    }
+
+  private def structureReflective(
       c: Class[?],
       enclPkg: Option[String],
       cmap: ClassMap
@@ -228,6 +244,274 @@ object ClassToAPI {
     )
     (staticStructure, instanceStructure)
   }
+
+  private def structureFromClassfile(
+      c: Class[?],
+      enclPkg: Option[String],
+      cmap: ClassMap
+  ): (api.Structure, api.Structure) = {
+    val cf = classFileForClass(c)
+
+    val declaredMethods = cf.methods.filter(m =>
+      !m.isConstructor && !m.isStaticInit && !m.isBridge && !m.isSynthetic
+    )
+    val declaredConstructors = cf.methods.filter(m => m.isConstructor && !m.isSynthetic)
+    val declaredFields = cf.fields
+
+    val inheritedMethods = cfPublicInherited(
+      c,
+      _.methods.filter(m =>
+        m.isPublic && !m.isConstructor && !m.isStaticInit && !m.isBridge && !m.isSynthetic
+      )
+    )
+    val inheritedFields = cfPublicInherited(c, _.fields.filter(_.isPublic))
+
+    val methods = cfMerge(
+      c,
+      cf,
+      declaredMethods,
+      inheritedMethods,
+      cfMethodToDef(enclPkg)
+    )
+    val fields = cfMerge(
+      c,
+      cf,
+      declaredFields,
+      inheritedFields,
+      cfFieldToDef(enclPkg)
+    )
+    // Constructors are never inherited.
+    val constructors = cfMerge(
+      c,
+      cf,
+      declaredConstructors,
+      Seq.empty,
+      cfConstructorToDef(enclPkg)
+    )
+    val classes = innerClassesFromClassfile(c, cf, cmap)
+    val all = methods ++ fields ++ constructors ++ classes
+
+    val parentJavaTypes = allSuperTypesSafe(c)
+    if (!Modifier.isPrivate(c.getModifiers))
+      cmap.inherited ++= parentJavaTypes.collect { case parent: Class[?] => c -> parent }
+    val parentTypes = types(parentJavaTypes)
+    val instanceStructure =
+      api.Structure.of(lzyS(parentTypes), lzyS(all.declared.toArray), lzyS(all.inherited.toArray))
+    val staticStructure = api.Structure.of(
+      lzyEmptyTpeArray,
+      lzyS(all.staticDeclared.toArray),
+      lzyS(all.staticInherited.toArray)
+    )
+    (staticStructure, instanceStructure)
+  }
+
+  /**
+   * Best-effort supertype walk for the classfile fallback: tolerates the same
+   * reflection failures that triggered the fallback. We use the classfile's
+   * superClassName / interfaceNames when reflection on the parents throws.
+   */
+  private def allSuperTypesSafe(c: Class[?]): Seq[Type] =
+    try allSuperTypes(c)
+    catch {
+      case _: (LinkageError | TypeNotPresentException | ClassNotFoundException) => Seq.empty
+    }
+
+  /**
+   * Reflection on `c.getAnnotations` triggers loading of every annotation type, which
+   * fails when an annotation lives in an optional/provided dep that isn't on the analysis
+   * classpath. Fall back to parsing the classfile's RuntimeVisible/Invisible Annotations
+   * attributes when reflection blows up.
+   */
+  private def classAnnotationsSafe(c: Class[?], cmap: ClassMap): Array[api.Annotation] =
+    try annotations(c.getAnnotations)
+    catch {
+      case e: (LinkageError | TypeNotPresentException | ClassNotFoundException) =>
+        cmap.log.warn(
+          s"Reflection failed reading annotations on ${c.getName} " +
+            s"(${e.getClass.getSimpleName}: ${e.getMessage}); falling back to classfile parser"
+        )
+        try {
+          val cf = classFileForClass(c)
+          cfAnnotations(cf.annotations(cf.attributes.toIndexedSeq))
+        } catch { case _: Throwable => emptyAnnotationArray }
+    }
+
+  /**
+   * `c.getTypeParameters` triggers resolution of generic bound types. Fall back to an
+   * empty array when that fails — the Signature attribute parser (deferred) would let us
+   * recover the type parameters from the classfile bytes.
+   */
+  private def classTypeParametersSafe(c: Class[?], cmap: ClassMap): Array[api.TypeParameter] =
+    try typeParameters(typeParameterTypes(c))
+    catch {
+      case e: (LinkageError | TypeNotPresentException | ClassNotFoundException) =>
+        cmap.log.warn(
+          s"Reflection failed reading type parameters on ${c.getName} " +
+            s"(${e.getClass.getSimpleName}: ${e.getMessage}); using empty type parameter list"
+        )
+        emptyTypeParameterArray
+    }
+
+  /**
+   * Returns members from supertypes paired with the supertype's `(Class, ClassFile)` so
+   * downstream code can read each member's attributes against the correct constant pool
+   * (attribute bytes contain indices that only make sense within the originating classfile).
+   */
+  private def cfPublicInherited(
+      c: Class[?],
+      select: ClassFile => Array[FieldOrMethodInfo]
+  ): Seq[(Class[?], ClassFile, FieldOrMethodInfo)] =
+    allSuperTypesSafe(c).collect { case parent: Class[?] =>
+      val pcf = classFileForClass(parent)
+      select(pcf).iterator.map(m => (parent, pcf, m)).toSeq
+    }.flatten
+
+  private def cfMerge(
+      declaringClass: Class[?],
+      declaringCf: ClassFile,
+      declared: Array[FieldOrMethodInfo],
+      inherited: Seq[(Class[?], ClassFile, FieldOrMethodInfo)],
+      toDef: (Class[?], ClassFile, FieldOrMethodInfo) => api.ClassDefinition
+  ): Defs = {
+    val (selfStatic, selfInstance) = declared.partition(_.isStatic)
+    val (inhStatic, inhInstance) = inherited.partition(_._3.isStatic)
+    Defs(
+      selfInstance.iterator.map(m => toDef(declaringClass, declaringCf, m)).toSeq,
+      inhInstance.iterator.map { case (pc, pcf, m) => toDef(pc, pcf, m) }.toSeq,
+      selfStatic.iterator.map(m => toDef(declaringClass, declaringCf, m)).toSeq,
+      inhStatic.iterator.map { case (pc, pcf, m) => toDef(pc, pcf, m) }.toSeq
+    )
+  }
+
+  private def cfAccess(flags: Int, pkg: Option[String]): api.Access = {
+    if ((flags & CF.ACC_PUBLIC) != 0) Public
+    else if ((flags & CF.ACC_PRIVATE) != 0) Private
+    else if ((flags & CF.ACC_PROTECTED) != 0) Protected
+    else packagePrivate(pkg)
+  }
+
+  private def cfModifiers(flags: Int): api.Modifiers =
+    new api.Modifiers(
+      (flags & CF.ACC_ABSTRACT) != 0,
+      false,
+      (flags & CF.ACC_FINAL) != 0,
+      false,
+      false,
+      false,
+      false,
+      false
+    )
+
+  private def cfMethodToDef(
+      enclPkg: Option[String]
+  )(declaringClass: Class[?], cf: ClassFile, m: FieldOrMethodInfo): api.ClassDefinition = {
+    val _ = declaringClass // unused for methods, but kept for uniform toDef signature
+    val mName = m.name.getOrElse("")
+    val (paramTypes, retType) = m.descriptor
+      .map(DescriptorParser.methodTypes)
+      .getOrElse((Array.empty[api.Type], Empty))
+    val params = cfParameterList(m, paramTypes, cf.parameterAnnotations(m.attributes))
+    val annots =
+      cfAnnotations(cf.annotations(m.attributes)) ++
+        cfExceptionAnnotations(cf.methodExceptions(m.attributes))
+    api.Def.of(
+      mName,
+      cfAccess(m.accessFlags, enclPkg),
+      cfModifiers(m.accessFlags),
+      annots,
+      emptyTypeParameterArray,
+      Array(params),
+      retType
+    )
+  }
+
+  private def cfFieldToDef(
+      enclPkg: Option[String]
+  )(declaringClass: Class[?], declaringCf: ClassFile, f: FieldOrMethodInfo): api.ClassDefinition = {
+    val fName = f.name.getOrElse("")
+    val fType = f.descriptor.map(DescriptorParser.fieldType).getOrElse(Empty)
+    val mods = cfModifiers(f.accessFlags)
+    val accs = cfAccess(f.accessFlags, enclPkg)
+    val annots = cfAnnotations(declaringCf.annotations(f.attributes))
+    val specificTpe: Option[api.Type] =
+      if (mods.isFinal)
+        declaringCf.constantValue(fName).map { v =>
+          api.Singleton.of(
+            pathFromStrings(
+              declaringClass.getName.split("\\.").toSeq :+
+                (fName + "$" + f.descriptor.getOrElse("") + "$" + v)
+            )
+          )
+        }
+      else None
+    val tpe = specificTpe.getOrElse(fType)
+    if (mods.isFinal) api.Val.of(fName, accs, mods, annots, tpe)
+    else api.Var.of(fName, accs, mods, annots, tpe)
+  }
+
+  private def cfConstructorToDef(
+      enclPkg: Option[String]
+  )(declaringClass: Class[?], cf: ClassFile, m: FieldOrMethodInfo): api.ClassDefinition = {
+    val cName = s"${declaringClass.getName.replace('.', ';')};init;"
+    val (paramTypes, _) = m.descriptor
+      .map(DescriptorParser.methodTypes)
+      .getOrElse((Array.empty[api.Type], Empty))
+    val params = cfParameterList(m, paramTypes, cf.parameterAnnotations(m.attributes))
+    val annots =
+      cfAnnotations(cf.annotations(m.attributes)) ++
+        cfExceptionAnnotations(cf.methodExceptions(m.attributes))
+    api.Def.of(
+      cName,
+      cfAccess(m.accessFlags, enclPkg),
+      cfModifiers(m.accessFlags),
+      annots,
+      emptyTypeParameterArray,
+      Array(params),
+      Empty
+    )
+  }
+
+  private def cfParameterList(
+      m: FieldOrMethodInfo,
+      paramTypes: Array[api.Type],
+      paramAnnots: IndexedSeq[IndexedSeq[ParsedAnnotation]]
+  ): api.ParameterList = {
+    val lastIdx = paramTypes.length - 1
+    val params = paramTypes.zipWithIndex.map { case (tpe, i) =>
+      val modifier =
+        if (m.isVarArgs && i == lastIdx) api.ParameterModifier.Repeated
+        else api.ParameterModifier.Plain
+      val annots = if (i < paramAnnots.length) paramAnnots(i) else IndexedSeq.empty
+      val annotated =
+        if (annots.isEmpty) tpe
+        else api.Annotated.of(tpe, cfAnnotations(annots))
+      api.MethodParameter.of("", annotated, false, modifier)
+    }
+    api.ParameterList.of(params, false)
+  }
+
+  private def cfAnnotations(
+      parsed: IndexedSeq[ParsedAnnotation]
+  ): Array[api.Annotation] =
+    if (parsed.isEmpty) emptyAnnotationArray
+    else parsed.iterator.map(cfAnnotation).toArray
+
+  private def cfAnnotation(a: ParsedAnnotation): api.Annotation = {
+    val args =
+      if (a.arguments.isEmpty) Array.empty[api.AnnotationArgument]
+      else a.arguments.iterator.map(p => api.AnnotationArgument.of(p.name, p.value)).toArray
+    api.Annotation.of(DescriptorParser.fieldType(a.typeDescriptor), args)
+  }
+
+  private def cfExceptionAnnotations(exceptions: IndexedSeq[String]): Array[api.Annotation] =
+    if (exceptions.isEmpty) emptyAnnotationArray
+    else
+      exceptions.iterator.map { name =>
+        api.Annotation.of(
+          Throws,
+          Array(api.AnnotationArgument.of("value", s"class $name"))
+        )
+      }.toArray
 
   /** Enumerates inner classes from the classfile instead of reflection. sbt/sbt#117 */
   private def innerClassesFromClassfile(
@@ -277,7 +561,6 @@ object ClassToAPI {
     }
   }
 
-  /** TODO: over time, ClassToAPI should switch the majority of access to the classfile parser */
   private def classFileForClass(c: Class[?]): ClassFile =
     classfile.Parser.apply(IO.classfileLocation(c), Logger.Null)
 

--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
@@ -307,8 +307,22 @@ object ClassToAPI {
 
   /**
    * Best-effort supertype walk for the classfile fallback: tolerates the same
-   * reflection failures that triggered the fallback. We use the classfile's
-   * superClassName / interfaceNames when reflection on the parents throws.
+   * reflection failures that triggered the fallback.
+   *
+   * TODO: returning Seq.empty on failure drops two pieces of information that
+   * incremental compilation relies on: (1) the inheritance edges in
+   * `cmap.inherited`, which gate downstream invalidation when a parent's API
+   * changes, and (2) the parent types in the instance Structure, which feed
+   * into the class's API hash. A proper fallback should:
+   *   1. Retry with raw `getSuperclass` / `getInterfaces` (no generics) — most
+   *      TypeNotPresentException cases come from parameterized supertypes like
+   *      `extends Foo<Missing>` and raw reflection sidesteps the type-arg
+   *      resolution.
+   *   2. If raw reflection still throws, read `cf.superClassName` and
+   *      `cf.interfaceNames` from the classfile (just strings — no class
+   *      loading) to populate `parentTypes`, and try `cl.loadClass(name)` per
+   *      parent for inherited-member enumeration, skipping parents the
+   *      classloader can't resolve.
    */
   private def allSuperTypesSafe(c: Class[?]): Seq[Type] =
     try allSuperTypes(c)
@@ -321,6 +335,16 @@ object ClassToAPI {
    * fails when an annotation lives in an optional/provided dep that isn't on the analysis
    * classpath. Fall back to parsing the classfile's RuntimeVisible/Invisible Annotations
    * attributes when reflection blows up.
+   *
+   * TODO: modern JDKs silently *drop* annotation entries whose type isn't loadable
+   * rather than throwing — so for a class whose only problem is a missing annotation
+   * type, this fallback never triggers and the annotation is lost from the API
+   * (ClassToAPISpecification pins this as a known limitation). Two recovery paths
+   * worth considering: (a) always read class-level annotations from the classfile and
+   * skip reflection here entirely, or (b) read both, compare counts, and merge.
+   * Option (a) is simpler and aligns with the long-term direction documented on
+   * `classFileForClass`. Same applies to method/field annotations on the reflection
+   * primary path.
    */
   private def classAnnotationsSafe(c: Class[?], cmap: ClassMap): Array[api.Annotation] =
     try annotations(c.getAnnotations)
@@ -338,8 +362,15 @@ object ClassToAPI {
 
   /**
    * `c.getTypeParameters` triggers resolution of generic bound types. Fall back to an
-   * empty array when that fails — the Signature attribute parser (deferred) would let us
-   * recover the type parameters from the classfile bytes.
+   * empty array when that fails.
+   *
+   * TODO: an empty type-parameter list is a fidelity loss vs. the reflection path
+   * and will change the API hash for any generic class that hits the fallback.
+   * Recover the type parameters (and their bounds) by parsing the `Signature`
+   * classfile attribute (JVMS §4.7.9 — ClassSignature: `<T extends Bound>...`).
+   * The Signature attribute is also what the method/field fallbacks need to
+   * recover generic return types, parameter types, and field types, so the
+   * parser should be designed as a single shared component (Phase 4).
    */
   private def classTypeParametersSafe(c: Class[?], cmap: ClassMap): Array[api.TypeParameter] =
     try typeParameters(typeParameterTypes(c))
@@ -561,6 +592,7 @@ object ClassToAPI {
     }
   }
 
+  /** TODO: over time, ClassToAPI should switch the majority of access to the classfile parser */
   private def classFileForClass(c: Class[?]): ClassFile =
     classfile.Parser.apply(IO.classfileLocation(c), Logger.Null)
 

--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/DescriptorParser.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/DescriptorParser.scala
@@ -1,0 +1,115 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package sbt
+package internal
+package inc
+
+import xsbti.api
+
+/**
+ * Parses JVM field and method descriptors into xsbti.api.Type values without
+ * loading the referenced classes, avoiding ClassNotFoundException when
+ * transitive dependencies are absent from the analysis classpath.
+ *
+ * Descriptor grammar (JVMS §4.3):
+ *   FieldDescriptor  ::= FieldType
+ *   MethodDescriptor ::= '(' FieldType* ')' ReturnDescriptor
+ *   FieldType        ::= BaseType | ObjectType | ArrayType
+ *   BaseType         ::= 'B'|'C'|'D'|'F'|'I'|'J'|'S'|'Z'
+ *   ObjectType       ::= 'L' ClassName ';'
+ *   ArrayType        ::= '[' ComponentType
+ *   ReturnDescriptor ::= FieldType | 'V'
+ *
+ * Generic signatures (the Signature attribute) are not parsed; erased types
+ * from the descriptor are used instead. This is sufficient for incremental
+ * compilation: binary-incompatible changes to generic signatures still change
+ * the erased descriptor and trigger recompilation.
+ */
+private[inc] object DescriptorParser {
+
+  private val Empty: api.Type = api.EmptyType.of()
+  private val ThisRef: api.PathComponent = api.This.of()
+  private val ArrayRef: api.Type = reference("scala.Array")
+
+  private val primitives: Map[Char, api.Type] = Map(
+    'B' -> reference("scala.Byte"),
+    'C' -> reference("scala.Char"),
+    'D' -> reference("scala.Double"),
+    'F' -> reference("scala.Float"),
+    'I' -> reference("scala.Int"),
+    'J' -> reference("scala.Long"),
+    'S' -> reference("scala.Short"),
+    'Z' -> reference("scala.Boolean"),
+  )
+
+  /** Parse a field descriptor such as {@code Ljava/lang/String;} or {@code I} or {@code [B}. */
+  def fieldType(descriptor: String): api.Type =
+    parseType(descriptor, 0)._1
+
+  /**
+   * Parse a method descriptor such as {@code ([Ljava/lang/String;)V}.
+   * @return (parameter types, return type); return type is EmptyType for void.
+   */
+  def methodTypes(descriptor: String): (Array[api.Type], api.Type) = {
+    val closeParen = descriptor.indexOf(')')
+    if (!descriptor.startsWith("(") || closeParen < 0)
+      throw new IllegalArgumentException(s"Not a valid method descriptor: $descriptor")
+    val params = parseParamTypes(descriptor, 1, closeParen)
+    val retDesc = descriptor.substring(closeParen + 1)
+    val ret = if (retDesc == "V") Empty else parseType(retDesc, 0)._1
+    (params, ret)
+  }
+
+  private def parseParamTypes(desc: String, from: Int, until: Int): Array[api.Type] = {
+    val buf = new scala.collection.mutable.ArrayBuffer[api.Type]()
+    var i = from
+    while (i < until) {
+      val (tpe, next) = parseType(desc, i)
+      buf += tpe
+      i = next
+    }
+    buf.toArray
+  }
+
+  private def parseType(desc: String, i: Int): (api.Type, Int) =
+    desc(i) match {
+      case c if primitives.contains(c) => (primitives(c), i + 1)
+      case 'V'                         => (Empty, i + 1)
+      case '[' =>
+        val (component, next) = parseType(desc, i + 1)
+        (api.Parameterized.of(ArrayRef, Array(component)), next)
+      case 'L' =>
+        val end = desc.indexOf(';', i + 1)
+        if (end < 0) throw new IllegalArgumentException(s"Unterminated object type in: $desc")
+        val className = desc.substring(i + 1, end).replace('/', '.')
+        (reference(className), end + 1)
+      case c =>
+        throw new IllegalArgumentException(s"Unknown descriptor char '$c' at $i in: $desc")
+    }
+
+  private[inc] def reference(dotted: String): api.Type = {
+    val lastDot = dotted.lastIndexOf('.')
+    if (lastDot < 0)
+      api.Projection.of(Empty, dotted)
+    else
+      api.Projection.of(
+        api.Singleton.of(pathFromString(dotted.substring(0, lastDot))),
+        dotted.substring(lastDot + 1)
+      )
+  }
+
+  private def pathFromString(pkg: String): api.Path = {
+    val parts: Array[api.PathComponent] =
+      pkg.split("\\.").map(api.Id.of(_).asInstanceOf[api.PathComponent]) :+ ThisRef
+    api.Path.of(parts)
+  }
+}

--- a/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/ClassToAPISpecification.scala
+++ b/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/ClassToAPISpecification.scala
@@ -109,6 +109,206 @@ class ClassToAPISpecification extends UnitSpec {
     }
   }
 
+  // sbt/sbt#117 (reflection-fallback variant): a method's return type lives in
+  // an optional dep that's no longer on the classpath. Reflection throws when
+  // forced; the classfile-based fallback should rebuild the Def from the descriptor.
+  it should "fall back to classfile parser when a method return type is missing" in {
+    withMissingDep("public Missing foo() { return null; }") { (api, name) =>
+      val outer = api.find(_.name == "Outer").get
+      val foo = outer.structure.declared.collectFirst {
+        case d: xsbti.api.Def if d.name == "foo" => d
+      }.getOrElse(fail(s"foo() not in declared: ${outer.structure.declared.toSeq}"))
+      assert(projectionId(foo.returnType).contains("Missing"))
+    }
+  }
+
+  it should "fall back to classfile parser when a method parameter type is missing" in {
+    withMissingDep("public void foo(Missing m) {}") { (api, _) =>
+      val outer = api.find(_.name == "Outer").get
+      val foo = outer.structure.declared.collectFirst {
+        case d: xsbti.api.Def if d.name == "foo" => d
+      }.getOrElse(fail("foo(Missing) not in declared"))
+      val paramType = foo.valueParameters.head.parameters.head.tpe
+      assert(projectionId(paramType).contains("Missing"))
+    }
+  }
+
+  it should "fall back to classfile parser when a field type is missing" in {
+    withMissingDep("public Missing field;") { (api, _) =>
+      val outer = api.find(_.name == "Outer").get
+      val field = outer.structure.declared.collectFirst {
+        case v: xsbti.api.Var if v.name == "field" => v
+      }.getOrElse(fail("field not in declared"))
+      assert(projectionId(field.tpe).contains("Missing"))
+    }
+  }
+
+  // Known limitation: when only the annotation *type* is missing (and nothing
+  // else in the class triggers a reflection failure), modern JDKs silently
+  // drop the unresolvable Annotation from c.getAnnotations() rather than
+  // throwing. classAnnotationsSafe only triggers fallback on exception, so
+  // the @Missing annotation is lost. Recovering it would require either
+  // always reading class annotations from the classfile (Phase 4 territory)
+  // or detecting count mismatches between reflection and classfile.
+  it should "(limitation) lose missing-type class annotations when reflection silently drops them" in {
+    IO.withTemporaryDirectory { temp =>
+      val libDir = new File(temp, "lib"); libDir.mkdir()
+      val srcDir = new File(temp, "src"); srcDir.mkdir()
+
+      val missingAnn = new File(temp, "Missing.java")
+      IO.write(
+        missingAnn,
+        """|import java.lang.annotation.*;
+           |@Retention(RetentionPolicy.RUNTIME)
+           |public @interface Missing {}
+           |""".stripMargin
+      )
+      compileJava(Seq(missingAnn), libDir, Seq.empty)
+
+      val outerFile = new File(temp, "Outer.java")
+      IO.write(outerFile, "@Missing public class Outer {}")
+      compileJava(Seq(outerFile), srcDir, Seq(libDir))
+
+      Using.resource(new java.net.URLClassLoader(Array(srcDir.toURI.toURL), null)) { cl =>
+        val outerClass = cl.loadClass("Outer")
+        val (apis, _, _) = ClassToAPI.process(Seq(outerClass))
+        val outer = apis.find(_.name == "Outer").get
+        // Pins current behavior. When we fix the limitation, this assertion
+        // will start failing and should flip to .exists(... "Missing" ...).
+        assert(!outer.annotations.exists(a => projectionId(a.base).contains("Missing")))
+      }
+    }
+  }
+
+  // Regression: inherited members carry attributes whose constant-pool indices
+  // belong to the *parent's* classfile, not the child's. The classfile fallback
+  // must read those attributes with the parent's ClassFile or it returns garbage
+  // (or trips the `entry.tag == ConstantUTF8` assertion in Parser#toUTF8).
+  it should "read inherited member annotations against the parent's constant pool" in {
+    IO.withTemporaryDirectory { temp =>
+      val libDir = new File(temp, "lib"); libDir.mkdir()
+      val srcDir = new File(temp, "src"); srcDir.mkdir()
+
+      val missing = new File(temp, "Missing.java")
+      IO.write(missing, "public class Missing {}")
+      compileJava(Seq(missing), libDir, Seq.empty)
+
+      val parent = new File(temp, "Parent.java")
+      IO.write(
+        parent,
+        """|public class Parent {
+           |  // Reference to Missing forces the reflection path to throw,
+           |  // which triggers the classfile fallback on Child too.
+           |  public Missing dep() { return null; }
+           |  @Deprecated public void inheritedMethod() {}
+           |}
+           |""".stripMargin
+      )
+      val child = new File(temp, "Child.java")
+      IO.write(child, "public class Child extends Parent {}")
+      compileJava(Seq(parent, child), srcDir, Seq(libDir))
+
+      Using.resource(new java.net.URLClassLoader(Array(srcDir.toURI.toURL), null)) { cl =>
+        val childClass = cl.loadClass("Child")
+        val (apis, _, _) = ClassToAPI.process(Seq(childClass))
+        val childApi = apis.find(_.name == "Child").get
+        val inheritedMethod = childApi.structure.inherited.collectFirst {
+          case d: xsbti.api.Def if d.name == "inheritedMethod" => d
+        }.getOrElse {
+          fail(
+            s"inheritedMethod not found in Child.structure.inherited: " +
+              childApi.structure.inherited.map(_.name).mkString(", ")
+          )
+        }
+        assert(
+          inheritedMethod.annotations.exists(a => projectionId(a.base).contains("Deprecated")),
+          s"expected @Deprecated on inherited method; got: " +
+            inheritedMethod.annotations.map(a => projectionId(a.base)).mkString(", ")
+        )
+      }
+    }
+  }
+
+  it should "emit @throws annotations on classfile-fallback methods" in {
+    withMissingDep(
+      """|public Missing dep() { return null; }
+         |public void thrower() throws java.io.IOException {}
+         |""".stripMargin
+    ) { (api, _) =>
+      val outer = api.find(_.name == "Outer").get
+      val thrower = outer.structure.declared.collectFirst {
+        case d: xsbti.api.Def if d.name == "thrower" => d
+      }.getOrElse(fail("thrower() not in declared"))
+      val throwsAnn = thrower.annotations.find(a => projectionId(a.base).contains("throws"))
+      assert(throwsAnn.isDefined, s"no @throws annotation: ${thrower.annotations.toSeq}")
+      assert(
+        throwsAnn.get.arguments.exists(_.value.contains("IOException")),
+        s"expected IOException in throws args; got: ${throwsAnn.get.arguments.toSeq}"
+      )
+    }
+  }
+
+  it should "log a warning when falling back to the classfile parser" in {
+    IO.withTemporaryDirectory { temp =>
+      val libDir = new File(temp, "lib"); libDir.mkdir()
+      val srcDir = new File(temp, "src"); srcDir.mkdir()
+      val missing = new File(temp, "Missing.java")
+      IO.write(missing, "public class Missing {}")
+      compileJava(Seq(missing), libDir, Seq.empty)
+      val outer = new File(temp, "Outer.java")
+      IO.write(outer, "public class Outer { public Missing foo() { return null; } }")
+      compileJava(Seq(outer), srcDir, Seq(libDir))
+
+      Using.resource(new java.net.URLClassLoader(Array(srcDir.toURI.toURL), null)) { cl =>
+        val outerClass = cl.loadClass("Outer")
+        val recording = new RecordingLogger
+        val (_, _, _) = ClassToAPI.process(Seq(outerClass), recording)
+        assert(
+          recording.warns.exists(_.contains("falling back to classfile parser")),
+          s"no fallback-warn observed; messages: ${recording.warns.mkString(" | ")}"
+        )
+      }
+    }
+  }
+
+  // ---- helpers ----
+
+  private def withMissingDep(outerBody: String)(
+      check: (Seq[ClassLike], String) => Unit
+  ): Unit = IO.withTemporaryDirectory { temp =>
+    val libDir = new File(temp, "lib"); libDir.mkdir()
+    val srcDir = new File(temp, "src"); srcDir.mkdir()
+
+    val missing = new File(temp, "Missing.java")
+    IO.write(missing, "public class Missing {}")
+    compileJava(Seq(missing), libDir, Seq.empty)
+
+    val outerFile = new File(temp, "Outer.java")
+    IO.write(outerFile, s"public class Outer {\n$outerBody\n}\n")
+    compileJava(Seq(outerFile), srcDir, Seq(libDir))
+
+    Using.resource(new java.net.URLClassLoader(Array(srcDir.toURI.toURL), null)) { cl =>
+      val outerClass = cl.loadClass("Outer")
+      val (apis, _, _) = ClassToAPI.process(Seq(outerClass))
+      check(apis, "Outer")
+    }
+  }
+
+  private def projectionId(t: xsbti.api.Type): Option[String] = t match {
+    case p: xsbti.api.Projection => Some(p.id)
+    case _                       => None
+  }
+
+  private class RecordingLogger extends sbt.util.Logger {
+    private val buf = collection.mutable.ListBuffer.empty[(sbt.util.Level.Value, String)]
+    override def trace(t: => Throwable): Unit = ()
+    override def success(message: => String): Unit = ()
+    override def log(level: sbt.util.Level.Value, message: => String): Unit =
+      buf.synchronized(buf += ((level, message)))
+    def warns: Seq[String] =
+      buf.synchronized(buf.collect { case (sbt.util.Level.Warn, msg) => msg }.toSeq)
+  }
+
   private def compileJava(files: Seq[File], outputDir: File, classpath: Seq[File]): Unit = {
     import javax.tools.{ StandardLocation, ToolProvider }
     import scala.jdk.CollectionConverters._

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/ClassFile.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/ClassFile.scala
@@ -33,6 +33,27 @@ private[sbt] trait ClassFile {
   def stringValue(a: AttributeInfo): String
 
   /**
+   * Parses Runtime{Visible,Invisible}Annotations attributes (JVMS 4.7.16) from the given
+   * attribute list. Returns annotations across both visibility variants in declaration order.
+   */
+  def annotations(attrs: IndexedSeq[AttributeInfo]): IndexedSeq[ParsedAnnotation]
+
+  /**
+   * Parses Runtime{Visible,Invisible}ParameterAnnotations attributes (JVMS 4.7.18).
+   * Result is indexed by parameter position; for each position, annotations from both
+   * visibility variants are concatenated.
+   */
+  def parameterAnnotations(
+      attrs: IndexedSeq[AttributeInfo]
+  ): IndexedSeq[IndexedSeq[ParsedAnnotation]]
+
+  /**
+   * Parses the Exceptions attribute (JVMS 4.7.5). Returns checked-exception class names
+   * in declaration order.
+   */
+  def methodExceptions(attrs: IndexedSeq[AttributeInfo]): IndexedSeq[String]
+
+  /**
    * If the given fieldName represents a ConstantValue field, parses its representation from
    * the constant pool and returns it.
    */
@@ -90,6 +111,15 @@ private[sbt] final case class FieldOrMethodInfo(
 ) {
   def isStatic = (accessFlags & ACC_STATIC) == ACC_STATIC
   def isPublic = (accessFlags & ACC_PUBLIC) == ACC_PUBLIC
+  def isPrivate = (accessFlags & ACC_PRIVATE) == ACC_PRIVATE
+  def isProtected = (accessFlags & ACC_PROTECTED) == ACC_PROTECTED
+  def isFinal = (accessFlags & ACC_FINAL) == ACC_FINAL
+  def isAbstract = (accessFlags & ACC_ABSTRACT) == ACC_ABSTRACT
+  def isVarArgs = (accessFlags & ACC_VARARGS) == ACC_VARARGS
+  def isBridge = (accessFlags & ACC_BRIDGE) == ACC_BRIDGE
+  def isSynthetic = (accessFlags & ACC_SYNTHETIC) == ACC_SYNTHETIC
+  def isConstructor = name.exists(_ == "<init>")
+  def isStaticInit = name.exists(_ == "<clinit>")
   def isMain = isPublic && isStatic && descriptor.exists(_ == "([Ljava/lang/String;)V")
 }
 private[sbt] final case class AttributeInfo(name: Option[String], value: Array[Byte]) {
@@ -99,7 +129,32 @@ private[sbt] final case class AttributeInfo(name: Option[String], value: Array[B
   def isInnerClasses = isNamed("InnerClasses")
   def isRuntimeVisibleAnnotations = isNamed("RuntimeVisibleAnnotations")
   def isRuntimeInvisibleAnnotations = isNamed("RuntimeInvisibleAnnotations")
+  def isRuntimeVisibleParameterAnnotations = isNamed("RuntimeVisibleParameterAnnotations")
+  def isRuntimeInvisibleParameterAnnotations = isNamed("RuntimeInvisibleParameterAnnotations")
+  def isExceptions = isNamed("Exceptions")
 }
+
+/**
+ * Structured form of a Java annotation parsed from the classfile.
+ *
+ * @param typeDescriptor JVM field descriptor of the annotation type (e.g. "Ljava/lang/Deprecated;")
+ * @param arguments      named element/value pairs in declaration order
+ */
+private[sbt] final case class ParsedAnnotation(
+    typeDescriptor: String,
+    arguments: IndexedSeq[ParsedAnnotationArg]
+)
+
+/**
+ * One element/value pair within a Java annotation.
+ *
+ * @param name  element name
+ * @param value serialized element value; the format mirrors java.lang.Object#toString-style
+ *              rendering so it can be stored in api.AnnotationArgument and contribute stably
+ *              to the API hash. The exact format is intentionally not part of any contract:
+ *              it only needs to be stable across compilations of identical classfiles.
+ */
+private[sbt] final case class ParsedAnnotationArg(name: String, value: String)
 private[sbt] final case class InnerClassInfo(
     accessFlags: Int,
     innerName: Option[String],
@@ -110,8 +165,17 @@ private[sbt] final case class InnerClassInfo(
   def isPublic = (accessFlags & ACC_PUBLIC) == ACC_PUBLIC
 }
 private[sbt] object Constants {
-  final val ACC_STATIC = 0x0008
   final val ACC_PUBLIC = 0x0001
+  final val ACC_PRIVATE = 0x0002
+  final val ACC_PROTECTED = 0x0004
+  final val ACC_STATIC = 0x0008
+  final val ACC_FINAL = 0x0010
+  final val ACC_INTERFACE = 0x0200
+  final val ACC_ABSTRACT = 0x0400
+  final val ACC_BRIDGE = 0x0040
+  final val ACC_VARARGS = 0x0080
+  final val ACC_SYNTHETIC = 0x1000
+  final val ACC_ENUM = 0x4000
 
   final val JavaMagic = 0xcafebabe
   final val ConstantUTF8 = 1

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Parser.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Parser.scala
@@ -237,6 +237,117 @@ private[sbt] object Parser {
         }
         next(1, Nil)
       }
+
+      // ---- structured annotation / exception parsing (JVMS 4.7.5, 4.7.16, 4.7.18) ----
+
+      def annotations(attrs: IndexedSeq[AttributeInfo]): IndexedSeq[ParsedAnnotation] = {
+        val relevant = attrs.filter(a =>
+          a.isRuntimeVisibleAnnotations || a.isRuntimeInvisibleAnnotations
+        )
+        if (relevant.isEmpty) IndexedSeq.empty
+        else relevant.flatMap(parseAnnotationsAttr).toIndexedSeq
+      }
+
+      def parameterAnnotations(
+          attrs: IndexedSeq[AttributeInfo]
+      ): IndexedSeq[IndexedSeq[ParsedAnnotation]] = {
+        val relevant = attrs.filter(a =>
+          a.isRuntimeVisibleParameterAnnotations || a.isRuntimeInvisibleParameterAnnotations
+        )
+        if (relevant.isEmpty) IndexedSeq.empty
+        else {
+          val perAttr = relevant.map(parseParameterAnnotationsAttr)
+          val maxLen = perAttr.iterator.map(_.length).maxOption.getOrElse(0)
+          IndexedSeq.tabulate(maxLen) { i =>
+            perAttr.flatMap(p => if (i < p.length) p(i) else IndexedSeq.empty)
+          }
+        }
+      }
+
+      def methodExceptions(attrs: IndexedSeq[AttributeInfo]): IndexedSeq[String] =
+        attrs.find(_.isExceptions) match {
+          case None => IndexedSeq.empty
+          case Some(attr) =>
+            val in = new DataInputStream(new ByteArrayInputStream(attr.value))
+            val n = in.readUnsignedShort()
+            IndexedSeq.tabulate(n) { _ =>
+              val idx = in.readUnsignedShort()
+              if (idx == 0) "" else getClassConstantName(idx)
+            }
+        }
+
+      private def parseAnnotationsAttr(attr: AttributeInfo): IndexedSeq[ParsedAnnotation] = {
+        val in = new DataInputStream(new ByteArrayInputStream(attr.value))
+        val n = in.readUnsignedShort()
+        IndexedSeq.tabulate(n)(_ => parseStructuredAnnotation(in))
+      }
+
+      private def parseParameterAnnotationsAttr(
+          attr: AttributeInfo
+      ): IndexedSeq[IndexedSeq[ParsedAnnotation]] = {
+        val in = new DataInputStream(new ByteArrayInputStream(attr.value))
+        val numParams = in.readUnsignedByte()
+        IndexedSeq.tabulate(numParams) { _ =>
+          val numAnnotations = in.readUnsignedShort()
+          IndexedSeq.tabulate(numAnnotations)(_ => parseStructuredAnnotation(in))
+        }
+      }
+
+      private def parseStructuredAnnotation(in: DataInputStream): ParsedAnnotation = {
+        val typeDesc = toUTF8(in.readUnsignedShort())
+        val numPairs = in.readUnsignedShort()
+        val args = IndexedSeq.tabulate(numPairs) { _ =>
+          val name = toUTF8(in.readUnsignedShort())
+          val value = serializeElementValue(in)
+          ParsedAnnotationArg(name, value)
+        }
+        ParsedAnnotation(typeDesc, args)
+      }
+
+      private def serializeElementValue(in: DataInputStream): String = {
+        val tag = in.readUnsignedByte().toChar
+        tag match {
+          case 'B' => "(byte)" + constantInt(in.readUnsignedShort())
+          case 'C' => "'" + constantInt(in.readUnsignedShort()).toChar.toString + "'"
+          case 'D' => constantDouble(in.readUnsignedShort()).toString + "d"
+          case 'F' => constantFloat(in.readUnsignedShort()).toString + "f"
+          case 'I' => constantInt(in.readUnsignedShort()).toString
+          case 'J' => constantLong(in.readUnsignedShort()).toString + "L"
+          case 'S' => "(short)" + constantInt(in.readUnsignedShort())
+          case 'Z' => if (constantInt(in.readUnsignedShort()) == 0) "false" else "true"
+          case 's' => "\"" + toUTF8(in.readUnsignedShort()) + "\""
+          case 'e' =>
+            val typeDesc = toUTF8(in.readUnsignedShort())
+            val constName = toUTF8(in.readUnsignedShort())
+            stripFieldDescriptor(typeDesc) + "." + constName
+          case 'c' =>
+            stripFieldDescriptor(toUTF8(in.readUnsignedShort())) + ".class"
+          case '@' =>
+            val nested = parseStructuredAnnotation(in)
+            val argList = nested.arguments.map(a => s"${a.name}=${a.value}").mkString(", ")
+            s"@${stripFieldDescriptor(nested.typeDescriptor)}($argList)"
+          case '[' =>
+            val n = in.readUnsignedShort()
+            val parts = (0 until n).map(_ => serializeElementValue(in))
+            parts.mkString("{", ", ", "}")
+          case other =>
+            sys.error(s"Unknown annotation element_value tag: '$other'")
+        }
+      }
+
+      private def stripFieldDescriptor(desc: String): String =
+        if (desc.startsWith("L") && desc.endsWith(";"))
+          slashesToDots(desc.substring(1, desc.length - 1))
+        else desc
+
+      private def constantInt(idx: Int): Int =
+        constantPool(idx).value.get.asInstanceOf[java.lang.Integer].intValue
+      private def constantLong(idx: Int): Long =
+        constantPool(idx).value.get.asInstanceOf[java.lang.Long].longValue
+      private def constantFloat(idx: Int): Float =
+        constantPool(idx).value.get.asInstanceOf[java.lang.Float].floatValue
+      private def constantDouble(idx: Int): Double =
+        constantPool(idx).value.get.asInstanceOf[java.lang.Double].doubleValue
     }
   }
   private def array[T: scala.reflect.ClassTag](size: Int)(f: => T) = Array.tabulate(size)(_ => f)

--- a/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/ParserSpecification.scala
+++ b/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/ParserSpecification.scala
@@ -14,7 +14,9 @@ package internal
 package inc
 package classfile
 
+import java.io.File
 import sbt.internal.util.ConsoleLogger
+import sbt.io.IO
 
 class ParserSpecification extends UnitSpec {
 
@@ -62,6 +64,194 @@ class ParserSpecification extends UnitSpec {
     assert(entry.isDefined)
     assert(entry.get.outerClassName == "java.util.AbstractMap")
     assert(entry.get.isPublic)
+  }
+
+  it should "parse Exceptions attribute for Thread.sleep" in {
+    val logger = ConsoleLogger()
+    val cf = Parser(sbt.io.IO.classfileLocation(classOf[Thread]), logger)
+    val sleep = cf.methods
+      .find(m => m.name.contains("sleep") && m.descriptor.contains("(J)V"))
+      .getOrElse(fail("Thread.sleep(long) not found"))
+    val exceptions = cf.methodExceptions(sleep.attributes)
+    assert(exceptions.contains("java.lang.InterruptedException"))
+  }
+
+  it should "expose access-flag predicates on FieldOrMethodInfo" in {
+    val logger = ConsoleLogger()
+    val stringCf = Parser(sbt.io.IO.classfileLocation(classOf[String]), logger)
+
+    val ctor = stringCf.methods
+      .find(m => m.isConstructor && m.descriptor.contains("(Ljava/lang/String;)V"))
+      .getOrElse(fail("String(String) constructor not found"))
+    assert(ctor.isConstructor)
+    assert(!ctor.isStatic)
+    assert(!ctor.isStaticInit)
+
+    // String.format(String, Object...) is varargs
+    val format = stringCf.methods
+      .find(m =>
+        m.name.contains("format") &&
+          m.descriptor.exists(d =>
+            d.startsWith("(Ljava/lang/String;[Ljava/lang/Object;)") && d.endsWith(
+              "Ljava/lang/String;"
+            )
+          )
+      )
+      .getOrElse(fail("String.format(String, Object...) not found"))
+    assert(format.isVarArgs)
+    assert(format.isStatic)
+
+    val boolCf = Parser(sbt.io.IO.classfileLocation(classOf[java.lang.Boolean]), logger)
+    val trueField = boolCf.fields
+      .find(_.name.contains("TRUE"))
+      .getOrElse(fail("Boolean.TRUE field not found"))
+    assert(trueField.isStatic)
+    assert(trueField.isFinal)
+    assert(trueField.isPublic)
+  }
+
+  it should "parse all element_value kinds in RuntimeVisibleAnnotations" in {
+    IO.withTemporaryDirectory { temp =>
+      val sources = Map(
+        "TestEnum.java" -> "public enum TestEnum { A, B }",
+        "Nested.java" ->
+          """|import java.lang.annotation.*;
+             |@Retention(RetentionPolicy.RUNTIME)
+             |public @interface Nested { String value(); }
+             |""".stripMargin,
+        "TestAnn.java" ->
+          """|import java.lang.annotation.*;
+             |@Retention(RetentionPolicy.RUNTIME)
+             |public @interface TestAnn {
+             |  String s();
+             |  int i();
+             |  boolean b();
+             |  char c();
+             |  double d();
+             |  float f();
+             |  long j();
+             |  byte bytev();
+             |  short shortv();
+             |  TestEnum e();
+             |  Class<?> cls();
+             |  int[] arr();
+             |  Nested nested();
+             |}
+             |""".stripMargin,
+        "Subject.java" ->
+          """|public class Subject {
+             |  @TestAnn(s="hello", i=42, b=true, c='x', d=3.14, f=2.5f, j=100L,
+             |           bytev=1, shortv=2, e=TestEnum.A, cls=String.class,
+             |           arr={1,2,3}, nested=@Nested(value="n"))
+             |  public void m() {}
+             |}
+             |""".stripMargin,
+      )
+      val outDir = compileJavaSources(temp, sources)
+      val cf = Parser(new File(outDir, "Subject.class"), ConsoleLogger())
+      val m = cf.methods
+        .find(_.name.contains("m"))
+        .getOrElse(fail("method m() not found"))
+      val ann = cf
+        .annotations(m.attributes)
+        .find(_.typeDescriptor == "LTestAnn;")
+        .getOrElse(fail("@TestAnn not found on method m()"))
+      val args = ann.arguments.map(a => a.name -> a.value).toMap
+      assert(args("s") == "\"hello\"")
+      assert(args("i") == "42")
+      assert(args("b") == "true")
+      assert(args("c") == "'x'")
+      assert(args("d") == "3.14d")
+      assert(args("f") == "2.5f")
+      assert(args("j") == "100L")
+      assert(args("bytev") == "(byte)1")
+      assert(args("shortv") == "(short)2")
+      assert(args("e") == "TestEnum.A")
+      assert(args("cls") == "java.lang.String.class")
+      assert(args("arr") == "{1, 2, 3}")
+      assert(args("nested") == "@Nested(value=\"n\")")
+    }
+  }
+
+  it should "parse parameter annotations by position" in {
+    IO.withTemporaryDirectory { temp =>
+      val sources = Map(
+        "PA.java" ->
+          """|import java.lang.annotation.*;
+             |@Retention(RetentionPolicy.RUNTIME)
+             |@Target(ElementType.PARAMETER)
+             |public @interface PA {}
+             |""".stripMargin,
+        "PB.java" ->
+          """|import java.lang.annotation.*;
+             |@Retention(RetentionPolicy.RUNTIME)
+             |@Target(ElementType.PARAMETER)
+             |public @interface PB {}
+             |""".stripMargin,
+        "Subject.java" ->
+          """|public class Subject {
+             |  public void m(@PA String a, String b, @PA @PB String c) {}
+             |}
+             |""".stripMargin,
+      )
+      val outDir = compileJavaSources(temp, sources)
+      val cf = Parser(new File(outDir, "Subject.class"), ConsoleLogger())
+      val m = cf.methods
+        .find(mm =>
+          mm.name.contains("m") && mm.descriptor.exists(
+            _ == "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V"
+          )
+        )
+        .getOrElse(fail("m(String, String, String) not found"))
+      val pas = cf.parameterAnnotations(m.attributes)
+      assert(pas.length == 3, s"expected 3 parameter slots, got ${pas.length}")
+      assert(pas(0).map(_.typeDescriptor).toSet == Set("LPA;"))
+      assert(pas(1).isEmpty, s"expected no annotations on parameter 1, got ${pas(1)}")
+      assert(pas(2).map(_.typeDescriptor).toSet == Set("LPA;", "LPB;"))
+    }
+  }
+
+  it should "detect bridge methods on generic classes" in {
+    IO.withTemporaryDirectory { temp =>
+      val sources = Map(
+        "Comp.java" ->
+          """|import java.util.Comparator;
+             |public class Comp implements Comparator<String> {
+             |  @Override public int compare(String a, String b) { return a.compareTo(b); }
+             |}
+             |""".stripMargin
+      )
+      val outDir = compileJavaSources(temp, sources)
+      val cf = Parser(new File(outDir, "Comp.class"), ConsoleLogger())
+      // The bridge has the erased descriptor (Ljava/lang/Object;Ljava/lang/Object;)I.
+      val bridge = cf.methods.find(m =>
+        m.name.contains("compare") &&
+          m.descriptor.contains("(Ljava/lang/Object;Ljava/lang/Object;)I")
+      )
+      assert(bridge.isDefined, "expected an erasure bridge for compare")
+      assert(bridge.get.isBridge)
+      assert(bridge.get.isSynthetic)
+    }
+  }
+
+  private def compileJavaSources(tempDir: File, sources: Map[String, String]): File = {
+    import javax.tools.{ StandardLocation, ToolProvider }
+    import scala.jdk.CollectionConverters._
+    val srcDir = new File(tempDir, "src")
+    val outDir = new File(tempDir, "out")
+    srcDir.mkdir()
+    outDir.mkdir()
+    val files = sources.toSeq.map { case (name, src) =>
+      val f = new File(srcDir, name); IO.write(f, src); f
+    }
+    val compiler = ToolProvider.getSystemJavaCompiler()
+    val fileManager = compiler.getStandardFileManager(null, null, null)
+    fileManager.setLocation(StandardLocation.CLASS_OUTPUT, Seq(outDir).asJava)
+    val units = fileManager.getJavaFileObjectsFromFiles(files.asJava)
+    val ok = compiler.getTask(null, fileManager, null, null, null, units).call()
+    fileManager.close()
+    assert(ok, s"javac failed compiling fixtures in $srcDir")
+    outDir
   }
 
 }


### PR DESCRIPTION
Set as a DRAFT first to see if this is the direction the community wants to go.

## Summary

Extends #1660 to the remaining reflection call sites in `ClassToAPI`. Continues chipping away at sbt/sbt#117 (the oldest open sbt bug, July 2011) where `ClassToAPI`'s reflection on a class triggers `NoClassDefFoundError` / `TypeNotPresentException` when a referenced type lives in an optional dep that isn't on the analysis classpath.

#1660 fixed the inner-class case by reading the `InnerClasses` attribute directly. This PR applies the same pattern to the residual sites — methods, constructors, fields, annotations, and exceptions — by keeping reflection as the primary path and falling back to classfile parsing when reflection throws `LinkageError | TypeNotPresentException | ClassNotFoundException`. The reflection path is **unchanged**, so the happy path has zero risk of behavioral regression.

### Why now

Our org is migrating onto Mill + Zinc; #1660 cleared the inner-class crashes but we still hit `ClassToAPI` aborts on classes whose method return / parameter types reference optional deps (e.g. Spring's `compileOnly` + JBoss VFS pattern), and on methods declaring checked exceptions whose types aren't on the classpath.

## Approach

`structure(c, enclPkg, cmap)` becomes a dispatcher:

```scala
try structureReflective(c, enclPkg, cmap)
catch {
  case e: (LinkageError | TypeNotPresentException | ClassNotFoundException) =>
    cmap.log.warn(s"Reflection failed introspecting \${c.getName} (...); falling back to classfile parser")
    structureFromClassfile(c, enclPkg, cmap)
}
```

The same wrap pattern is applied at `c.getAnnotations` and `c.getTypeParameters` in `toDefinitions0`. The fallback emits a `warn` so this rare path is observable in incremental compilation logs.

## Changes

| File | What |
|------|------|
| `ClassFile.scala` | New `ParsedAnnotation` / `ParsedAnnotationArg` case classes. Trait methods `annotations(attrs)`, `parameterAnnotations(attrs)`, `methodExceptions(attrs)`. `AttributeInfo` predicates for `Exceptions` / `RuntimeVisible+Invisible ParameterAnnotations`. `FieldOrMethodInfo` predicates (`isPrivate`/`isProtected`/`isFinal`/`isAbstract`/`isVarArgs`/`isBridge`/`isSynthetic`/`isConstructor`/`isStaticInit`/`isMain`) and the corresponding `ACC_*` constants. |
| `Parser.scala` | Structured parsers for the three new attribute kinds (JVMS §4.7.5, §4.7.16, §4.7.18) reusing the existing constant-pool helpers. `element_value` serializer covers all 13 kinds including nested annotations and arrays. |
| `ClassToAPI.scala` | `structure()` dispatcher + `structureFromClassfile`. `classAnnotationsSafe` and `classTypeParametersSafe` wrappers at the class level. `cf*` helpers convert `FieldOrMethodInfo` to `api.Def`/`Val`/`Var` directly. Inherited members carry the parent's `(Class, ClassFile)` so attribute byte indices resolve against the correct constant pool (a bug caught mid-refactor — without this, reads either return garbage or trip the `entry.tag == ConstantUTF8` assertion in `toUTF8`). Main-class detection moves to the classfile unconditionally (strictly more reliable; no transitive-dep resolution). |
| `DescriptorParser.scala` (new) | Parses JVM field/method descriptors into `xsbti.api.Type` without loading the referenced classes. Mirrors `ClassToAPI.PrimitiveRefs` (`I` → `scala.Int`, etc.) so fallback-produced types hash-compatibly with the reflection path. |
| `ParserSpecification.scala` | +5 tests: `methodExceptions` against `Thread.sleep`, `FieldOrMethodInfo` predicates against JDK, full `element_value` kind coverage via inline-compiled fixture, parameter annotations indexed by position, bridge/synthetic on erasure bridge. |
| `ClassToAPISpecification.scala` | +7 tests: fallback on missing return / parameter / field / class-annotation types (last pins a documented limitation), inherited-member parent-constant-pool regression, `@throws` annotation emission, warn-on-fallback logging. |

## Deferred (TODOs in source)

These are intentional follow-ups to keep this PR scoped:

1. **`Signature` attribute parser (JVMS §4.7.9)** — `classTypeParametersSafe` currently degrades to an empty type-parameter list when reflection on `c.getTypeParameters` throws. A signature parser would also let the method/field fallbacks recover generic return types, generic parameter types, and generic field types. TODO on `classTypeParametersSafe`.
2. **Two-layer supertype recovery** — `allSuperTypesSafe` returns `Seq.empty` on reflection failure, which drops the `cmap.inherited` edges (incremental invalidation cascade) and the parent types in the instance `Structure` (API hash). Right fix: retry with raw `getSuperclass`/`getInterfaces` (no generics), then if that still throws, use `cf.superClassName` + `cf.interfaceNames` directly. TODO on `allSuperTypesSafe`.
3. **Silently-dropped class annotations** — modern JDKs' `c.getAnnotations()` silently drops unresolvable annotation types rather than throwing, so `classAnnotationsSafe` doesn't get a chance to fall back for that specific case. Pinned as a `(limitation)` test. Fix: switch class annotation reading off reflection entirely. TODO on `classAnnotationsSafe`.