### PR TITLE
Record classfile-derived API for un-loadable Java classes (#837)

### DIFF
--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
@@ -1,0 +1,307 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package sbt
+package internal
+package inc
+
+import java.io.{ ByteArrayInputStream, DataInputStream }
+import java.lang.reflect.Modifier
+import scala.collection.mutable.ArrayBuffer
+import xsbti.api
+import xsbti.api.SafeLazyProxy
+import sbt.internal.inc.classfile.{ AttributeInfo, ClassFile, FieldOrMethodInfo }
+import sbt.util.Logger
+
+/**
+ * Builds an [[xsbti.api.ClassLike]] for a Java class directly from its classfile, without loading
+ * it via reflection. This is the fallback used for classes that cannot be reflectively loaded
+ * during post-compile analysis (sbt/zinc#837, sbt/sbt#117) — without it those classes get no API
+ * recorded, so name-hashing can miss dependents when the class's own public shape changes.
+ *
+ * It mirrors the structure [[ClassToAPI]] produces (a class + module `ClassLike` pair, declared
+ * members split into static/instance) and reuses [[ClassToAPI]]'s access/modifier/type helpers, so
+ * the result slots into the same analysis. Member types are erased (from JVM descriptors), but
+ * generic signatures, checked exceptions, and declared annotations are folded in conservatively (raw
+ * `Signature` string / `throws` and annotation *type* names — not annotation element values), so a
+ * change to any of them still changes the hash. Enum children, type parameters, and inherited
+ * members are not modelled — see the "Phase 2" scope in docs/design/classfile-based-java-api.md. The
+ * output need not match the reflection-derived API byte-for-byte; it only needs to be deterministic
+ * and to change when the class's public shape changes.
+ */
+object ClassfileToAPI {
+  import api.DefinitionType.{ ClassDef, Module, Trait }
+
+  private val noAnnotations = new Array[api.Annotation](0)
+  private val noTypeParameters = new Array[api.TypeParameter](0)
+  private val noTypes = new Array[api.Type](0)
+  private val noStrings = new Array[String](0)
+  private val noDefinitions = new Array[api.ClassDefinition](0)
+
+  private def strict[T <: AnyRef](t: T): api.Lazy[T] = SafeLazyProxy.strict(t)
+
+  // A synthetic annotation that folds public-shape signals the erased descriptor can't capture —
+  // the raw generic Signature, checked-exception (throws) types, and declared annotation types —
+  // into the API, so changing any of them still changes the hash. Conservative Phase-2 fold (raw
+  // Signature string and exception/annotation *type* names, not annotation element values); proper
+  // modelling is Phase 3.
+  private val SyntheticRef = ClassToAPI.reference("xsbti.api.ClassfileApi")
+
+  private def syntheticAnnotations(parts: (String, Iterable[String])*): Array[api.Annotation] = {
+    val args = parts.flatMap {
+      case (label, values) =>
+        if (values.isEmpty) None
+        else Some(api.AnnotationArgument.of(label, values.mkString(",")))
+    }
+    if (args.isEmpty) noAnnotations
+    else Array(api.Annotation.of(SyntheticRef, args.toArray))
+  }
+
+  /** Resolved checked-exception type names from a method's `Exceptions` attribute (JVMS 4.7.5). */
+  private def exceptionNames(cf: ClassFile, attrs: Seq[AttributeInfo]): Seq[String] =
+    attrs.find(_.isNamed("Exceptions")) match {
+      case None => Nil
+      case Some(a) =>
+        try {
+          val in = new DataInputStream(new ByteArrayInputStream(a.value))
+          val count = in.readUnsignedShort()
+          List.fill(count) {
+            val classConstant = cf.constantPool(in.readUnsignedShort())
+            cf.constantPool(classConstant.nameIndex).value.fold("")(_.toString).replace('/', '.')
+          }
+        } catch { case _: Throwable => Nil }
+    }
+
+  /** Declared annotation type names from RuntimeVisible/Invisible annotations (JVMS 4.7.16). */
+  private def annotationTypeNames(cf: ClassFile, attrs: Seq[AttributeInfo]): Seq[String] = {
+    val names = ArrayBuffer.empty[String]
+    for (a <- attrs if a.isRuntimeVisibleAnnotations || a.isRuntimeInvisibleAnnotations) {
+      try {
+        val in = new DataInputStream(new ByteArrayInputStream(a.value))
+        def utf8(i: Int): String = cf.constantPool(i).value.fold("")(_.toString)
+        def skipElementValue(): Unit =
+          in.readUnsignedByte().toChar match {
+            case 'e' => in.readUnsignedShort(); in.readUnsignedShort()
+            case 'c' => in.readUnsignedShort()
+            case '@' => readAnnotation()
+            case '[' =>
+              val n = in.readUnsignedShort()
+              (0 until n).foreach(_ => skipElementValue())
+            case _ => in.readUnsignedShort()
+          }
+        def readAnnotation(): Unit = {
+          names += utf8(in.readUnsignedShort()).stripPrefix("L").stripSuffix(";").replace('/', '.')
+          val pairs = in.readUnsignedShort()
+          (0 until pairs).foreach { _ => in.readUnsignedShort(); skipElementValue() }
+        }
+        val num = in.readUnsignedShort()
+        (0 until num).foreach(_ => readAnnotation())
+      } catch { case _: Throwable => () }
+    }
+    names.toSeq
+  }
+
+  /**
+   * Produces the API (class + module `ClassLike` for each input) and the names of any classes that
+   * declare a `main` method. Each input pairs the class's source (canonical) name — supplied by the
+   * caller so it stays consistent with the product/dependency relations — with its parsed classfile.
+   */
+  def process(
+      named: Seq[(String, ClassFile)],
+      log: Logger = Logger.Null
+  ): (Seq[api.ClassLike], Seq[String]) = {
+    val classApis = ArrayBuffer.empty[api.ClassLike]
+    val mainClasses = ArrayBuffer.empty[String]
+    for ((name, cf) <- named) {
+      classApis ++= classLikes(name, cf)
+      if (cf.methods.exists(_.isMain)) mainClasses += name
+    }
+    (classApis.toSeq, mainClasses.toSeq)
+  }
+
+  private def classLikes(name: String, cf: ClassFile): Seq[api.ClassLike] = {
+    // Use the binary name's package (last '.' before the simple/binary name); the canonical name's
+    // dots would mis-split nested classes (e.g. "pkg.Outer.Inner").
+    val enclPkg = ClassToAPI.packageAndName(cf.className)._1
+    val mods = ClassToAPI.modifiers(cf.accessFlags)
+    val acc = ClassToAPI.access(cf.accessFlags, enclPkg)
+    val isInterface = Modifier.isInterface(cf.accessFlags)
+    val tpe = if (isInterface) Trait else ClassDef
+    // Top-level unless the classfile's InnerClasses attribute lists itself as a member of another.
+    val topLevel =
+      !cf.innerClasses.exists(i => i.innerClassName == cf.className && i.outerClassName.nonEmpty)
+
+    val fields = cf.fields.toIndexedSeq.map(fieldDef(cf, _, enclPkg))
+    val methods = cf.methods.toIndexedSeq.collect {
+      case m if !m.name.contains("<clinit>") => methodDef(cf, m, cf.className, enclPkg)
+    }
+    val (staticFields, instanceFields) = fields.partition(_._1)
+    val (staticMethods, instanceMethods) = methods.partition(_._1)
+    val instanceDeclared: Array[api.ClassDefinition] =
+      (instanceFields.map(_._2) ++ instanceMethods.map(_._2)).toArray
+    val staticDeclared: Array[api.ClassDefinition] =
+      (staticFields.map(_._2) ++ staticMethods.map(_._2)).toArray
+
+    val parents: Array[api.Type] =
+      (cf.superClassName +: cf.interfaceNames.toIndexedSeq)
+        .filter(_.nonEmpty)
+        .map(ClassToAPI.reference)
+        .toArray
+
+    val classAnnots = syntheticAnnotations(
+      "signature" -> cf.attributes.find(_.isSignature).map(cf.stringValue).toList,
+      "annotations" -> annotationTypeNames(cf, cf.attributes.toIndexedSeq)
+    )
+
+    val instanceStructure =
+      api.Structure.of(strict(parents), strict(instanceDeclared), strict(noDefinitions))
+    val staticStructure =
+      api.Structure.of(strict(noTypes), strict(staticDeclared), strict(noDefinitions))
+
+    val cls = api.ClassLike.of(
+      name,
+      acc,
+      mods,
+      classAnnots,
+      tpe,
+      strict(ClassToAPI.Empty),
+      strict(instanceStructure),
+      noStrings,
+      noTypes,
+      topLevel,
+      noTypeParameters
+    )
+    val stat = api.ClassLike.of(
+      name,
+      acc,
+      mods,
+      classAnnots,
+      Module,
+      strict(ClassToAPI.Empty),
+      strict(staticStructure),
+      noStrings,
+      noTypes,
+      topLevel,
+      noTypeParameters
+    )
+    cls :: stat :: Nil
+  }
+
+  /** (isStatic, FieldLike) for a classfile field. */
+  private def fieldDef(
+      cf: ClassFile,
+      f: FieldOrMethodInfo,
+      enclPkg: Option[String]
+  ): (Boolean, api.ClassDefinition) = {
+    val name = f.name.getOrElse("")
+    val mods = ClassToAPI.modifiers(f.accessFlags)
+    // Compilers inline static-final constants, so fold the constant value into the type (mirroring
+    // ClassToAPI.singletonForConstantField) so a value change (X = 1 -> 2) changes the hash.
+    val constant: Option[AnyRef] =
+      if (mods.isFinal)
+        (try cf.constantValue(name)
+        catch { case _: Throwable => None })
+      else None
+    val tpe = constant match {
+      case Some(value) =>
+        val tag = name + "$" + f.descriptor.getOrElse("") + "$" + value
+        api.Singleton.of(ClassToAPI.pathFromStrings(cf.className.split("\\.").toIndexedSeq :+ tag))
+      case None => parseFieldType(f.descriptor.getOrElse("V"))
+    }
+    val acc = ClassToAPI.access(f.accessFlags, enclPkg)
+    val annots = syntheticAnnotations(
+      "signature" -> f.attributes.find(_.isSignature).map(cf.stringValue).toList,
+      "annotations" -> annotationTypeNames(cf, f.attributes)
+    )
+    val fieldLike =
+      if (mods.isFinal) api.Val.of(name, acc, mods, annots, tpe)
+      else api.Var.of(name, acc, mods, annots, tpe)
+    (f.isStatic, fieldLike)
+  }
+
+  /** (isStatic, Def) for a classfile method; `<init>` is named like [[ClassToAPI]]'s constructors. */
+  private def methodDef(
+      cf: ClassFile,
+      m: FieldOrMethodInfo,
+      binaryName: String,
+      enclPkg: Option[String]
+  ): (Boolean, api.ClassDefinition) = {
+    val (paramTypes, returnType) = parseMethodType(m.descriptor.getOrElse("()V"))
+    val params = paramTypes.map(t =>
+      api.MethodParameter.of("", t, false, api.ParameterModifier.Plain)
+    )
+    val paramList = api.ParameterList.of(params, false)
+    // Match ClassToAPI.uniqueConstructorName, which uses the binary (not canonical) class name.
+    val name =
+      if (m.name.contains("<init>")) s"${binaryName.replace('.', ';')};init;"
+      else m.name.getOrElse("")
+    val acc = ClassToAPI.access(m.accessFlags, enclPkg)
+    val mods = ClassToAPI.modifiers(m.accessFlags)
+    val annots = syntheticAnnotations(
+      "signature" -> m.attributes.find(_.isSignature).map(cf.stringValue).toList,
+      "throws" -> exceptionNames(cf, m.attributes),
+      "annotations" -> annotationTypeNames(cf, m.attributes)
+    )
+    val d = api.Def.of(name, acc, mods, annots, noTypeParameters, Array(paramList), returnType)
+    (m.isStatic, d)
+  }
+
+  private val ObjectRef = ClassToAPI.reference("java.lang.Object")
+
+  /** Parses a JVM field descriptor (JVMS 4.3.2) into an erased [[xsbti.api.Type]]. */
+  private[inc] def parseFieldType(descriptor: String): api.Type = parseType(descriptor, 0)._1
+
+  /** Parses a JVM method descriptor (JVMS 4.3.3) into (parameter types, return type), erased. */
+  private[inc] def parseMethodType(descriptor: String): (Array[api.Type], api.Type) = {
+    val params = ArrayBuffer.empty[api.Type]
+    var i = 1 // skip '('
+    while (i < descriptor.length && descriptor.charAt(i) != ')') {
+      val (tpe, next) = parseType(descriptor, i)
+      params += tpe
+      i = next
+    }
+    // `i` should sit on ')'; on a malformed/truncated descriptor fall back to a void return rather
+    // than indexing past the end.
+    val returnType =
+      if (i + 1 < descriptor.length) parseType(descriptor, i + 1)._1
+      else ClassToAPI.primitive("void")
+    (params.toArray, returnType)
+  }
+
+  /**
+   * Parses one field type starting at `i`, returning the type and the index just past it. Unknown
+   * or truncated tokens (corrupt classfile, or a future descriptor form) degrade to an opaque
+   * `Object` reference rather than throwing — this is a best-effort fallback that must never fail a
+   * compile that would otherwise succeed.
+   */
+  private def parseType(descriptor: String, i: Int): (api.Type, Int) =
+    if (i >= descriptor.length) (ObjectRef, i + 1)
+    else
+      descriptor.charAt(i) match {
+        case 'B' => (ClassToAPI.primitive("byte"), i + 1)
+        case 'C' => (ClassToAPI.primitive("char"), i + 1)
+        case 'D' => (ClassToAPI.primitive("double"), i + 1)
+        case 'F' => (ClassToAPI.primitive("float"), i + 1)
+        case 'I' => (ClassToAPI.primitive("int"), i + 1)
+        case 'J' => (ClassToAPI.primitive("long"), i + 1)
+        case 'S' => (ClassToAPI.primitive("short"), i + 1)
+        case 'Z' => (ClassToAPI.primitive("boolean"), i + 1)
+        case 'V' => (ClassToAPI.primitive("void"), i + 1)
+        case '[' =>
+          val (elem, next) = parseType(descriptor, i + 1)
+          (ClassToAPI.array(elem), next)
+        case 'L' =>
+          val semi = descriptor.indexOf(';', i)
+          val end = if (semi < 0) descriptor.length else semi
+          (ClassToAPI.reference(descriptor.substring(i + 1, end).replace('/', '.')), end + 1)
+        case _ => (ObjectRef, i + 1)
+      }
+}

--- a/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/ClassfileToAPISpecification.scala
+++ b/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/ClassfileToAPISpecification.scala
@@ -1,0 +1,232 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package sbt
+package internal
+package inc
+
+import java.io.File
+import sbt.internal.inc.classfile.{ JavaCompilerForUnitTesting, Parser }
+import sbt.io.IO
+import sbt.util.Logger
+import xsbt.api.HashAPI
+import xsbti.api.{ ClassLike, DefinitionType }
+
+class ClassfileToAPISpecification extends UnitSpec {
+
+  // The point of Phase 2 (sbt/zinc#837): a class that can't be reflectively loaded still gets an
+  // API recorded from its classfile, and that API's hash changes when the class's public shape
+  // changes — so name-hashing invalidates dependents. The hash need not match the reflection-derived
+  // one; it only needs to be deterministic and shape-sensitive.
+  "ClassfileToAPI" should "build a deterministic API whose hash tracks the class's public shape" in {
+    IO.withTemporaryDirectory { temp =>
+      def classApi(dirName: String, source: String): ClassLike = {
+        val dir = new File(temp, dirName)
+        dir.mkdir()
+        val src = new File(dir, "Sample.java")
+        IO.write(src, source)
+        JavaCompilerForUnitTesting.compileJava(Seq(src), dir, Seq.empty)
+        val cf = Parser(new File(dir, "Sample.class").toPath, Logger.Null)
+        val (apis, _) = ClassfileToAPI.process(Seq("Sample" -> cf))
+        apis.find(_.definitionType == DefinitionType.ClassDef).get
+      }
+
+      val intGreet = "public class Sample { public int greet(int n) { return 0; } }"
+      val a = classApi("a", intGreet)
+      val aAgain = classApi("a2", intGreet)
+      // changed return type -> different public shape
+      val b = classApi("b", "public class Sample { public String greet(int n) { return null; } }")
+
+      assert(HashAPI(a) == HashAPI(aAgain), "hash must be deterministic across runs")
+      assert(HashAPI(a) != HashAPI(b), "hash must change when a method's signature changes")
+
+      // sanity: the method was actually modelled
+      val defs = a.structure.declared.collect { case d: xsbti.api.Def => d.name }.toSet
+      assert(defs.contains("greet"))
+    }
+  }
+
+  // Full path: the #837 un-loadable inner class now gets an API recorded via JavaAnalyze ->
+  // readClassfileAPI -> ClassfileToAPI, including its declared members.
+  it should "record API for an un-loadable inner class through JavaAnalyze" in {
+    IO.withTemporaryDirectory { temp =>
+      val classesDir = new File(temp, "classes")
+      val libDir = new File(temp, "lib")
+      classesDir.mkdir()
+      libDir.mkdir()
+
+      val baseFile = new File(temp, "Base.java")
+      IO.write(baseFile, "package pkg; public class Base {}")
+      JavaCompilerForUnitTesting.compileJava(Seq(baseFile), libDir, Seq.empty)
+
+      val outerFile = new File(temp, "Outer.java")
+      IO.write(
+        outerFile,
+        """|public class Outer {
+           |  public class Inner extends pkg.Base { public int answer() { return 42; } }
+           |}
+           |""".stripMargin
+      )
+      JavaCompilerForUnitTesting.compileJava(Seq(outerFile), classesDir, Seq(libDir))
+
+      // Make Base package-private: Outer$Inner can no longer be loaded during analysis.
+      IO.write(baseFile, "package pkg; class Base {}")
+      JavaCompilerForUnitTesting.compileJava(Seq(baseFile), classesDir, Seq.empty)
+
+      val callback = JavaCompilerForUnitTesting.analyze(
+        classesDir,
+        Seq(outerFile),
+        (cb, src, named) => {
+          val (apis, _) = ClassfileToAPI.process(named)
+          apis.foreach(cb.api(src, _))
+        }
+      )
+
+      val recorded = callback.apis.values.flatten.toSet
+      assert(recorded.map(_.name).contains("Outer.Inner"))
+
+      val innerClass = recorded
+        .find(c => c.name == "Outer.Inner" && c.definitionType == DefinitionType.ClassDef)
+        .get
+      val memberDefs =
+        innerClass.structure.declared.collect { case d: xsbti.api.Def => d.name }.toSet
+      assert(memberDefs.contains("answer"))
+    }
+  }
+
+  it should "split static/instance members and parse array and multi-arg descriptors" in {
+    IO.withTemporaryDirectory { temp =>
+      val src = new File(temp, "S.java")
+      IO.write(
+        src,
+        """|public class S {
+           |  public int inst;
+           |  public static int stat;
+           |  public int[] arr(String s, long[] xs) { return null; }
+           |  public static void run() {}
+           |}
+           |""".stripMargin
+      )
+      JavaCompilerForUnitTesting.compileJava(Seq(src), temp, Seq.empty)
+      val cf = Parser(new File(temp, "S.class").toPath, Logger.Null)
+      val (apis, _) = ClassfileToAPI.process(Seq("S" -> cf))
+      val cls = apis.find(_.definitionType == DefinitionType.ClassDef).get
+      val mod = apis.find(_.definitionType == DefinitionType.Module).get
+      def names(c: ClassLike): Set[String] = c.structure.declared.map(_.name).toSet
+
+      // instance members on the class, static members on the module — and no leakage either way
+      assert(names(cls).contains("inst") && names(cls).contains("arr"))
+      assert(names(mod).contains("stat") && names(mod).contains("run"))
+      assert(!names(cls).contains("stat") && !names(cls).contains("run"))
+      assert(!names(mod).contains("inst") && !names(mod).contains("arr"))
+    }
+  }
+
+  // The fallback runs only for classes that already failed to load, so it must never throw on an
+  // odd/truncated descriptor and turn a gracefully-skipped class into a compile failure.
+  it should "degrade gracefully on malformed or truncated descriptors instead of throwing" in {
+    // None of these should throw; each yields some (best-effort) type.
+    assert(ClassfileToAPI.parseFieldType("Ljava/lang/String") ne null) // missing ';'
+    assert(ClassfileToAPI.parseFieldType("Q") ne null) // unknown token
+    assert(ClassfileToAPI.parseFieldType("") ne null) // empty
+    assert(ClassfileToAPI.parseMethodType("(I")._2 ne null) // missing ')'
+    assert(ClassfileToAPI.parseMethodType("()")._2 ne null) // missing return type
+    assert(ClassfileToAPI.parseMethodType("")._2 ne null) // empty
+
+    // Well-formed descriptors still parse to the right arity.
+    val (params, _) = ClassfileToAPI.parseMethodType("(Ljava/lang/String;[I)V")
+    assert(params.length == 2)
+  }
+
+  // P2a: generic-only changes share an erased descriptor, so without folding the raw Signature
+  // attribute into the API this would be missed.
+  it should "detect generic Signature changes that share an erased descriptor" in {
+    IO.withTemporaryDirectory { temp =>
+      val a = sampleApis(
+        temp,
+        "a",
+        "import java.util.List;\npublic class Sample { public List<String> answer() { return null; } }"
+      )
+      val b = sampleApis(
+        temp,
+        "b",
+        "import java.util.List;\npublic class Sample { public List<Integer> answer() { return null; } }"
+      )
+      assert(hashAll(a) != hashAll(b))
+    }
+  }
+
+  // P2b: compilers inline static-final constants, so a value change must change the hash even though
+  // the field descriptor is unchanged.
+  it should "detect static final constant value changes" in {
+    IO.withTemporaryDirectory { temp =>
+      val a = sampleApis(temp, "a", "public class Sample { public static final int X = 1; }")
+      val b = sampleApis(temp, "b", "public class Sample { public static final int X = 2; }")
+      assert(hashAll(a) != hashAll(b))
+    }
+  }
+
+  // P2 (exceptions): adding a checked exception changes the Java contract (callers must handle it),
+  // even though the descriptor is unchanged, so the hash must change.
+  it should "detect checked-exception (throws) changes" in {
+    IO.withTemporaryDirectory { temp =>
+      val a = sampleApis(temp, "a", "public class Sample { public void run() {} }")
+      val b = sampleApis(
+        temp,
+        "b",
+        "import java.io.IOException;\npublic class Sample { public void run() throws IOException {} }"
+      )
+      assert(hashAll(a) != hashAll(b))
+    }
+  }
+
+  // P3 (annotations): a declared annotation is public shape for annotation-driven clients.
+  it should "detect added or removed declared annotations" in {
+    IO.withTemporaryDirectory { temp =>
+      val a = sampleApis(temp, "a", "public class Sample { public void run() {} }")
+      val b = sampleApis(temp, "b", "public class Sample { @Deprecated public void run() {} }")
+      assert(hashAll(a) != hashAll(b))
+    }
+  }
+
+  // P3: only a method actually named `main` (not just any public-static-void(String[])) is a main.
+  it should "treat only a method named main as a main class" in {
+    IO.withTemporaryDirectory { temp =>
+      def mainsOf(dirName: String, source: String): Seq[String] = {
+        val dir = new File(temp, dirName)
+        dir.mkdir()
+        val src = new File(dir, "Sample.java")
+        IO.write(src, source)
+        JavaCompilerForUnitTesting.compileJava(Seq(src), dir, Seq.empty)
+        val cf = Parser(new File(dir, "Sample.class").toPath, Logger.Null)
+        ClassfileToAPI.process(Seq("Sample" -> cf))._2
+      }
+      // same descriptor as main but a different name -> not a main class
+      assert(mainsOf("a", "public class Sample { public static void foo(String[] a) {} }").isEmpty)
+      assert(mainsOf("b", "public class Sample { public static void main(String[] a) {} }") == Seq(
+        "Sample"
+      ))
+    }
+  }
+
+  private def sampleApis(temp: File, dirName: String, source: String): Seq[ClassLike] = {
+    val dir = new File(temp, dirName)
+    dir.mkdir()
+    val src = new File(dir, "Sample.java")
+    IO.write(src, source)
+    JavaCompilerForUnitTesting.compileJava(Seq(src), dir, Seq.empty)
+    val cf = Parser(new File(dir, "Sample.class").toPath, Logger.Null)
+    ClassfileToAPI.process(Seq("Sample" -> cf))._1
+  }
+
+  private def hashAll(apis: Seq[ClassLike]): Int = apis.map(HashAPI(_)).sum
+
+}

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/ClassFile.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/ClassFile.scala
@@ -90,7 +90,9 @@ private[sbt] final case class FieldOrMethodInfo(
 ) {
   def isStatic = (accessFlags & ACC_STATIC) == ACC_STATIC
   def isPublic = (accessFlags & ACC_PUBLIC) == ACC_PUBLIC
-  def isMain = isPublic && isStatic && descriptor.exists(_ == "([Ljava/lang/String;)V")
+  def isMain =
+    isPublic && isStatic && name.contains("main") &&
+      descriptor.exists(_ == "([Ljava/lang/String;)V")
 }
 private[sbt] final case class AttributeInfo(name: Option[String], value: Array[Byte]) {
   def isNamed(s: String) = name.exists(s == _)

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/JavaAnalyze.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/JavaAnalyze.scala
@@ -38,7 +38,8 @@ private[sbt] object JavaAnalyze {
   )(
       analysis: xsbti.AnalysisCallback,
       loader: ClassLoader,
-      readAPI: (VirtualFileRef, Seq[Class[?]]) => Set[(String, String)]
+      readAPI: (VirtualFileRef, Seq[Class[?]]) => Set[(String, String)],
+      readClassfileAPI: (VirtualFileRef, Seq[(String, ClassFile)]) => Unit = (_, _) => ()
   ): Unit = {
     val sourceMap = sources
       .toSet[VirtualFile]
@@ -226,6 +227,16 @@ private[sbt] object JavaAnalyze {
           (classFile.superClassName +: classFile.interfaceNames.toIndexedSeq).filter(_.nonEmpty)
         processDependencies(parents, DependencyByInheritance, classFile.className)
       }
+
+      // sbt/zinc#837 (Phase 2): record API for un-loadable classes from the classfile, so
+      // name-hashing detects changes to their own public shape (reflection can't load them).
+      val unloadableNamed = classFiles.iterator
+        .filter(cf => binaryClassNameToSourceName.contains(cf.className))
+        .map(cf => binaryClassNameToSourceName(cf.className) -> cf)
+        .toSeq
+      // Best-effort: never let classfile-based API extraction fail a compile that would otherwise
+      // succeed (these classes already couldn't be loaded), matching load()/loadInnerClass.
+      if (unloadableNamed.nonEmpty) trapAndLog(log)(readClassfileAPI(source, unloadableNamed))
     }
   }
 

--- a/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/JavaCompilerForUnitTesting.scala
+++ b/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/JavaCompilerForUnitTesting.scala
@@ -120,7 +120,12 @@ object JavaCompilerForUnitTesting {
    * the given `srcFiles`. Unlike [[compileJavaSrcs]] this does not compile, so the caller can stage
    * the class files (e.g. compile against one classpath, then swap a dependency) before analysis.
    */
-  def analyze(classesDir: File, srcFiles: Seq[File]): TestCallback = {
+  def analyze(
+      classesDir: File,
+      srcFiles: Seq[File],
+      readClassfileAPI: (AnalysisCallback, VirtualFileRef, Seq[(String, ClassFile)]) => Unit =
+        (_, _, _) => ()
+  ): TestCallback = {
     val srcs: List[VirtualFile] = srcFiles.toList.map(f => new TestVirtualFile(f.toPath))
     val analysisCallback = new TestCallback
     val classFiles = (sbt.io.PathFinder(classesDir) ** "*.class").get().map(_.toPath)
@@ -132,7 +137,8 @@ object JavaCompilerForUnitTesting {
     JavaAnalyze(classFiles, srcs, ConsoleLogger(), output, finalJarOutput = None)(
       analysisCallback,
       classloader,
-      (_, classes) => extractParents(classes)
+      (_, classes) => extractParents(classes),
+      readClassfileAPI(analysisCallback, _, _)
     )
     analysisCallback
   }

--- a/zinc/src/main/scala/sbt/internal/inc/javac/AnalyzingJavaCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/javac/AnalyzingJavaCompiler.scala
@@ -17,7 +17,7 @@ package javac
 import java.nio.file.Path
 import java.net.URLClassLoader
 
-import sbt.internal.inc.classfile.JavaAnalyze
+import sbt.internal.inc.classfile.{ ClassFile, JavaAnalyze }
 import sbt.internal.inc.classpath.ClasspathUtil
 import xsbti.compile._
 import xsbti.{
@@ -192,6 +192,14 @@ final class AnalyzingJavaCompiler private[sbt] (
         }
       }
 
+      // Read the API of classes that couldn't be reflectively loaded, from their classfiles
+      // (sbt/zinc#837), so name-hashing still tracks changes to their own public shape.
+      def readClassfileAPI(source: VirtualFileRef, classFiles: Seq[(String, ClassFile)]): Unit = {
+        val (apis, mainClasses) = ClassfileToAPI.process(classFiles, log)
+        apis.foreach(callback.api(source, _))
+        mainClasses.foreach(callback.mainClass(source, _))
+      }
+
       // Record progress for java analysis
       val javaAnalysisPhase = "Java analysis"
       progressOpt.map { progress =>
@@ -214,7 +222,8 @@ final class AnalyzingJavaCompiler private[sbt] (
             JavaAnalyze(newClasses.toSeq, srcs, log, output, finalJarOutput)(
               callback,
               loader,
-              readAPI
+              readAPI,
+              readClassfileAPI
             )
           } finally classes.close()
         }


### PR DESCRIPTION
Builds on #1714 (merged). Records an `xsbti.api.ClassLike` for Java classes that can't be reflectively loaded during analysis (sbt/zinc#837, sbt/sbt#117), so name-hashing tracks changes to their own public shape — derived directly from the classfile instead of reflection.

- `ClassfileToAPI` builds a class + module `ClassLike` from the classfile (members split static/instance), conservatively folding constants, the raw `Signature`, `throws`, and annotation types so changes are detected.
- `JavaAnalyze` gains a `readClassfileAPI` callback (no-op default), wired in `AnalyzingJavaCompiler`, for the un-loadable fallback path #1714 added.

Does not touch loadable classes (still reflection-based). Covered by `ClassfileToAPISpecification` / `AnalyzeSpecification`.
