### PR TITLE
Fix IllegalAccessError analyzing Java compiled with --add-exports (#837)

### DIFF
--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassToAPI.scala
@@ -271,7 +271,11 @@ object ClassToAPI {
     val loader = if (cl == null) ClassLoader.getSystemClassLoader else cl
     try Some(loader.loadClass(info.innerClassName))
     catch {
-      case e: (ClassNotFoundException | NoClassDefFoundError) =>
+      // Skip inner classes that can't be loaded for analysis: a missing referenced type
+      // (NoClassDefFoundError, sbt/sbt#117), or a superclass in a module not exported to the
+      // unnamed module (IllegalAccessError from --add-exports, sbt/zinc#837). Structural failures
+      // such as VerifyError / ClassFormatError are left to propagate as real classfile problems.
+      case e: (ClassNotFoundException | NoClassDefFoundError | IllegalAccessError) =>
         log.warn(s"Could not load inner class ${info.innerClassName}: $e")
         None
     }

--- a/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/ClassToAPISpecification.scala
+++ b/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/ClassToAPISpecification.scala
@@ -109,6 +109,85 @@ class ClassToAPISpecification extends UnitSpec {
     }
   }
 
+  // sbt/zinc#837
+  it should "not throw IllegalAccessError when inner class superclass is inaccessible" in {
+    IO.withTemporaryDirectory { temp =>
+      val libDir = new File(temp, "lib")
+      val srcDir = new File(temp, "src")
+      libDir.mkdir()
+      srcDir.mkdir()
+
+      // Compile against a public Base so Outer.Inner compiles cleanly.
+      val baseFile = new File(temp, "Base.java")
+      IO.write(baseFile, "package pkg; public class Base {}")
+      compileJava(Seq(baseFile), libDir, Seq.empty)
+
+      val outerFile = new File(temp, "Outer.java")
+      IO.write(
+        outerFile,
+        """|public class Outer {
+           |  public class Inner extends pkg.Base {}
+           |  public void hello() {}
+           |}
+           |""".stripMargin
+      )
+      compileJava(Seq(outerFile), srcDir, Seq(libDir))
+
+      // Overwrite Base with a package-private version: Outer$Inner (in the default package) can no
+      // longer access its superclass, so loading it throws IllegalAccessError at link time, the
+      // same failure mode as classes compiled with --add-exports.
+      IO.write(baseFile, "package pkg; class Base {}")
+      compileJava(Seq(baseFile), srcDir, Seq.empty)
+
+      Using.resource(new java.net.URLClassLoader(Array(srcDir.toURI.toURL), null)) { classloader =>
+        val outerClass = classloader.loadClass("Outer")
+        val (apis, _, _) = ClassToAPI.process(Seq(outerClass))
+
+        val names = apis.map(_.name).toSet
+        assert(names.contains("Outer"))
+        assert(!names.contains("Outer.Inner"))
+      }
+    }
+  }
+
+  // sbt/zinc#837 completeness probe: a class that LOADS but references an inaccessible type only in
+  // its generic supertype and member positions must not crash ClassToAPI. Reflection resolves such
+  // types without an access check, so IllegalAccessError only arises at class-load (caught by
+  // JavaAnalyze.load / loadInnerClass), not during the reflective supertype/member walk.
+  it should "not crash when a loaded class references an inaccessible type in supertype/members" in {
+    IO.withTemporaryDirectory { temp =>
+      val srcDir = new File(temp, "src")
+      srcDir.mkdir()
+
+      val containerFile = new File(temp, "Container.java")
+      IO.write(containerFile, "package pkg; public class Container<T> {}")
+      val secretFile = new File(temp, "Secret.java")
+      IO.write(secretFile, "package pkg; public class Secret {}")
+      val holderFile = new File(temp, "Holder.java")
+      IO.write(
+        holderFile,
+        """|public class Holder extends pkg.Container<pkg.Secret> {
+           |  public pkg.Secret field;
+           |  public pkg.Secret get(pkg.Secret p) { return null; }
+           |}
+           |""".stripMargin
+      )
+      compileJava(Seq(containerFile, secretFile, holderFile), srcDir, Seq.empty)
+
+      // Make Secret package-private: Holder (default package) can no longer access it, but its raw
+      // supertype pkg.Container stays public so Holder still loads. Secret is now reachable only via
+      // the generic supertype signature and Holder's members.
+      IO.write(secretFile, "package pkg; class Secret {}")
+      compileJava(Seq(secretFile), srcDir, Seq.empty)
+
+      Using.resource(new java.net.URLClassLoader(Array(srcDir.toURI.toURL), null)) { classloader =>
+        val holder = classloader.loadClass("Holder")
+        val (apis, _, _) = ClassToAPI.process(Seq(holder))
+        assert(apis.map(_.name).toSet.contains("Holder"))
+      }
+    }
+  }
+
   private def compileJava(files: Seq[File], outputDir: File, classpath: Seq[File]): Unit = {
     import javax.tools.{ StandardLocation, ToolProvider }
     import scala.jdk.CollectionConverters._

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/JavaAnalyze.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/JavaAnalyze.scala
@@ -103,7 +103,7 @@ private[sbt] object JavaAnalyze {
           // module not exported to the unnamed module). Fall back to the classfile so the product
           // and member-ref dependencies are still recorded; the API and inheritance dependencies
           // need the loaded Class and are skipped.
-          classFileSourceName(classFile) match {
+          canonicalClassName(classFile) match {
             case Some(className) =>
               analysis.generatedNonLocalClass(source, finalClassFile, binaryClassName, className)
               binaryClassNameToSourceName.update(binaryClassName, className)
@@ -302,13 +302,13 @@ private[sbt] object JavaAnalyze {
   }
 
   /**
-   * Reconstructs the source (canonical) name of a class from its classfile's InnerClasses
-   * attribute, for classes that cannot be reflectively loaded (sbt/zinc#837). This mirrors the
-   * canonical name that [[loadEnclosingClass]] derives via reflection for member and top-level
-   * classes, using the authoritative simple names from the attribute. Returns None for local and
-   * anonymous classes (which have no canonical name and are recorded as local products instead).
+   * Reconstructs the canonical name of a class from its classfile's InnerClasses attribute, for
+   * classes that cannot be reflectively loaded (sbt/zinc#837). This mirrors the canonical name that
+   * [[loadEnclosingClass]] derives via reflection for member and top-level classes, using the
+   * authoritative simple names from the attribute. Returns None for local and anonymous classes
+   * (which have no canonical name and are recorded as local products instead).
    */
-  private def classFileSourceName(classFile: ClassFile): Option[String] = {
+  private def canonicalClassName(classFile: ClassFile): Option[String] = {
     val inners = classFile.innerClasses
     def canonical(binaryName: String): Option[String] =
       inners.find(_.innerClassName == binaryName) match {

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/JavaAnalyze.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/JavaAnalyze.scala
@@ -48,15 +48,11 @@ private[sbt] object JavaAnalyze {
     val directOutputJarOrNull: Path = JarUtils.getOutputJar(output).getOrElse(null)
     val mappedOutputJarOrNull: Path = finalJarOutput.getOrElse(null)
 
-    def load(tpe: String, errMsg: => Option[String]): Option[Class[?]] = {
-      if (tpe.endsWith("module-info")) None
-      else
-        try {
-          Some(Class.forName(tpe, false, loader))
-        } catch {
-          case e: Throwable => errMsg.foreach(msg => log.warn(msg + " : " + e.toString)); None
-        }
-    }
+    def load(tpe: String, errMsg: => Option[String]): Option[Class[?]] =
+      try Some(Class.forName(tpe, false, loader))
+      catch {
+        case e: Throwable => errMsg.foreach(msg => log.warn(msg + " : " + e.toString)); None
+      }
 
     def remapClassFile(classFile: Path) =
       if (directOutputJarOrNull != null && classFile.getFileSystem.provider.getScheme == "jar")
@@ -75,6 +71,9 @@ private[sbt] object JavaAnalyze {
     )
 
     val binaryClassNameToLoadedClass = new mutable.HashMap[String, Class[?]]
+    // Source (canonical) names of classes that couldn't be reflectively loaded (sbt/zinc#837),
+    // derived from the classfile so their products and member-ref dependencies are still recorded.
+    val binaryClassNameToSourceName = new mutable.HashMap[String, String]
 
     val classfilesCache = mutable.Map.empty[String, Path]
 
@@ -86,19 +85,30 @@ private[sbt] object JavaAnalyze {
       _ <- classFile.sourceFile orElse guessSourceName(newClass.getFileName.toString)
       source <- guessSourcePath(sourceMap, classFile, log)
       binaryClassName = classFile.className
-      loadedClass <- load(
-        binaryClassName,
-        Some("Error reading API from class file: " + binaryClassName)
-      )
+      // module-info.class is not a real class; it has no API or dependencies to analyze, and is
+      // deliberately excluded (do not let it fall into the unloadable-class fallback below).
+      if !binaryClassName.endsWith("module-info")
     } {
-      binaryClassNameToLoadedClass.update(binaryClassName, loadedClass)
-
-      val srcClassName = loadEnclosingClass(loadedClass)
       val finalClassFile: Path = remapClassFile(newClass)
-      srcClassName match {
-        case Some(className) =>
-          analysis.generatedNonLocalClass(source, finalClassFile, binaryClassName, className)
-        case None => analysis.generatedLocalClass(source, finalClassFile)
+      load(binaryClassName, Some("Error reading API from class file: " + binaryClassName)) match {
+        case Some(loadedClass) =>
+          binaryClassNameToLoadedClass.update(binaryClassName, loadedClass)
+          loadEnclosingClass(loadedClass) match {
+            case Some(className) =>
+              analysis.generatedNonLocalClass(source, finalClassFile, binaryClassName, className)
+            case None => analysis.generatedLocalClass(source, finalClassFile)
+          }
+        case None =>
+          // sbt/zinc#837: the class can't be reflectively loaded (e.g. its superclass is in a
+          // module not exported to the unnamed module). Fall back to the classfile so the product
+          // and member-ref dependencies are still recorded; the API and inheritance dependencies
+          // need the loaded Class and are skipped.
+          classFileSourceName(classFile) match {
+            case Some(className) =>
+              analysis.generatedNonLocalClass(source, finalClassFile, binaryClassName, className)
+              binaryClassNameToSourceName.update(binaryClassName, className)
+            case None => analysis.generatedLocalClass(source, finalClassFile)
+          }
       }
 
       sourceToClassFiles(source) += classFile
@@ -107,7 +117,7 @@ private[sbt] object JavaAnalyze {
     // get class to class dependencies and map back to source to class dependencies
     for ((source, classFiles) <- sourceToClassFiles) {
       analysis.startSource(source)
-      val loadedClasses = classFiles.map(c => binaryClassNameToLoadedClass(c.className))
+      val loadedClasses = classFiles.flatMap(c => binaryClassNameToLoadedClass.get(c.className))
       // Local classes are either local, anonymous or inner Java classes
       val (nonLocalClasses, localClassesOrStale) =
         loadedClasses.partition(_.getCanonicalName != null)
@@ -127,7 +137,9 @@ private[sbt] object JavaAnalyze {
           loadedClass <- binaryClassNameToLoadedClass.get(className)
           sourceName <- binaryToSourceName(loadedClass)
         } yield sourceName
-        nonLocalSourceName.orElse(localClassesToSources.get(className))
+        nonLocalSourceName
+          .orElse(binaryClassNameToSourceName.get(className))
+          .orElse(localClassesToSources.get(className))
       }
 
       def processDependency(
@@ -205,6 +217,15 @@ private[sbt] object JavaAnalyze {
         case (className, inheritanceDeps) =>
           processDependencies(inheritanceDeps, LocalDependencyByInheritance, className)
       }
+
+      // sbt/zinc#837: classes that couldn't be reflectively loaded have no extractable API, but
+      // their direct superclass and interfaces are still in the classfile, so record those
+      // inheritance edges (e.g. the `Inner extends pkg.Base` relationship that caused the issue).
+      for (classFile <- classFiles if binaryClassNameToSourceName.contains(classFile.className)) {
+        val parents =
+          (classFile.superClassName +: classFile.interfaceNames.toIndexedSeq).filter(_.nonEmpty)
+        processDependencies(parents, DependencyByInheritance, classFile.className)
+      }
     }
   }
 
@@ -278,6 +299,25 @@ private[sbt] object JavaAnalyze {
         loadEnclosingClass(clazz.getEnclosingClass)
       case other => other
     }
+  }
+
+  /**
+   * Reconstructs the source (canonical) name of a class from its classfile's InnerClasses
+   * attribute, for classes that cannot be reflectively loaded (sbt/zinc#837). This mirrors the
+   * canonical name that [[loadEnclosingClass]] derives via reflection for member and top-level
+   * classes, using the authoritative simple names from the attribute. Returns None for local and
+   * anonymous classes (which have no canonical name and are recorded as local products instead).
+   */
+  private def classFileSourceName(classFile: ClassFile): Option[String] = {
+    val inners = classFile.innerClasses
+    def canonical(binaryName: String): Option[String] =
+      inners.find(_.innerClassName == binaryName) match {
+        case None                                      => Some(binaryName) // top-level class
+        case Some(info) if info.outerClassName.isEmpty => None // local or anonymous class
+        case Some(info) =>
+          canonical(info.outerClassName).map(_ + "." + info.innerName.getOrElse(binaryName))
+      }
+    canonical(classFile.className)
   }
 
   /*

--- a/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/AnalyzeSpecification.scala
+++ b/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/AnalyzeSpecification.scala
@@ -14,6 +14,10 @@ package internal
 package inc
 package classfile
 
+import java.io.File
+import sbt.io.IO
+import xsbti.api.DependencyContext._
+
 class AnalyzeSpecification extends UnitSpec {
 
   "Analyze" should "extract dependencies of inner classes" in {
@@ -212,6 +216,98 @@ class AnalyzeSpecification extends UnitSpec {
     )
     assert(deps.memberRef("Foo").contains("A1"))
     assert(deps.memberRef("Foo").contains("A2"))
+  }
+
+  // sbt/zinc#837: an inner class whose superclass is inaccessible can't be reflectively loaded,
+  // but JavaAnalyze should still record its product and member-ref deps from the classfile rather
+  // than dropping it (or crashing).
+  "Analyze" should "record products for inner classes that cannot be reflectively loaded" in {
+    IO.withTemporaryDirectory { temp =>
+      val classesDir = new File(temp, "classes")
+      val libDir = new File(temp, "lib")
+      classesDir.mkdir()
+      libDir.mkdir()
+
+      // Compile against a public Base so Outer.Inner compiles cleanly.
+      val baseFile = new File(temp, "Base.java")
+      IO.write(baseFile, "package pkg; public class Base {}")
+      JavaCompilerForUnitTesting.compileJava(Seq(baseFile), libDir, Seq.empty)
+
+      val outerFile = new File(temp, "Outer.java")
+      IO.write(
+        outerFile,
+        """|public class Outer {
+           |  public class Inner extends pkg.Base {}
+           |}
+           |""".stripMargin
+      )
+      JavaCompilerForUnitTesting.compileJava(Seq(outerFile), classesDir, Seq(libDir))
+
+      // Overwrite Base with a package-private version: Outer$Inner (in the default package) can no
+      // longer access its superclass, so it fails to load with IllegalAccessError during analysis.
+      IO.write(baseFile, "package pkg; class Base {}")
+      JavaCompilerForUnitTesting.compileJava(Seq(baseFile), classesDir, Seq.empty)
+
+      val callback = JavaCompilerForUnitTesting.analyze(classesDir, Seq(outerFile))
+
+      // The product for the un-loadable inner class is still recorded, derived from the classfile.
+      val products = callback.productClassesToSources.keySet.map(_.getFileName.toString)
+      assert(products.contains("Outer.class"))
+      assert(products.contains("Outer$Inner.class"))
+
+      // ... under its classfile-derived source (canonical) name.
+      val recordedNames = callback.classNames.values.flatten.toSet
+      assert(recordedNames.contains(("Outer.Inner", "Outer$Inner")))
+
+      // Member-ref deps to the un-loadable class are recorded (Outer references Outer.Inner) ...
+      assert(
+        callback.classDependencies.contains(("Outer.Inner", "Outer", DependencyByMemberRef))
+      )
+      // ... as are member-ref deps from it (Outer.Inner references its external superclass pkg.Base).
+      assert(
+        callback.binaryDependencies.exists {
+          case (_, onBinaryName, fromClassName, ctx) =>
+            onBinaryName == "pkg.Base" &&
+            fromClassName == "Outer.Inner" &&
+            ctx == DependencyByMemberRef
+        }
+      )
+      // ... and crucially the inheritance edge that caused the issue (Outer.Inner extends pkg.Base),
+      // recovered from the classfile since the class can't be loaded to extract its API.
+      assert(
+        callback.binaryDependencies.exists {
+          case (_, onBinaryName, fromClassName, ctx) =>
+            onBinaryName == "pkg.Base" &&
+            fromClassName == "Outer.Inner" &&
+            ctx == DependencyByInheritance
+        }
+      )
+    }
+  }
+
+  // sbt/zinc#837 regression: the unloadable-class fallback must not record module-info.class, which
+  // load() deliberately skips (it is not a real class).
+  "Analyze" should "not record module-info as a generated class" in {
+    IO.withTemporaryDirectory { temp =>
+      val classesDir = new File(temp, "classes")
+      classesDir.mkdir()
+
+      val moduleInfo = new File(temp, "module-info.java")
+      IO.write(moduleInfo, "module foo {}")
+      val fooFile = new File(temp, "Foo.java")
+      IO.write(fooFile, "package p; public class Foo {}")
+      JavaCompilerForUnitTesting.compileJava(Seq(moduleInfo, fooFile), classesDir, Seq.empty)
+
+      val callback = JavaCompilerForUnitTesting.analyze(classesDir, Seq(moduleInfo, fooFile))
+
+      val products = callback.productClassesToSources.keySet.map(_.getFileName.toString)
+      assert(products.contains("Foo.class"))
+      assert(!products.contains("module-info.class"))
+
+      val recordedNames =
+        callback.classNames.values.flatten.toSet.map((p: (String, String)) => p._1)
+      assert(!recordedNames.contains("module-info"))
+    }
   }
 
 }

--- a/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/JavaCompilerForUnitTesting.scala
+++ b/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/JavaCompilerForUnitTesting.scala
@@ -103,6 +103,40 @@ object JavaCompilerForUnitTesting {
     }
   }
 
+  /** Compiles the given Java sources to `outputDir`, with `classpath` available at compile time. */
+  def compileJava(files: Seq[File], outputDir: File, classpath: Seq[File]): Unit = {
+    val compiler = ToolProvider.getSystemJavaCompiler()
+    val fileManager = compiler.getStandardFileManager(null, null, null)
+    fileManager.setLocation(StandardLocation.CLASS_OUTPUT, Seq(outputDir).asJava)
+    if (classpath.nonEmpty)
+      fileManager.setLocation(StandardLocation.CLASS_PATH, classpath.asJava)
+    val units = fileManager.getJavaFileObjectsFromFiles(files.asJava)
+    compiler.getTask(null, fileManager, null, null, null, units).call()
+    fileManager.close()
+  }
+
+  /**
+   * Runs [[JavaAnalyze]] over the class files already present in `classesDir`, mapping them back to
+   * the given `srcFiles`. Unlike [[compileJavaSrcs]] this does not compile, so the caller can stage
+   * the class files (e.g. compile against one classpath, then swap a dependency) before analysis.
+   */
+  def analyze(classesDir: File, srcFiles: Seq[File]): TestCallback = {
+    val srcs: List[VirtualFile] = srcFiles.toList.map(f => new TestVirtualFile(f.toPath))
+    val analysisCallback = new TestCallback
+    val classFiles = (sbt.io.PathFinder(classesDir) ** "*.class").get().map(_.toPath)
+    val classloader = new URLClassLoader(Array(classesDir.toURI.toURL), null)
+    val output = new SingleOutput {
+      override def getOutputDirectoryAsPath: Path = classesDir.toPath
+      override def getOutputDirectory: File = classesDir
+    }
+    JavaAnalyze(classFiles, srcs, ConsoleLogger(), output, finalJarOutput = None)(
+      analysisCallback,
+      classloader,
+      (_, classes) => extractParents(classes)
+    )
+    analysisCallback
+  }
+
   private def prepareSrcFile(baseDir: File, fileName: String, src: String): File = {
     val srcFile = new File(baseDir, fileName)
     IO.write(srcFile, src)


### PR DESCRIPTION
Fixes #837.

The crash is `ClassToAPI` reflectively loading an inner class whose superclass is inaccessible (a module-internal type reached via `--add-exports`); the `IllegalAccessError` propagated out and aborted the whole compile.

- `ClassToAPI.loadInnerClass` now catches `IllegalAccessError` alongside `ClassNotFoundException`/`NoClassDefFoundError`, so an inner class that can't be linked in the analysis classloader is logged and skipped instead of crashing. Structural errors (`VerifyError`/`ClassFormatError`/…) are intentionally left to propagate as genuine classfile problems.
- `JavaAnalyze` no longer silently drops a class that fails reflective loading: it records the **product**, **member-ref** dependencies, and direct **inheritance** dependencies (superclass + interfaces) for it, derived from the classfile. Canonical names are reconstructed from the `InnerClasses` attribute.
- `module-info.class` is explicitly excluded from that fallback (it is deliberately not analyzed as a class).

## Known limitation / follow-up
The un-loadable class still gets no `api.ClassLike` recorded (API extraction is reflection-based and the class can't be loaded), so name-hashing can miss dependents when **that class's own** public shape changes. Pre-existing and shared with the `NoClassDefFoundError` case (sbt/sbt#117). The complete fix — classfile-based Java API extraction — would also resolve #151 and #1697 and is best done separately.
