### PR TITLE
Extract Java API from classfiles behind IncOptions.classfileJavaApi (#837)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,12 +126,27 @@ runner can force it on or off for the whole run via a system property, so the sa
 can be checked under both paths:
 
 ```
-$ sbt -Dzinc.scripted.classfileJavaApi=true  scripted   # classfile-based Java API path
-$ sbt -Dzinc.scripted.classfileJavaApi=false scripted   # reflection path (the default)
+$ sbt -Dzinc.scripted.classfileJavaApi=true -Dzinc.classfileJavaApi.strict=true scripted  # classfile path
+$ sbt -Dzinc.scripted.classfileJavaApi=false scripted                                      # reflection (default)
 ```
 
-Without the property, each test uses its own value (the default, unless its
-`incOptions.properties` overrides it).
+Two properties are involved:
+
+- `-Dzinc.scripted.classfileJavaApi=true|false` forces `IncOptions.classfileJavaApi` for the whole
+  scripted run. Without it, each test uses its own value (the default, unless its
+  `incOptions.properties` overrides it).
+- `-Dzinc.classfileJavaApi.strict=true` makes a failure *inside* the classfile-based extractor
+  propagate instead of being logged and swallowed. In production that path is deliberately
+  best-effort (it must never fail a compile that would otherwise succeed), but under
+  `classfileApiOnly` it is the primary path for every Java class, so for testing we want a crash
+  there to fail the build. Pair it with the property above when running the matrix.
+
+Note: the scripted suite is good at catching *crashes and structural breakage* in the classfile
+path, but it is largely insensitive to *fine-grained* Java API-hash regressions (e.g. a dropped
+method return type) because cross-unit invalidation there is dominated by source changes and
+inheritance edges. That fine-grained correctness is pinned by the unit tests in `zinc-apiinfo`
+(`ClassfileToAPISpecification`, `DifferentialApiSpecification`, `FBoundStressSpecification`) and by
+`IncrementalCompilerSpec`'s classfileJavaApi-vs-reflection invalidation check.
 
 ### Reaching out for help
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,32 @@ benchmarks and include them in *both* the commit message and PR description.
 The richer the descriptions the better. If you're not changing the compiler
 bridge, you don't need to run these benchmarks.
 
+### Running scripted tests
+
+Zinc's integration tests live in `zinc/src/sbt-test` and are run with the `scripted` sbt
+task, which replays each `test`/`pending` script against a real incremental compile:
+
+```
+$ sbt scripted                                   # the whole suite
+$ sbt "scripted source-dependencies/*"           # one group
+$ sbt "scripted source-dependencies/java-basic"  # a single test
+```
+
+#### Running scripted tests in the classfile Java API mode
+
+`IncOptions.classfileJavaApi` makes Zinc extract each Java class's API from its class file
+instead of by reflectively loading it (sbt/zinc#837). It is off by default. The scripted
+runner can force it on or off for the whole run via a system property, so the same scenarios
+can be checked under both paths:
+
+```
+$ sbt -Dzinc.scripted.classfileJavaApi=true  scripted   # classfile-based Java API path
+$ sbt -Dzinc.scripted.classfileJavaApi=false scripted   # reflection path (the default)
+```
+
+Without the property, each test uses its own value (the default, unless its
+`incOptions.properties` overrides it).
+
 ### Reaching out for help
 
 If you need any help, consider opening a draft pull request and asking

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/compile/IncOptions.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/compile/IncOptions.java
@@ -79,6 +79,9 @@ public final class IncOptions implements java.io.Serializable {
     public static boolean defaultPipelining() {
         return false;
     }
+    public static boolean defaultClassfileJavaApi() {
+        return false;
+    }
     public static IncOptions create() {
         return new IncOptions();
     }
@@ -145,6 +148,18 @@ public final class IncOptions implements java.io.Serializable {
     public static IncOptions of(int _transitiveStep, double _recompileAllFraction, boolean _relationsDebug, boolean _apiDebug, int _apiDiffContextSize, java.io.File _apiDumpDirectory, xsbti.compile.ClassFileManagerType _classfileManagerType, xsbti.compile.AuxiliaryClassFiles[] _auxiliaryClassFiles, boolean _useCustomizedFileManager, boolean _recompileOnMacroDef, boolean _useOptimizedSealed, boolean _storeApis, boolean _enabled, java.util.Map<String, String> _extra, boolean _logRecompileOnMacro, xsbti.compile.ExternalHooks _externalHooks, String[] _ignoredScalacOptions, boolean _strictMode, boolean _allowMachinePath, boolean _pipelining) {
         return new IncOptions(_transitiveStep, _recompileAllFraction, _relationsDebug, _apiDebug, _apiDiffContextSize, _apiDumpDirectory, _classfileManagerType, _auxiliaryClassFiles, _useCustomizedFileManager, _recompileOnMacroDef, _useOptimizedSealed, _storeApis, _enabled, _extra, _logRecompileOnMacro, _externalHooks, _ignoredScalacOptions, _strictMode, _allowMachinePath, _pipelining);
     }
+    public static IncOptions create(int _transitiveStep, double _recompileAllFraction, boolean _relationsDebug, boolean _apiDebug, int _apiDiffContextSize, java.util.Optional<java.io.File> _apiDumpDirectory, java.util.Optional<xsbti.compile.ClassFileManagerType> _classfileManagerType, xsbti.compile.AuxiliaryClassFiles[] _auxiliaryClassFiles, boolean _useCustomizedFileManager, java.util.Optional<Boolean> _recompileOnMacroDef, boolean _useOptimizedSealed, boolean _storeApis, boolean _enabled, java.util.Map<String, String> _extra, boolean _logRecompileOnMacro, xsbti.compile.ExternalHooks _externalHooks, String[] _ignoredScalacOptions, boolean _strictMode, boolean _allowMachinePath, boolean _pipelining, boolean _classfileJavaApi) {
+        return new IncOptions(_transitiveStep, _recompileAllFraction, _relationsDebug, _apiDebug, _apiDiffContextSize, _apiDumpDirectory, _classfileManagerType, _auxiliaryClassFiles, _useCustomizedFileManager, _recompileOnMacroDef, _useOptimizedSealed, _storeApis, _enabled, _extra, _logRecompileOnMacro, _externalHooks, _ignoredScalacOptions, _strictMode, _allowMachinePath, _pipelining, _classfileJavaApi);
+    }
+    public static IncOptions of(int _transitiveStep, double _recompileAllFraction, boolean _relationsDebug, boolean _apiDebug, int _apiDiffContextSize, java.util.Optional<java.io.File> _apiDumpDirectory, java.util.Optional<xsbti.compile.ClassFileManagerType> _classfileManagerType, xsbti.compile.AuxiliaryClassFiles[] _auxiliaryClassFiles, boolean _useCustomizedFileManager, java.util.Optional<Boolean> _recompileOnMacroDef, boolean _useOptimizedSealed, boolean _storeApis, boolean _enabled, java.util.Map<String, String> _extra, boolean _logRecompileOnMacro, xsbti.compile.ExternalHooks _externalHooks, String[] _ignoredScalacOptions, boolean _strictMode, boolean _allowMachinePath, boolean _pipelining, boolean _classfileJavaApi) {
+        return new IncOptions(_transitiveStep, _recompileAllFraction, _relationsDebug, _apiDebug, _apiDiffContextSize, _apiDumpDirectory, _classfileManagerType, _auxiliaryClassFiles, _useCustomizedFileManager, _recompileOnMacroDef, _useOptimizedSealed, _storeApis, _enabled, _extra, _logRecompileOnMacro, _externalHooks, _ignoredScalacOptions, _strictMode, _allowMachinePath, _pipelining, _classfileJavaApi);
+    }
+    public static IncOptions create(int _transitiveStep, double _recompileAllFraction, boolean _relationsDebug, boolean _apiDebug, int _apiDiffContextSize, java.io.File _apiDumpDirectory, xsbti.compile.ClassFileManagerType _classfileManagerType, xsbti.compile.AuxiliaryClassFiles[] _auxiliaryClassFiles, boolean _useCustomizedFileManager, boolean _recompileOnMacroDef, boolean _useOptimizedSealed, boolean _storeApis, boolean _enabled, java.util.Map<String, String> _extra, boolean _logRecompileOnMacro, xsbti.compile.ExternalHooks _externalHooks, String[] _ignoredScalacOptions, boolean _strictMode, boolean _allowMachinePath, boolean _pipelining, boolean _classfileJavaApi) {
+        return new IncOptions(_transitiveStep, _recompileAllFraction, _relationsDebug, _apiDebug, _apiDiffContextSize, _apiDumpDirectory, _classfileManagerType, _auxiliaryClassFiles, _useCustomizedFileManager, _recompileOnMacroDef, _useOptimizedSealed, _storeApis, _enabled, _extra, _logRecompileOnMacro, _externalHooks, _ignoredScalacOptions, _strictMode, _allowMachinePath, _pipelining, _classfileJavaApi);
+    }
+    public static IncOptions of(int _transitiveStep, double _recompileAllFraction, boolean _relationsDebug, boolean _apiDebug, int _apiDiffContextSize, java.io.File _apiDumpDirectory, xsbti.compile.ClassFileManagerType _classfileManagerType, xsbti.compile.AuxiliaryClassFiles[] _auxiliaryClassFiles, boolean _useCustomizedFileManager, boolean _recompileOnMacroDef, boolean _useOptimizedSealed, boolean _storeApis, boolean _enabled, java.util.Map<String, String> _extra, boolean _logRecompileOnMacro, xsbti.compile.ExternalHooks _externalHooks, String[] _ignoredScalacOptions, boolean _strictMode, boolean _allowMachinePath, boolean _pipelining, boolean _classfileJavaApi) {
+        return new IncOptions(_transitiveStep, _recompileAllFraction, _relationsDebug, _apiDebug, _apiDiffContextSize, _apiDumpDirectory, _classfileManagerType, _auxiliaryClassFiles, _useCustomizedFileManager, _recompileOnMacroDef, _useOptimizedSealed, _storeApis, _enabled, _extra, _logRecompileOnMacro, _externalHooks, _ignoredScalacOptions, _strictMode, _allowMachinePath, _pipelining, _classfileJavaApi);
+    }
     private int transitiveStep;
     private double recompileAllFraction;
     private boolean relationsDebug;
@@ -165,6 +180,7 @@ public final class IncOptions implements java.io.Serializable {
     private boolean strictMode;
     private boolean allowMachinePath;
     private boolean pipelining;
+    private boolean classfileJavaApi;
     protected IncOptions() {
         super();
         transitiveStep = xsbti.compile.IncOptions.defaultTransitiveStep();
@@ -187,6 +203,7 @@ public final class IncOptions implements java.io.Serializable {
         strictMode = xsbti.compile.IncOptions.defaultStrictMode();
         allowMachinePath = xsbti.compile.IncOptions.defaultAllowMachinePath();
         pipelining = xsbti.compile.IncOptions.defaultPipelining();
+        classfileJavaApi = xsbti.compile.IncOptions.defaultClassfileJavaApi();
     }
     protected IncOptions(int _transitiveStep, double _recompileAllFraction, boolean _relationsDebug, boolean _apiDebug, int _apiDiffContextSize, java.util.Optional<java.io.File> _apiDumpDirectory, java.util.Optional<xsbti.compile.ClassFileManagerType> _classfileManagerType, boolean _useCustomizedFileManager, java.util.Optional<Boolean> _recompileOnMacroDef, boolean _useOptimizedSealed, boolean _storeApis, boolean _enabled, java.util.Map<String, String> _extra, boolean _logRecompileOnMacro, xsbti.compile.ExternalHooks _externalHooks) {
         super();
@@ -210,6 +227,7 @@ public final class IncOptions implements java.io.Serializable {
         strictMode = xsbti.compile.IncOptions.defaultStrictMode();
         allowMachinePath = xsbti.compile.IncOptions.defaultAllowMachinePath();
         pipelining = xsbti.compile.IncOptions.defaultPipelining();
+        classfileJavaApi = xsbti.compile.IncOptions.defaultClassfileJavaApi();
     }
     protected IncOptions(int _transitiveStep, double _recompileAllFraction, boolean _relationsDebug, boolean _apiDebug, int _apiDiffContextSize, java.io.File _apiDumpDirectory, xsbti.compile.ClassFileManagerType _classfileManagerType, boolean _useCustomizedFileManager, boolean _recompileOnMacroDef, boolean _useOptimizedSealed, boolean _storeApis, boolean _enabled, java.util.Map<String, String> _extra, boolean _logRecompileOnMacro, xsbti.compile.ExternalHooks _externalHooks) {
         super();
@@ -233,6 +251,7 @@ public final class IncOptions implements java.io.Serializable {
         strictMode = xsbti.compile.IncOptions.defaultStrictMode();
         allowMachinePath = xsbti.compile.IncOptions.defaultAllowMachinePath();
         pipelining = xsbti.compile.IncOptions.defaultPipelining();
+        classfileJavaApi = xsbti.compile.IncOptions.defaultClassfileJavaApi();
     }
     protected IncOptions(int _transitiveStep, double _recompileAllFraction, boolean _relationsDebug, boolean _apiDebug, int _apiDiffContextSize, java.util.Optional<java.io.File> _apiDumpDirectory, java.util.Optional<xsbti.compile.ClassFileManagerType> _classfileManagerType, boolean _useCustomizedFileManager, java.util.Optional<Boolean> _recompileOnMacroDef, boolean _useOptimizedSealed, boolean _storeApis, boolean _enabled, java.util.Map<String, String> _extra, boolean _logRecompileOnMacro, xsbti.compile.ExternalHooks _externalHooks, String[] _ignoredScalacOptions) {
         super();
@@ -256,6 +275,7 @@ public final class IncOptions implements java.io.Serializable {
         strictMode = xsbti.compile.IncOptions.defaultStrictMode();
         allowMachinePath = xsbti.compile.IncOptions.defaultAllowMachinePath();
         pipelining = xsbti.compile.IncOptions.defaultPipelining();
+        classfileJavaApi = xsbti.compile.IncOptions.defaultClassfileJavaApi();
     }
     protected IncOptions(int _transitiveStep, double _recompileAllFraction, boolean _relationsDebug, boolean _apiDebug, int _apiDiffContextSize, java.io.File _apiDumpDirectory, xsbti.compile.ClassFileManagerType _classfileManagerType, boolean _useCustomizedFileManager, boolean _recompileOnMacroDef, boolean _useOptimizedSealed, boolean _storeApis, boolean _enabled, java.util.Map<String, String> _extra, boolean _logRecompileOnMacro, xsbti.compile.ExternalHooks _externalHooks, String[] _ignoredScalacOptions) {
         super();
@@ -279,6 +299,7 @@ public final class IncOptions implements java.io.Serializable {
         strictMode = xsbti.compile.IncOptions.defaultStrictMode();
         allowMachinePath = xsbti.compile.IncOptions.defaultAllowMachinePath();
         pipelining = xsbti.compile.IncOptions.defaultPipelining();
+        classfileJavaApi = xsbti.compile.IncOptions.defaultClassfileJavaApi();
     }
     protected IncOptions(int _transitiveStep, double _recompileAllFraction, boolean _relationsDebug, boolean _apiDebug, int _apiDiffContextSize, java.util.Optional<java.io.File> _apiDumpDirectory, java.util.Optional<xsbti.compile.ClassFileManagerType> _classfileManagerType, boolean _useCustomizedFileManager, java.util.Optional<Boolean> _recompileOnMacroDef, boolean _useOptimizedSealed, boolean _storeApis, boolean _enabled, java.util.Map<String, String> _extra, boolean _logRecompileOnMacro, xsbti.compile.ExternalHooks _externalHooks, String[] _ignoredScalacOptions, boolean _strictMode) {
         super();
@@ -302,6 +323,7 @@ public final class IncOptions implements java.io.Serializable {
         strictMode = _strictMode;
         allowMachinePath = xsbti.compile.IncOptions.defaultAllowMachinePath();
         pipelining = xsbti.compile.IncOptions.defaultPipelining();
+        classfileJavaApi = xsbti.compile.IncOptions.defaultClassfileJavaApi();
     }
     protected IncOptions(int _transitiveStep, double _recompileAllFraction, boolean _relationsDebug, boolean _apiDebug, int _apiDiffContextSize, java.io.File _apiDumpDirectory, xsbti.compile.ClassFileManagerType _classfileManagerType, boolean _useCustomizedFileManager, boolean _recompileOnMacroDef, boolean _useOptimizedSealed, boolean _storeApis, boolean _enabled, java.util.Map<String, String> _extra, boolean _logRecompileOnMacro, xsbti.compile.ExternalHooks _externalHooks, String[] _ignoredScalacOptions, boolean _strictMode) {
         super();
@@ -325,6 +347,7 @@ public final class IncOptions implements java.io.Serializable {
         strictMode = _strictMode;
         allowMachinePath = xsbti.compile.IncOptions.defaultAllowMachinePath();
         pipelining = xsbti.compile.IncOptions.defaultPipelining();
+        classfileJavaApi = xsbti.compile.IncOptions.defaultClassfileJavaApi();
     }
     protected IncOptions(int _transitiveStep, double _recompileAllFraction, boolean _relationsDebug, boolean _apiDebug, int _apiDiffContextSize, java.util.Optional<java.io.File> _apiDumpDirectory, java.util.Optional<xsbti.compile.ClassFileManagerType> _classfileManagerType, boolean _useCustomizedFileManager, java.util.Optional<Boolean> _recompileOnMacroDef, boolean _useOptimizedSealed, boolean _storeApis, boolean _enabled, java.util.Map<String, String> _extra, boolean _logRecompileOnMacro, xsbti.compile.ExternalHooks _externalHooks, String[] _ignoredScalacOptions, boolean _strictMode, boolean _allowMachinePath, boolean _pipelining) {
         super();
@@ -348,6 +371,7 @@ public final class IncOptions implements java.io.Serializable {
         strictMode = _strictMode;
         allowMachinePath = _allowMachinePath;
         pipelining = _pipelining;
+        classfileJavaApi = xsbti.compile.IncOptions.defaultClassfileJavaApi();
     }
     protected IncOptions(int _transitiveStep, double _recompileAllFraction, boolean _relationsDebug, boolean _apiDebug, int _apiDiffContextSize, java.io.File _apiDumpDirectory, xsbti.compile.ClassFileManagerType _classfileManagerType, boolean _useCustomizedFileManager, boolean _recompileOnMacroDef, boolean _useOptimizedSealed, boolean _storeApis, boolean _enabled, java.util.Map<String, String> _extra, boolean _logRecompileOnMacro, xsbti.compile.ExternalHooks _externalHooks, String[] _ignoredScalacOptions, boolean _strictMode, boolean _allowMachinePath, boolean _pipelining) {
         super();
@@ -371,6 +395,7 @@ public final class IncOptions implements java.io.Serializable {
         strictMode = _strictMode;
         allowMachinePath = _allowMachinePath;
         pipelining = _pipelining;
+        classfileJavaApi = xsbti.compile.IncOptions.defaultClassfileJavaApi();
     }
     protected IncOptions(int _transitiveStep, double _recompileAllFraction, boolean _relationsDebug, boolean _apiDebug, int _apiDiffContextSize, java.util.Optional<java.io.File> _apiDumpDirectory, java.util.Optional<xsbti.compile.ClassFileManagerType> _classfileManagerType, xsbti.compile.AuxiliaryClassFiles[] _auxiliaryClassFiles, boolean _useCustomizedFileManager, java.util.Optional<Boolean> _recompileOnMacroDef, boolean _useOptimizedSealed, boolean _storeApis, boolean _enabled, java.util.Map<String, String> _extra, boolean _logRecompileOnMacro, xsbti.compile.ExternalHooks _externalHooks, String[] _ignoredScalacOptions, boolean _strictMode, boolean _allowMachinePath, boolean _pipelining) {
         super();
@@ -394,6 +419,7 @@ public final class IncOptions implements java.io.Serializable {
         strictMode = _strictMode;
         allowMachinePath = _allowMachinePath;
         pipelining = _pipelining;
+        classfileJavaApi = xsbti.compile.IncOptions.defaultClassfileJavaApi();
     }
     protected IncOptions(int _transitiveStep, double _recompileAllFraction, boolean _relationsDebug, boolean _apiDebug, int _apiDiffContextSize, java.io.File _apiDumpDirectory, xsbti.compile.ClassFileManagerType _classfileManagerType, xsbti.compile.AuxiliaryClassFiles[] _auxiliaryClassFiles, boolean _useCustomizedFileManager, boolean _recompileOnMacroDef, boolean _useOptimizedSealed, boolean _storeApis, boolean _enabled, java.util.Map<String, String> _extra, boolean _logRecompileOnMacro, xsbti.compile.ExternalHooks _externalHooks, String[] _ignoredScalacOptions, boolean _strictMode, boolean _allowMachinePath, boolean _pipelining) {
         super();
@@ -417,6 +443,55 @@ public final class IncOptions implements java.io.Serializable {
         strictMode = _strictMode;
         allowMachinePath = _allowMachinePath;
         pipelining = _pipelining;
+        classfileJavaApi = xsbti.compile.IncOptions.defaultClassfileJavaApi();
+    }
+    protected IncOptions(int _transitiveStep, double _recompileAllFraction, boolean _relationsDebug, boolean _apiDebug, int _apiDiffContextSize, java.util.Optional<java.io.File> _apiDumpDirectory, java.util.Optional<xsbti.compile.ClassFileManagerType> _classfileManagerType, xsbti.compile.AuxiliaryClassFiles[] _auxiliaryClassFiles, boolean _useCustomizedFileManager, java.util.Optional<Boolean> _recompileOnMacroDef, boolean _useOptimizedSealed, boolean _storeApis, boolean _enabled, java.util.Map<String, String> _extra, boolean _logRecompileOnMacro, xsbti.compile.ExternalHooks _externalHooks, String[] _ignoredScalacOptions, boolean _strictMode, boolean _allowMachinePath, boolean _pipelining, boolean _classfileJavaApi) {
+        super();
+        transitiveStep = _transitiveStep;
+        recompileAllFraction = _recompileAllFraction;
+        relationsDebug = _relationsDebug;
+        apiDebug = _apiDebug;
+        apiDiffContextSize = _apiDiffContextSize;
+        apiDumpDirectory = _apiDumpDirectory;
+        classfileManagerType = _classfileManagerType;
+        auxiliaryClassFiles = _auxiliaryClassFiles;
+        useCustomizedFileManager = _useCustomizedFileManager;
+        recompileOnMacroDef = _recompileOnMacroDef;
+        useOptimizedSealed = _useOptimizedSealed;
+        storeApis = _storeApis;
+        enabled = _enabled;
+        extra = _extra;
+        logRecompileOnMacro = _logRecompileOnMacro;
+        externalHooks = _externalHooks;
+        ignoredScalacOptions = _ignoredScalacOptions;
+        strictMode = _strictMode;
+        allowMachinePath = _allowMachinePath;
+        pipelining = _pipelining;
+        classfileJavaApi = _classfileJavaApi;
+    }
+    protected IncOptions(int _transitiveStep, double _recompileAllFraction, boolean _relationsDebug, boolean _apiDebug, int _apiDiffContextSize, java.io.File _apiDumpDirectory, xsbti.compile.ClassFileManagerType _classfileManagerType, xsbti.compile.AuxiliaryClassFiles[] _auxiliaryClassFiles, boolean _useCustomizedFileManager, boolean _recompileOnMacroDef, boolean _useOptimizedSealed, boolean _storeApis, boolean _enabled, java.util.Map<String, String> _extra, boolean _logRecompileOnMacro, xsbti.compile.ExternalHooks _externalHooks, String[] _ignoredScalacOptions, boolean _strictMode, boolean _allowMachinePath, boolean _pipelining, boolean _classfileJavaApi) {
+        super();
+        transitiveStep = _transitiveStep;
+        recompileAllFraction = _recompileAllFraction;
+        relationsDebug = _relationsDebug;
+        apiDebug = _apiDebug;
+        apiDiffContextSize = _apiDiffContextSize;
+        apiDumpDirectory = java.util.Optional.<java.io.File>ofNullable(_apiDumpDirectory);
+        classfileManagerType = java.util.Optional.<xsbti.compile.ClassFileManagerType>ofNullable(_classfileManagerType);
+        auxiliaryClassFiles = _auxiliaryClassFiles;
+        useCustomizedFileManager = _useCustomizedFileManager;
+        recompileOnMacroDef = java.util.Optional.<Boolean>ofNullable(_recompileOnMacroDef);
+        useOptimizedSealed = _useOptimizedSealed;
+        storeApis = _storeApis;
+        enabled = _enabled;
+        extra = _extra;
+        logRecompileOnMacro = _logRecompileOnMacro;
+        externalHooks = _externalHooks;
+        ignoredScalacOptions = _ignoredScalacOptions;
+        strictMode = _strictMode;
+        allowMachinePath = _allowMachinePath;
+        pipelining = _pipelining;
+        classfileJavaApi = _classfileJavaApi;
     }
     /** After which step include whole transitive closure of invalidated source files. */
     public int transitiveStep() {
@@ -537,74 +612,85 @@ public final class IncOptions implements java.io.Serializable {
     public boolean pipelining() {
         return this.pipelining;
     }
+    /**
+     * Extract each Java class's API from its classfile instead of by reflectively loading it.
+     * This avoids loading/linking Java classes during post-compile analysis (sbt/zinc#837, #151,
+     * #1697). Off by default while the classfile-based path is validated as the eventual default.
+     */
+    public boolean classfileJavaApi() {
+        return this.classfileJavaApi;
+    }
     public IncOptions withTransitiveStep(int transitiveStep) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining, classfileJavaApi);
     }
     public IncOptions withRecompileAllFraction(double recompileAllFraction) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining, classfileJavaApi);
     }
     public IncOptions withRelationsDebug(boolean relationsDebug) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining, classfileJavaApi);
     }
     public IncOptions withApiDebug(boolean apiDebug) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining, classfileJavaApi);
     }
     public IncOptions withApiDiffContextSize(int apiDiffContextSize) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining, classfileJavaApi);
     }
     public IncOptions withApiDumpDirectory(java.util.Optional<java.io.File> apiDumpDirectory) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining, classfileJavaApi);
     }
     public IncOptions withApiDumpDirectory(java.io.File apiDumpDirectory) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, java.util.Optional.<java.io.File>ofNullable(apiDumpDirectory), classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, java.util.Optional.<java.io.File>ofNullable(apiDumpDirectory), classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining, classfileJavaApi);
     }
     public IncOptions withClassfileManagerType(java.util.Optional<xsbti.compile.ClassFileManagerType> classfileManagerType) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining, classfileJavaApi);
     }
     public IncOptions withClassfileManagerType(xsbti.compile.ClassFileManagerType classfileManagerType) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, java.util.Optional.<xsbti.compile.ClassFileManagerType>ofNullable(classfileManagerType), auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, java.util.Optional.<xsbti.compile.ClassFileManagerType>ofNullable(classfileManagerType), auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining, classfileJavaApi);
     }
     public IncOptions withAuxiliaryClassFiles(xsbti.compile.AuxiliaryClassFiles[] auxiliaryClassFiles) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining, classfileJavaApi);
     }
     public IncOptions withUseCustomizedFileManager(boolean useCustomizedFileManager) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining, classfileJavaApi);
     }
     public IncOptions withRecompileOnMacroDef(java.util.Optional<Boolean> recompileOnMacroDef) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining, classfileJavaApi);
     }
     public IncOptions withRecompileOnMacroDef(boolean recompileOnMacroDef) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, java.util.Optional.<Boolean>ofNullable(recompileOnMacroDef), useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, java.util.Optional.<Boolean>ofNullable(recompileOnMacroDef), useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining, classfileJavaApi);
     }
     public IncOptions withUseOptimizedSealed(boolean useOptimizedSealed) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining, classfileJavaApi);
     }
     public IncOptions withStoreApis(boolean storeApis) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining, classfileJavaApi);
     }
     public IncOptions withEnabled(boolean enabled) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining, classfileJavaApi);
     }
     public IncOptions withExtra(java.util.Map<String, String> extra) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining, classfileJavaApi);
     }
     public IncOptions withLogRecompileOnMacro(boolean logRecompileOnMacro) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining, classfileJavaApi);
     }
     public IncOptions withExternalHooks(xsbti.compile.ExternalHooks externalHooks) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining, classfileJavaApi);
     }
     public IncOptions withIgnoredScalacOptions(String[] ignoredScalacOptions) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining, classfileJavaApi);
     }
     public IncOptions withStrictMode(boolean strictMode) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining, classfileJavaApi);
     }
     public IncOptions withAllowMachinePath(boolean allowMachinePath) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining, classfileJavaApi);
     }
     public IncOptions withPipelining(boolean pipelining) {
-        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining);
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining, classfileJavaApi);
+    }
+    public IncOptions withClassfileJavaApi(boolean classfileJavaApi) {
+        return new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize, apiDumpDirectory, classfileManagerType, auxiliaryClassFiles, useCustomizedFileManager, recompileOnMacroDef, useOptimizedSealed, storeApis, enabled, extra, logRecompileOnMacro, externalHooks, ignoredScalacOptions, strictMode, allowMachinePath, pipelining, classfileJavaApi);
     }
     @Override
     public boolean equals(Object obj) {
@@ -614,15 +700,15 @@ public final class IncOptions implements java.io.Serializable {
             return false;
         } else {
             IncOptions o = (IncOptions)obj;
-            return (this.transitiveStep() == o.transitiveStep()) && (this.recompileAllFraction() == o.recompileAllFraction()) && (this.relationsDebug() == o.relationsDebug()) && (this.apiDebug() == o.apiDebug()) && (this.apiDiffContextSize() == o.apiDiffContextSize()) && this.apiDumpDirectory().equals(o.apiDumpDirectory()) && this.classfileManagerType().equals(o.classfileManagerType()) && java.util.Arrays.deepEquals(this.auxiliaryClassFiles(), o.auxiliaryClassFiles()) && (this.useCustomizedFileManager() == o.useCustomizedFileManager()) && this.recompileOnMacroDef().equals(o.recompileOnMacroDef()) && (this.useOptimizedSealed() == o.useOptimizedSealed()) && (this.storeApis() == o.storeApis()) && (this.enabled() == o.enabled()) && this.extra().equals(o.extra()) && (this.logRecompileOnMacro() == o.logRecompileOnMacro()) && this.externalHooks().equals(o.externalHooks()) && java.util.Arrays.deepEquals(this.ignoredScalacOptions(), o.ignoredScalacOptions()) && (this.strictMode() == o.strictMode()) && (this.allowMachinePath() == o.allowMachinePath()) && (this.pipelining() == o.pipelining());
+            return (this.transitiveStep() == o.transitiveStep()) && (this.recompileAllFraction() == o.recompileAllFraction()) && (this.relationsDebug() == o.relationsDebug()) && (this.apiDebug() == o.apiDebug()) && (this.apiDiffContextSize() == o.apiDiffContextSize()) && this.apiDumpDirectory().equals(o.apiDumpDirectory()) && this.classfileManagerType().equals(o.classfileManagerType()) && java.util.Arrays.deepEquals(this.auxiliaryClassFiles(), o.auxiliaryClassFiles()) && (this.useCustomizedFileManager() == o.useCustomizedFileManager()) && this.recompileOnMacroDef().equals(o.recompileOnMacroDef()) && (this.useOptimizedSealed() == o.useOptimizedSealed()) && (this.storeApis() == o.storeApis()) && (this.enabled() == o.enabled()) && this.extra().equals(o.extra()) && (this.logRecompileOnMacro() == o.logRecompileOnMacro()) && this.externalHooks().equals(o.externalHooks()) && java.util.Arrays.deepEquals(this.ignoredScalacOptions(), o.ignoredScalacOptions()) && (this.strictMode() == o.strictMode()) && (this.allowMachinePath() == o.allowMachinePath()) && (this.pipelining() == o.pipelining()) && (this.classfileJavaApi() == o.classfileJavaApi());
         }
     }
     @Override
     public int hashCode() {
-        return 37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.compile.IncOptions".hashCode()) + Integer.hashCode(transitiveStep())) + Double.hashCode(recompileAllFraction())) + Boolean.hashCode(relationsDebug())) + Boolean.hashCode(apiDebug())) + Integer.hashCode(apiDiffContextSize())) + apiDumpDirectory().hashCode()) + classfileManagerType().hashCode()) + java.util.Arrays.deepHashCode(auxiliaryClassFiles())) + Boolean.hashCode(useCustomizedFileManager())) + recompileOnMacroDef().hashCode()) + Boolean.hashCode(useOptimizedSealed())) + Boolean.hashCode(storeApis())) + Boolean.hashCode(enabled())) + extra().hashCode()) + Boolean.hashCode(logRecompileOnMacro())) + externalHooks().hashCode()) + java.util.Arrays.deepHashCode(ignoredScalacOptions())) + Boolean.hashCode(strictMode())) + Boolean.hashCode(allowMachinePath())) + Boolean.hashCode(pipelining()));
+        return 37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.compile.IncOptions".hashCode()) + Integer.hashCode(transitiveStep())) + Double.hashCode(recompileAllFraction())) + Boolean.hashCode(relationsDebug())) + Boolean.hashCode(apiDebug())) + Integer.hashCode(apiDiffContextSize())) + apiDumpDirectory().hashCode()) + classfileManagerType().hashCode()) + java.util.Arrays.deepHashCode(auxiliaryClassFiles())) + Boolean.hashCode(useCustomizedFileManager())) + recompileOnMacroDef().hashCode()) + Boolean.hashCode(useOptimizedSealed())) + Boolean.hashCode(storeApis())) + Boolean.hashCode(enabled())) + extra().hashCode()) + Boolean.hashCode(logRecompileOnMacro())) + externalHooks().hashCode()) + java.util.Arrays.deepHashCode(ignoredScalacOptions())) + Boolean.hashCode(strictMode())) + Boolean.hashCode(allowMachinePath())) + Boolean.hashCode(pipelining())) + Boolean.hashCode(classfileJavaApi()));
     }
     @Override
     public String toString() {
-        return "IncOptions("  + "transitiveStep: " + transitiveStep() + ", " + "recompileAllFraction: " + recompileAllFraction() + ", " + "relationsDebug: " + relationsDebug() + ", " + "apiDebug: " + apiDebug() + ", " + "apiDiffContextSize: " + apiDiffContextSize() + ", " + "apiDumpDirectory: " + apiDumpDirectory() + ", " + "classfileManagerType: " + classfileManagerType() + ", " + "auxiliaryClassFiles: " + auxiliaryClassFiles() + ", " + "useCustomizedFileManager: " + useCustomizedFileManager() + ", " + "recompileOnMacroDef: " + recompileOnMacroDef() + ", " + "useOptimizedSealed: " + useOptimizedSealed() + ", " + "storeApis: " + storeApis() + ", " + "enabled: " + enabled() + ", " + "extra: " + extra() + ", " + "logRecompileOnMacro: " + logRecompileOnMacro() + ", " + "externalHooks: " + externalHooks() + ", " + "ignoredScalacOptions: " + ignoredScalacOptions() + ", " + "strictMode: " + strictMode() + ", " + "allowMachinePath: " + allowMachinePath() + ", " + "pipelining: " + pipelining() + ")";
+        return "IncOptions("  + "transitiveStep: " + transitiveStep() + ", " + "recompileAllFraction: " + recompileAllFraction() + ", " + "relationsDebug: " + relationsDebug() + ", " + "apiDebug: " + apiDebug() + ", " + "apiDiffContextSize: " + apiDiffContextSize() + ", " + "apiDumpDirectory: " + apiDumpDirectory() + ", " + "classfileManagerType: " + classfileManagerType() + ", " + "auxiliaryClassFiles: " + auxiliaryClassFiles() + ", " + "useCustomizedFileManager: " + useCustomizedFileManager() + ", " + "recompileOnMacroDef: " + recompileOnMacroDef() + ", " + "useOptimizedSealed: " + useOptimizedSealed() + ", " + "storeApis: " + storeApis() + ", " + "enabled: " + enabled() + ", " + "extra: " + extra() + ", " + "logRecompileOnMacro: " + logRecompileOnMacro() + ", " + "externalHooks: " + externalHooks() + ", " + "ignoredScalacOptions: " + ignoredScalacOptions() + ", " + "strictMode: " + strictMode() + ", " + "allowMachinePath: " + allowMachinePath() + ", " + "pipelining: " + pipelining() + ", " + "classfileJavaApi: " + classfileJavaApi() + ")";
     }
 }

--- a/internal/compiler-interface/src/main/contraband/incremental.contra
+++ b/internal/compiler-interface/src/main/contraband/incremental.contra
@@ -105,6 +105,12 @@ type IncOptions {
   pipelining: Boolean! = raw"xsbti.compile.IncOptions.defaultPipelining()"
   @since("1.4.0")
 
+  ## Extract each Java class's API from its classfile instead of by reflectively loading it.
+  ## This avoids loading/linking Java classes during post-compile analysis (sbt/zinc#837, #151,
+  ## #1697). Off by default while the classfile-based path is validated as the eventual default.
+  classfileJavaApi: Boolean! = raw"xsbti.compile.IncOptions.defaultClassfileJavaApi()"
+  @since("2.0.0")
+
   #x public static int defaultTransitiveStep() {
   #x     return 3;
   #x }
@@ -173,6 +179,9 @@ type IncOptions {
   #x     return true;
   #x }
   #x public static boolean defaultPipelining() {
+  #x     return false;
+  #x }
+  #x public static boolean defaultClassfileJavaApi() {
   #x     return false;
   #x }
 }

--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
@@ -19,7 +19,8 @@ import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
 import xsbti.api
 import xsbti.api.SafeLazyProxy
-import sbt.internal.inc.classfile.{ AttributeInfo, ClassFile, FieldOrMethodInfo }
+import sbt.internal.inc.classfile.{ AttributeInfo, ClassFile, FieldOrMethodInfo, SignatureParser }
+import sbt.internal.inc.classfile.SignatureModel._
 import sbt.util.Logger
 
 /**
@@ -30,13 +31,14 @@ import sbt.util.Logger
  *
  * It mirrors the structure [[ClassToAPI]] produces (a class + module `ClassLike` pair, declared
  * members split into static/instance) and reuses [[ClassToAPI]]'s access/modifier/type helpers, so
- * the result slots into the same analysis. Member types are erased (from JVM descriptors), but
- * generic signatures, checked exceptions, and declared annotations are folded in conservatively (raw
- * `Signature` string / `throws` and annotation *type* names — not annotation element values), so a
- * change to any of them still changes the hash. Enum children, type parameters, and inherited
- * members are not modelled — see the "Phase 2" scope in docs/design/classfile-based-java-api.md. The
- * output need not match the reflection-derived API byte-for-byte; it only needs to be deterministic
- * and to change when the class's public shape changes.
+ * the result slots into the same analysis. Member types use real generics parsed from the `Signature`
+ * attribute ([[SignatureParser]]), falling back to erased JVM descriptors when it is absent; class
+ * and method type parameters and enum children are modelled. Checked exceptions (`throws`) and
+ * declared annotations (type + element values) are folded into a synthetic annotation so changes are
+ * detected. Inherited members are not modelled (only declared ones) — see Phase 3 in
+ * docs/design/classfile-based-java-api.md. The output need not match the reflection-derived API
+ * byte-for-byte (e.g. type-variable names are unqualified, and wildcards keep only their bound); it
+ * only needs to be deterministic and to change when the class's public shape changes.
  */
 object ClassfileToAPI {
   import api.DefinitionType.{ ClassDef, Module, Trait }
@@ -46,14 +48,15 @@ object ClassfileToAPI {
   private val noTypes = new Array[api.Type](0)
   private val noStrings = new Array[String](0)
   private val noDefinitions = new Array[api.ClassDefinition](0)
+  private val AccEnum = 0x4000 // ACC_ENUM; not exposed by java.lang.reflect.Modifier
+  private val AccVarargs = 0x0080 // ACC_VARARGS (on a method)
 
   private def strict[T <: AnyRef](t: T): api.Lazy[T] = SafeLazyProxy.strict(t)
 
-  // A synthetic annotation that folds public-shape signals the erased descriptor can't capture —
-  // the raw generic Signature, checked-exception (throws) types, and declared annotation types —
-  // into the API, so changing any of them still changes the hash. Conservative Phase-2 fold (raw
-  // Signature string and exception/annotation *type* names, not annotation element values); proper
-  // modelling is Phase 3.
+  // A synthetic annotation that folds public-shape signals not carried by the modelled member types —
+  // checked-exception (throws) types and declared annotations (type + element values), plus the raw
+  // Signature string as a parse-failure fallback — into the API, so changing any of them changes the
+  // hash.
   private val SyntheticRef = ClassToAPI.reference("xsbti.api.ClassfileApi")
 
   private def syntheticAnnotations(parts: (String, Iterable[String])*): Array[api.Annotation] = {
@@ -81,33 +84,42 @@ object ClassfileToAPI {
         } catch { case NonFatal(_) => Nil }
     }
 
-  /** Declared annotation type names from RuntimeVisible/Invisible annotations (JVMS 4.7.16). */
-  private def annotationTypeNames(cf: ClassFile, attrs: Seq[AttributeInfo]): Seq[String] = {
-    val names = ArrayBuffer.empty[String]
+  /**
+   * Declared annotations rendered as `type(name=value,...)` strings, from RuntimeVisible/Invisible
+   * attributes (JVMS 4.7.16) — capturing element values too, so `@A("a")` differs from `@A("b")`.
+   */
+  private def annotationStrings(cf: ClassFile, attrs: Seq[AttributeInfo]): Seq[String] = {
+    val out = ArrayBuffer.empty[String]
     for (a <- attrs if a.isRuntimeVisibleAnnotations || a.isRuntimeInvisibleAnnotations) {
       try {
         val in = new DataInputStream(new ByteArrayInputStream(a.value))
-        def utf8(i: Int): String = cf.constantPool(i).value.fold("")(_.toString)
-        def skipElementValue(): Unit =
+        def poolStr(i: Int): String = cf.constantPool(i).value.fold("")(_.toString)
+        // Length-prefix each composed value so concatenation can't collide (e.g. {"a,b","c"} vs
+        // {"a","b,c"}); we only need distinct, deterministic strings for hashing, not parseability.
+        def lp(s: String): String = s.length.toString + ":" + s
+        def elementValue(): String =
           in.readUnsignedByte().toChar match {
-            case 'e' => in.readUnsignedShort(); in.readUnsignedShort()
-            case 'c' => in.readUnsignedShort()
-            case '@' => readAnnotation()
+            case 'e' => poolStr(in.readUnsignedShort()) + "." + poolStr(in.readUnsignedShort())
+            case 'c' => poolStr(in.readUnsignedShort())
+            case '@' => annotationString()
             case '[' =>
               val n = in.readUnsignedShort()
-              (0 until n).foreach(_ => skipElementValue())
-            case _ => in.readUnsignedShort()
+              (0 until n).map(_ => lp(elementValue())).mkString("[", "", "]")
+            case _ => poolStr(in.readUnsignedShort())
           }
-        def readAnnotation(): Unit = {
-          names += utf8(in.readUnsignedShort()).stripPrefix("L").stripSuffix(";").replace('/', '.')
+        def annotationString(): String = {
+          val tpe =
+            poolStr(in.readUnsignedShort()).stripPrefix("L").stripSuffix(";").replace('/', '.')
           val pairs = in.readUnsignedShort()
-          (0 until pairs).foreach { _ => in.readUnsignedShort(); skipElementValue() }
+          val args =
+            (0 until pairs).map(_ => lp(poolStr(in.readUnsignedShort()) + "=" + elementValue()))
+          if (args.isEmpty) tpe else args.mkString(tpe + "(", "", ")")
         }
         val num = in.readUnsignedShort()
-        (0 until num).foreach(_ => readAnnotation())
+        (0 until num).foreach(_ => out += annotationString())
       } catch { case NonFatal(_) => () }
     }
-    names.toSeq
+    out.toSeq
   }
 
   /**
@@ -151,16 +163,30 @@ object ClassfileToAPI {
     val staticDeclared: Array[api.ClassDefinition] =
       (staticFields.map(_._2) ++ staticMethods.map(_._2)).toArray
 
-    val parents: Array[api.Type] =
-      (cf.superClassName +: cf.interfaceNames.toIndexedSeq)
-        .filter(_.nonEmpty)
-        .map(ClassToAPI.reference)
-        .toArray
+    val classSigStr = cf.attributes.find(_.isSignature).map(cf.stringValue)
+    val classSig = classSigStr.flatMap(SignatureParser.classSignature)
+    val (typeParams, parents): (Array[api.TypeParameter], Array[api.Type]) = classSig match {
+      case Some(cs) =>
+        (
+          cs.typeParams.map(toTypeParam).toArray,
+          (cs.superclass +: cs.interfaces).map(toType).toArray
+        )
+      case None =>
+        val erased = (cf.superClassName +: cf.interfaceNames.toIndexedSeq)
+          .filter(_.nonEmpty)
+          .map(ClassToAPI.reference)
+          .toArray
+        (noTypeParameters, erased)
+    }
 
     val classAnnots = syntheticAnnotations(
-      "signature" -> cf.attributes.find(_.isSignature).map(cf.stringValue).toList,
-      "annotations" -> annotationTypeNames(cf, cf.attributes.toIndexedSeq)
+      "signature" -> unparsedSignature(classSigStr, classSig),
+      "annotations" -> annotationStrings(cf, cf.attributes.toIndexedSeq)
     )
+
+    // ClassToAPI models a Java enum's sealed children as a single self-reference; mirror that.
+    val children: Array[api.Type] =
+      if ((cf.accessFlags & AccEnum) != 0) Array(ClassToAPI.reference(name)) else noTypes
 
     val instanceStructure =
       api.Structure.of(strict(parents), strict(instanceDeclared), strict(noDefinitions))
@@ -176,9 +202,9 @@ object ClassfileToAPI {
       strict(ClassToAPI.Empty),
       strict(instanceStructure),
       noStrings,
-      noTypes,
+      children,
       topLevel,
-      noTypeParameters
+      typeParams
     )
     val stat = api.ClassLike.of(
       name,
@@ -211,16 +237,18 @@ object ClassfileToAPI {
         (try cf.constantValue(name)
         catch { case NonFatal(_) => None })
       else None
+    val sigStr = f.attributes.find(_.isSignature).map(cf.stringValue)
+    val sig = sigStr.flatMap(SignatureParser.fieldSignature)
     val tpe = constant match {
       case Some(value) =>
         val tag = name + "$" + f.descriptor.getOrElse("") + "$" + value
         api.Singleton.of(ClassToAPI.pathFromStrings(cf.className.split("\\.").toIndexedSeq :+ tag))
-      case None => parseFieldType(f.descriptor.getOrElse("V"))
+      case None => sig.map(toType).getOrElse(parseFieldType(f.descriptor.getOrElse("V")))
     }
     val acc = ClassToAPI.access(f.accessFlags, enclPkg)
     val annots = syntheticAnnotations(
-      "signature" -> f.attributes.find(_.isSignature).map(cf.stringValue).toList,
-      "annotations" -> annotationTypeNames(cf, f.attributes)
+      "signature" -> unparsedSignature(sigStr, sig),
+      "annotations" -> annotationStrings(cf, f.attributes)
     )
     val fieldLike =
       if (mods.isFinal) api.Val.of(name, acc, mods, annots, tpe)
@@ -235,27 +263,102 @@ object ClassfileToAPI {
       binaryName: String,
       enclPkg: Option[String]
   ): (Boolean, api.ClassDefinition) = {
-    val (paramTypes, returnType) = parseMethodType(m.descriptor.getOrElse("()V"))
-    val params = paramTypes.map(t =>
-      api.MethodParameter.of("", t, false, api.ParameterModifier.Plain)
-    )
+    val sigStr = m.attributes.find(_.isSignature).map(cf.stringValue)
+    val sig = sigStr.flatMap(SignatureParser.methodSignature)
+    val (paramTypes, rawReturn, typeParams): (Array[api.Type], api.Type, Array[api.TypeParameter]) =
+      sig match {
+        case Some(ms) =>
+          (ms.params.map(toType).toArray, toType(ms.result), ms.typeParams.map(toTypeParam).toArray)
+        case None =>
+          val (ps, ret) = parseMethodType(m.descriptor.getOrElse("()V"))
+          (ps, ret, noTypeParameters)
+      }
+    val isCtor = m.name.contains("<init>")
+    // ClassToAPI uses Empty (not Unit) for a constructor's "return type".
+    val returnType = if (isCtor) ClassToAPI.Empty else rawReturn
+    // ACC_VARARGS marks the trailing array parameter as repeated (`T...` vs `T[]`).
+    val isVarargs = (m.accessFlags & AccVarargs) != 0
+    val lastParam = paramTypes.length - 1
+    val params = paramTypes.zipWithIndex.map {
+      case (t, i) =>
+        val modifier =
+          if (isVarargs && i == lastParam) api.ParameterModifier.Repeated
+          else api.ParameterModifier.Plain
+        api.MethodParameter.of("", t, false, modifier)
+    }
     val paramList = api.ParameterList.of(params, false)
     // Match ClassToAPI.uniqueConstructorName, which uses the binary (not canonical) class name.
     val name =
-      if (m.name.contains("<init>")) s"${binaryName.replace('.', ';')};init;"
+      if (isCtor) s"${binaryName.replace('.', ';')};init;"
       else m.name.getOrElse("")
     val acc = ClassToAPI.access(m.accessFlags, enclPkg)
     val mods = ClassToAPI.modifiers(m.accessFlags)
     val annots = syntheticAnnotations(
-      "signature" -> m.attributes.find(_.isSignature).map(cf.stringValue).toList,
+      "signature" -> unparsedSignature(sigStr, sig),
       "throws" -> exceptionNames(cf, m.attributes),
-      "annotations" -> annotationTypeNames(cf, m.attributes)
+      "annotations" -> annotationStrings(cf, m.attributes)
     )
-    val d = api.Def.of(name, acc, mods, annots, noTypeParameters, Array(paramList), returnType)
+    val d = api.Def.of(name, acc, mods, annots, typeParams, Array(paramList), returnType)
     (m.isStatic, d)
   }
 
   private val ObjectRef = ClassToAPI.reference("java.lang.Object")
+
+  // --- Generic signatures (JVMS 4.7.9) parsed by SignatureParser, mapped to api types ----------
+
+  private def toType(t: SigType): api.Type =
+    t match {
+      case SigPrimitive(tag) => ClassToAPI.primitive(primitiveName(tag))
+      case SigVoid           => ClassToAPI.primitive("void")
+      case SigArray(elem)    => ClassToAPI.array(toType(elem))
+      case SigVar(varName)   => api.ParameterRef.of(varName)
+      case SigClass(clsName, args, inners) =>
+        val full = (clsName +: inners.map(_.name)).mkString(".")
+        val all = (args ++ inners.flatMap(_.args)).map(toTypeArg).toArray
+        if (all.isEmpty) ClassToAPI.reference(full)
+        else api.Parameterized.of(ClassToAPI.reference(full), all)
+    }
+
+  // A wildcard's bound is kept (so `List<? extends Number>` differs from `List<? extends String>`);
+  // the extends/super direction is not separately modelled. Unbounded `*` -> `_`, as ClassToAPI does.
+  private def toTypeArg(a: SigArg): api.Type =
+    a match {
+      case SigWildcard        => ClassToAPI.reference("_")
+      case SigBounded(_, tpe) => toType(tpe)
+    }
+
+  private def toTypeParam(p: SigTypeParam): api.TypeParameter =
+    api.TypeParameter.of(
+      p.name,
+      noAnnotations,
+      noTypeParameters,
+      api.Variance.Invariant,
+      ClassToAPI.NothingRef,
+      api.Structure.of(
+        strict(p.bounds.map(toType).toArray),
+        strict(noDefinitions),
+        strict(noDefinitions)
+      )
+    )
+
+  private def primitiveName(tag: Char): String =
+    tag match {
+      case 'B' => "byte"
+      case 'C' => "char"
+      case 'D' => "double"
+      case 'F' => "float"
+      case 'I' => "int"
+      case 'J' => "long"
+      case 'S' => "short"
+      case 'Z' => "boolean"
+      case _   => "void"
+    }
+
+  // The raw signature is folded into the synthetic annotation only as a fallback — when a Signature
+  // attribute is present but SignatureParser could not parse it — so generic changes are still
+  // detected. When it parses, the real mapped types above carry the generics instead.
+  private def unparsedSignature(raw: Option[String], parsed: Option[Any]): Iterable[String] =
+    if (raw.isDefined && parsed.isEmpty) raw.toList else Nil
 
   /** Parses a JVM field descriptor (JVMS 4.3.2) into an erased [[xsbti.api.Type]]. */
   private[inc] def parseFieldType(descriptor: String): api.Type = parseType(descriptor, 0)._1

--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
@@ -19,7 +19,13 @@ import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
 import xsbti.api
 import xsbti.api.SafeLazyProxy
-import sbt.internal.inc.classfile.{ AttributeInfo, ClassFile, FieldOrMethodInfo, SignatureParser }
+import sbt.internal.inc.classfile.{
+  AttributeInfo,
+  ClassFile,
+  FieldOrMethodInfo,
+  InnerClassInfo,
+  SignatureParser
+}
 import sbt.internal.inc.classfile.SignatureModel._
 import sbt.util.Logger
 
@@ -35,10 +41,12 @@ import sbt.util.Logger
  * attribute ([[SignatureParser]]), falling back to erased JVM descriptors when it is absent; class
  * and method type parameters and enum children are modelled. Checked exceptions (`throws`) and
  * declared annotations (type + element values) are folded into a synthetic annotation so changes are
- * detected. Inherited members are not modelled (only declared ones) — see Phase 3 in
- * docs/design/classfile-based-java-api.md. The output need not match the reflection-derived API
- * byte-for-byte (e.g. type-variable names are unqualified, and wildcards keep only their bound); it
- * only needs to be deterministic and to change when the class's public shape changes.
+ * detected. Inherited public members are recovered by reading parent classfiles via the
+ * `resolveParent` resolver (bytes only — no class loading), so this stays immune to the module /
+ * classpath issues that motivated the classfile path. The output need not match the reflection-derived
+ * API byte-for-byte (e.g. type-variable names are unqualified, and wildcards keep only their bound);
+ * it only needs to be deterministic and to change when the class's public shape changes. See
+ * docs/design/classfile-based-java-api.md.
  */
 object ClassfileToAPI {
   import api.DefinitionType.{ ClassDef, Module, Trait }
@@ -53,10 +61,10 @@ object ClassfileToAPI {
 
   private def strict[T <: AnyRef](t: T): api.Lazy[T] = SafeLazyProxy.strict(t)
 
-  // A synthetic annotation that folds public-shape signals not carried by the modelled member types —
-  // checked-exception (throws) types and declared annotations (type + element values), plus the raw
-  // Signature string as a parse-failure fallback — into the API, so changing any of them changes the
-  // hash.
+  // A synthetic annotation that folds public-shape signals not fully carried by the modelled member
+  // types — checked-exception (throws) types, declared annotations (type + element values), and the
+  // raw Signature string (which captures generic details the lossy type mapping drops) — into the
+  // API, so changing any of them changes the hash.
   private val SyntheticRef = ClassToAPI.reference("xsbti.api.ClassfileApi")
 
   private def syntheticAnnotations(parts: (String, Iterable[String])*): Array[api.Annotation] = {
@@ -129,18 +137,26 @@ object ClassfileToAPI {
    */
   def process(
       named: Seq[(String, ClassFile)],
+      resolveParent: String => Option[ClassFile] = _ => None,
       log: Logger = Logger.Null
   ): (Seq[api.ClassLike], Seq[String]) = {
+    // Cache parsed parents across the batch so e.g. java.lang.Object is read once.
+    val cache = scala.collection.mutable.Map.empty[String, Option[ClassFile]]
+    val cachedResolve = (n: String) => cache.getOrElseUpdate(n, resolveParent(n))
     val classApis = ArrayBuffer.empty[api.ClassLike]
     val mainClasses = ArrayBuffer.empty[String]
     for ((name, cf) <- named) {
-      classApis ++= classLikes(name, cf)
+      classApis ++= classLikes(name, cf, cachedResolve)
       if (cf.methods.exists(_.isMain)) mainClasses += name
     }
     (classApis.toSeq, mainClasses.toSeq)
   }
 
-  private def classLikes(name: String, cf: ClassFile): Seq[api.ClassLike] = {
+  private def classLikes(
+      name: String,
+      cf: ClassFile,
+      resolveParent: String => Option[ClassFile]
+  ): Seq[api.ClassLike] = {
     // Use the binary name's package (last '.' before the simple/binary name); the canonical name's
     // dots would mis-split nested classes (e.g. "pkg.Outer.Inner").
     val enclPkg = ClassToAPI.packageAndName(cf.className)._1
@@ -158,10 +174,17 @@ object ClassfileToAPI {
     }
     val (staticFields, instanceFields) = fields.partition(_._1)
     val (staticMethods, instanceMethods) = methods.partition(_._1)
+    // Direct member classes are listed among the outer's declared members, like ClassToAPI: a static
+    // nested class on the module, an instance inner class on the class. (Local/anonymous classes have
+    // no innerName and are excluded.) Built from the InnerClasses attribute — no class loading.
+    val (staticNested, instanceNested) =
+      memberClasses(cf, publicOnly = false).partition(_.isStatic)
     val instanceDeclared: Array[api.ClassDefinition] =
-      (instanceFields.map(_._2) ++ instanceMethods.map(_._2)).toArray
+      (instanceFields.map(_._2) ++ instanceMethods.map(_._2) ++
+        instanceNested.flatMap(nestedClassDefs(name, _, enclPkg))).toArray
     val staticDeclared: Array[api.ClassDefinition] =
-      (staticFields.map(_._2) ++ staticMethods.map(_._2)).toArray
+      (staticFields.map(_._2) ++ staticMethods.map(_._2) ++
+        staticNested.flatMap(nestedClassDefs(name, _, enclPkg))).toArray
 
     val classSigStr = cf.attributes.find(_.isSignature).map(cf.stringValue)
     val classSig = classSigStr.flatMap(SignatureParser.classSignature)
@@ -180,7 +203,7 @@ object ClassfileToAPI {
     }
 
     val classAnnots = syntheticAnnotations(
-      "signature" -> unparsedSignature(classSigStr, classSig),
+      "signature" -> rawSignature(classSigStr),
       "annotations" -> annotationStrings(cf, cf.attributes.toIndexedSeq)
     )
 
@@ -188,10 +211,11 @@ object ClassfileToAPI {
     val children: Array[api.Type] =
       if ((cf.accessFlags & AccEnum) != 0) Array(ClassToAPI.reference(name)) else noTypes
 
+    val (instanceInherited, staticInherited) = collectInherited(cf, resolveParent)
     val instanceStructure =
-      api.Structure.of(strict(parents), strict(instanceDeclared), strict(noDefinitions))
+      api.Structure.of(strict(parents), strict(instanceDeclared), strict(instanceInherited))
     val staticStructure =
-      api.Structure.of(strict(noTypes), strict(staticDeclared), strict(noDefinitions))
+      api.Structure.of(strict(noTypes), strict(staticDeclared), strict(staticInherited))
 
     val cls = api.ClassLike.of(
       name,
@@ -247,7 +271,7 @@ object ClassfileToAPI {
     }
     val acc = ClassToAPI.access(f.accessFlags, enclPkg)
     val annots = syntheticAnnotations(
-      "signature" -> unparsedSignature(sigStr, sig),
+      "signature" -> rawSignature(sigStr),
       "annotations" -> annotationStrings(cf, f.attributes)
     )
     val fieldLike =
@@ -294,12 +318,147 @@ object ClassfileToAPI {
     val acc = ClassToAPI.access(m.accessFlags, enclPkg)
     val mods = ClassToAPI.modifiers(m.accessFlags)
     val annots = syntheticAnnotations(
-      "signature" -> unparsedSignature(sigStr, sig),
+      "signature" -> rawSignature(sigStr),
       "throws" -> exceptionNames(cf, m.attributes),
       "annotations" -> annotationStrings(cf, m.attributes)
     )
     val d = api.Def.of(name, acc, mods, annots, typeParams, Array(paramList), returnType)
     (m.isStatic, d)
+  }
+
+  // A direct member class, listed among the outer class's declared members as a class + module
+  // ClassLikeDef pair (canonical name), mirroring ClassToAPI — so adding/removing a nested class
+  // changes the outer's API. Built from the InnerClasses attribute alone; the nested class's own
+  // ClassLike carries its full structure and type parameters, so the reference here uses none.
+  private def nestedClassDefs(
+      outerName: String,
+      info: InnerClassInfo,
+      enclPkg: Option[String]
+  ): Seq[api.ClassDefinition] = {
+    val canonical = outerName + "." + info.innerName.getOrElse("")
+    val acc = ClassToAPI.access(info.accessFlags, enclPkg)
+    val mods = ClassToAPI.modifiers(info.accessFlags)
+    val tpe = if (Modifier.isInterface(info.accessFlags)) Trait else ClassDef
+    Seq(
+      api.ClassLikeDef.of(canonical, acc, mods, noAnnotations, noTypeParameters, tpe),
+      api.ClassLikeDef.of(canonical, acc, mods, noAnnotations, noTypeParameters, Module)
+    )
+  }
+
+  // The dotted source (canonical) name of a class from its own InnerClasses attribute — the
+  // classfile analogue of Class.getCanonicalName — used to name inherited member classes consistently
+  // with ClassToAPI. Falls back to the binary name (e.g. for top-level/local classes).
+  private def canonicalName(cf: ClassFile): String = {
+    val inners = cf.innerClasses
+    def go(binaryName: String): String =
+      inners.find(_.innerClassName == binaryName) match {
+        case Some(info) if info.outerClassName.nonEmpty && info.innerName.isDefined =>
+          go(info.outerClassName) + "." + info.innerName.get
+        case _ => binaryName
+      }
+    go(cf.className)
+  }
+
+  /** A class's own named direct member classes, from the InnerClasses attribute (no class loading). */
+  private def memberClasses(cf: ClassFile, publicOnly: Boolean): Seq[InnerClassInfo] =
+    cf.innerClasses.toIndexedSeq.filter(i =>
+      i.outerClassName == cf.className && i.innerName.isDefined && (!publicOnly || i.isPublic)
+    )
+
+  // Erased names of supertypes this class references WITH type arguments (from the Signature
+  // attribute). ClassToAPI collects inherited member classes only from raw (non-generic) supertypes —
+  // a generic supertype surfaces as a ParameterizedType that its inner-class walk filters out — so we
+  // mirror that, otherwise an enum would inherit java.lang.Enum.EnumDesc that reflection never lists.
+  // (Inherited methods/fields are unaffected: those come from every supertype in both paths.)
+  // A supertype is "generic" if its outer OR any inner suffix carries type arguments — e.g.
+  // `Outer<String>.Inner` is a parameterized type even though `Inner` itself has none. The key is the
+  // erased ($-joined) binary name so it matches superTypeNames/cf.superClassName ("Outer$Inner").
+  private def genericSuperNames(cf: ClassFile): Set[String] =
+    cf.attributes
+      .find(_.isSignature)
+      .map(cf.stringValue)
+      .flatMap(SignatureParser.classSignature) match {
+      case Some(cs) =>
+        (cs.superclass +: cs.interfaces).collect {
+          case SigClass(n, args, inners) if args.nonEmpty || inners.exists(_.args.nonEmpty) =>
+            (n +: inners.map(_.name)).mkString("$")
+        }.toSet
+      case None => Set.empty
+    }
+
+  // Supertypes whose members are inherited. An interface's classfile lists Object as its super_class,
+  // but it does not inherit Object's members (reflection's getMethods agrees), so for interfaces we
+  // walk only the super-interfaces.
+  private def superTypeNames(cf: ClassFile): Seq[String] =
+    (if (Modifier.isInterface(cf.accessFlags)) cf.interfaceNames.toIndexedSeq
+     else cf.superClassName +: cf.interfaceNames.toIndexedSeq).filter(_.nonEmpty)
+
+  /**
+   * Public members inherited from super + interfaces (transitively), as (instance, static) — read
+   * from parent classfiles via `resolveParent` (byte-only, no class loading). Mirrors reflection's
+   * `getMethods`/`getFields`: most-derived wins (dedup by name+descriptor for methods, name for
+   * fields), constructors/initializers and static interface methods excluded. Missing parents are
+   * skipped (fail-soft).
+   */
+  private def collectInherited(
+      cf: ClassFile,
+      resolveParent: String => Option[ClassFile]
+  ): (Array[api.ClassDefinition], Array[api.ClassDefinition]) = {
+    val seenMethods = scala.collection.mutable.Set.empty[(String, String)]
+    val seenFields = scala.collection.mutable.Set.empty[String]
+    val seenNested = scala.collection.mutable.Set.empty[String]
+    val ownCanonical = canonicalName(cf)
+    // Seed with the class's own members so overridden/hidden inherited ones are excluded.
+    cf.methods.foreach(m => seenMethods += ((m.name.getOrElse(""), m.descriptor.getOrElse(""))))
+    cf.fields.foreach(f => seenFields += f.name.getOrElse(""))
+    memberClasses(cf, publicOnly = false)
+      .foreach(i => seenNested += ownCanonical + "." + i.innerName.getOrElse(""))
+    val instance = ArrayBuffer.empty[api.ClassDefinition]
+    val static = ArrayBuffer.empty[api.ClassDefinition]
+    val visited = scala.collection.mutable.Set.empty[String]
+    // (parent binary name, whether to collect that parent's member classes — false for a generically
+    // referenced parent, matching reflection). Methods/fields are always collected.
+    val queue = scala.collection.mutable.Queue.empty[(String, Boolean)]
+    val rootGeneric = genericSuperNames(cf)
+    queue ++= superTypeNames(cf).map(n => (n, !rootGeneric.contains(n)))
+    while (queue.nonEmpty) {
+      val (parentName, collectNested) = queue.dequeue()
+      if (visited.add(parentName)) resolveParent(parentName).foreach { pcf =>
+        val penc = ClassToAPI.packageAndName(pcf.className)._1
+        val parentIsInterface = Modifier.isInterface(pcf.accessFlags)
+        for (m <- pcf.methods) {
+          val mname = m.name.getOrElse("")
+          if (
+            m.isPublic && mname != "<init>" && mname != "<clinit>" &&
+            !(parentIsInterface && m.isStatic)
+          ) {
+            if (seenMethods.add((mname, m.descriptor.getOrElse("")))) {
+              val (isStat, d) = methodDef(pcf, m, pcf.className, penc)
+              if (isStat) static += d else instance += d
+            }
+          }
+        }
+        for (f <- pcf.fields) {
+          if (f.isPublic && seenFields.add(f.name.getOrElse(""))) {
+            val (isStat, fl) = fieldDef(pcf, f, penc)
+            if (isStat) static += fl else instance += fl
+          }
+        }
+        // Public member classes of a raw (non-generic) parent are inherited too (ClassToAPI lists them).
+        if (collectNested) {
+          val parentCanonical = canonicalName(pcf)
+          for (i <- memberClasses(pcf, publicOnly = true)) {
+            if (seenNested.add(parentCanonical + "." + i.innerName.getOrElse(""))) {
+              val defs = nestedClassDefs(parentCanonical, i, penc)
+              if (i.isStatic) static ++= defs else instance ++= defs
+            }
+          }
+        }
+        val parentGeneric = genericSuperNames(pcf)
+        queue ++= superTypeNames(pcf).map(n => (n, !parentGeneric.contains(n)))
+      }
+    }
+    (instance.toArray, static.toArray)
   }
 
   private val ObjectRef = ClassToAPI.reference("java.lang.Object")
@@ -354,11 +513,14 @@ object ClassfileToAPI {
       case _   => "void"
     }
 
-  // The raw signature is folded into the synthetic annotation only as a fallback — when a Signature
-  // attribute is present but SignatureParser could not parse it — so generic changes are still
-  // detected. When it parses, the real mapped types above carry the generics instead.
-  private def unparsedSignature(raw: Option[String], parsed: Option[Any]): Iterable[String] =
-    if (raw.isDefined && parsed.isEmpty) raw.toList else Nil
+  // The raw Signature attribute is folded into the synthetic annotation whenever it is present —
+  // not only when parsing fails. The mapped `api.Type`s carry the structure (declared/inherited
+  // members), but they are intentionally lossy: `toTypeArg` drops wildcard variance (so
+  // `List<? extends Number>` and `List<? super Number>` map to the same type) and the parsed
+  // generic `throws` are not modelled (only the erased `Exceptions` attribute is). Folding the raw
+  // signature string guarantees the hash still changes on those generic-only differences, so
+  // name-hashing never under-invalidates. Costs nothing for non-generic members (no attribute).
+  private def rawSignature(raw: Option[String]): Iterable[String] = raw.toList
 
   /** Parses a JVM field descriptor (JVMS 4.3.2) into an erased [[xsbti.api.Type]]. */
   private[inc] def parseFieldType(descriptor: String): api.Type = parseType(descriptor, 0)._1

--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
@@ -16,6 +16,7 @@ package inc
 import java.io.{ ByteArrayInputStream, DataInputStream }
 import java.lang.reflect.Modifier
 import scala.collection.mutable.ArrayBuffer
+import scala.util.control.NonFatal
 import xsbti.api
 import xsbti.api.SafeLazyProxy
 import sbt.internal.inc.classfile.{ AttributeInfo, ClassFile, FieldOrMethodInfo }
@@ -77,7 +78,7 @@ object ClassfileToAPI {
             val classConstant = cf.constantPool(in.readUnsignedShort())
             cf.constantPool(classConstant.nameIndex).value.fold("")(_.toString).replace('/', '.')
           }
-        } catch { case _: Throwable => Nil }
+        } catch { case NonFatal(_) => Nil }
     }
 
   /** Declared annotation type names from RuntimeVisible/Invisible annotations (JVMS 4.7.16). */
@@ -104,7 +105,7 @@ object ClassfileToAPI {
         }
         val num = in.readUnsignedShort()
         (0 until num).foreach(_ => readAnnotation())
-      } catch { case _: Throwable => () }
+      } catch { case NonFatal(_) => () }
     }
     names.toSeq
   }
@@ -208,7 +209,7 @@ object ClassfileToAPI {
     val constant: Option[AnyRef] =
       if (mods.isFinal)
         (try cf.constantValue(name)
-        catch { case _: Throwable => None })
+        catch { case NonFatal(_) => None })
       else None
     val tpe = constant match {
       case Some(value) =>

--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
@@ -188,19 +188,13 @@ object ClassfileToAPI {
 
     val classSigStr = cf.attributes.find(_.isSignature).map(cf.stringValue)
     val classSig = classSigStr.flatMap(SignatureParser.classSignature)
-    val (typeParams, parents): (Array[api.TypeParameter], Array[api.Type]) = classSig match {
-      case Some(cs) =>
-        (
-          cs.typeParams.map(toTypeParam).toArray,
-          (cs.superclass +: cs.interfaces).map(toType).toArray
-        )
-      case None =>
-        val erased = (cf.superClassName +: cf.interfaceNames.toIndexedSeq)
-          .filter(_.nonEmpty)
-          .map(ClassToAPI.reference)
-          .toArray
-        (noTypeParameters, erased)
-    }
+    val typeParams: Array[api.TypeParameter] =
+      classSig.map(_.typeParams.map(toTypeParam).toArray).getOrElse(noTypeParameters)
+    // Parents are the *transitive* supertype closure (matching ClassToAPI.allSuperTypes), resolved
+    // through parent classfiles — not just the direct supertypes. Otherwise a subtyping relationship
+    // this class holds only through an intermediate (e.g. a member-less marker interface that a
+    // superclass stops implementing) would not change its API, under-invalidating its dependents.
+    val parents: Array[api.Type] = collectParents(cf, resolveParent)
 
     val classAnnots = syntheticAnnotations(
       "signature" -> rawSignature(classSigStr),
@@ -460,6 +454,53 @@ object ClassfileToAPI {
     }
     (instance.toArray, static.toArray)
   }
+
+  /**
+   * The transitive supertype closure as api type references, resolved through parent classfiles
+   * (byte-only, no class loading) — the classfile analogue of [[ClassToAPI.allSuperTypes]]. Direct
+   * supertypes keep their generic form from the `Signature` attribute; ancestors are followed via
+   * their erased (`$`-joined) binary names. Cycle-safe (a visited set keyed on the erased name) and
+   * fail-soft (an unresolved parent just ends that branch). `java.lang.Object` is included for a
+   * class but not for an interface, matching reflection (an interface's `getGenericSuperclass` is
+   * null). The class itself is excluded.
+   */
+  private def collectParents(
+      cf: ClassFile,
+      resolveParent: String => Option[ClassFile]
+  ): Array[api.Type] = {
+    // (erased binary name, reference) for each direct supertype of `c` — generic when a Signature is
+    // present, erased otherwise; Object dropped for interfaces (via superTypeNames' class/iface split).
+    def directSupers(c: ClassFile): Seq[(String, api.Type)] = {
+      val isIface = Modifier.isInterface(c.accessFlags)
+      c.attributes
+        .find(_.isSignature)
+        .map(c.stringValue)
+        .flatMap(SignatureParser.classSignature) match {
+        case Some(cs) =>
+          val supers = if (isIface) cs.interfaces else cs.superclass +: cs.interfaces
+          supers.collect { case s: SigClass => erasedSigClassName(s) -> toType(s) }
+        case None =>
+          superTypeNames(c).map(n => n -> ClassToAPI.reference(n))
+      }
+    }
+    val out = ArrayBuffer.empty[api.Type]
+    val visited = scala.collection.mutable.Set(cf.className) // exclude self
+    val queue = scala.collection.mutable.Queue.empty[(String, api.Type)]
+    queue ++= directSupers(cf)
+    while (queue.nonEmpty) {
+      val (name, ref) = queue.dequeue()
+      if (visited.add(name)) {
+        out += ref
+        resolveParent(name).foreach(pcf => queue ++= directSupers(pcf))
+      }
+    }
+    out.toArray
+  }
+
+  // The erased ($-joined) binary name of a class-type signature, matching cf.superClassName /
+  // interfaceNames (e.g. `pkg.Outer<String>.Inner` -> "pkg.Outer$Inner").
+  private def erasedSigClassName(s: SigClass): String =
+    (s.name +: s.inners.map(_.name)).mkString("$")
 
   private val ObjectRef = ClassToAPI.reference("java.lang.Object")
 

--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
@@ -440,21 +440,21 @@ object ClassfileToAPI {
   /**
    * Public members inherited from super + interfaces (transitively), as (instance, static) — read
    * from parent classfiles via `resolveParent` (byte-only, no class loading). Mirrors reflection's
-   * `getMethods`/`getFields`: most-derived wins (dedup by name+descriptor for methods, name for
-   * fields), constructors/initializers and static interface methods excluded. Missing parents are
-   * skipped (fail-soft).
+   * `getMethods`/`getFields`: methods dedup by name+descriptor (override semantics, most-derived
+   * wins), while fields are NOT deduped by name — Java fields hide rather than override, and
+   * `getFields` keeps a hidden ancestor field as inherited (its only dedup is by declaring class,
+   * which the visited-set provides). Constructors/initializers and static interface methods are
+   * excluded. Missing parents are skipped (fail-soft).
    */
   private def collectInherited(
       cf: ClassFile,
       resolveParent: String => Option[ClassFile]
   ): (Array[api.ClassDefinition], Array[api.ClassDefinition]) = {
     val seenMethods = scala.collection.mutable.Set.empty[(String, String)]
-    val seenFields = scala.collection.mutable.Set.empty[String]
     val seenNested = scala.collection.mutable.Set.empty[String]
     val ownCanonical = canonicalName(cf)
-    // Seed with the class's own members so overridden/hidden inherited ones are excluded.
+    // Seed with the class's own methods so overridden inherited ones are excluded.
     cf.methods.foreach(m => seenMethods += ((m.name.getOrElse(""), m.descriptor.getOrElse(""))))
-    cf.fields.foreach(f => seenFields += f.name.getOrElse(""))
     memberClasses(cf, publicOnly = false)
       .foreach(i => seenNested += ownCanonical + "." + i.innerName.getOrElse(""))
     val instance = ArrayBuffer.empty[api.ClassDefinition]
@@ -483,7 +483,7 @@ object ClassfileToAPI {
           }
         }
         for (f <- pcf.fields) {
-          if (f.isPublic && seenFields.add(f.name.getOrElse(""))) {
+          if (f.isPublic) {
             val (isStat, fl) = fieldDef(pcf, f, penc)
             if (isStat) static += fl else instance += fl
           }

--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
@@ -92,39 +92,69 @@ object ClassfileToAPI {
         } catch { case NonFatal(_) => Nil }
     }
 
+  // Decodes one `annotation` structure (JVMS 4.7.16) from `in` into a `type(name=value,...)` string,
+  // capturing element values too (so `@A("a")` differs from `@A("b")`). Length-prefixes each composed
+  // value so concatenation can't collide (e.g. {"a,b","c"} vs {"a","b,c"}); we only need distinct,
+  // deterministic strings for hashing, not parseability.
+  private def decodeAnnotation(in: DataInputStream, cf: ClassFile): String = {
+    def poolStr(i: Int): String = cf.constantPool(i).value.fold("")(_.toString)
+    def lp(s: String): String = s.length.toString + ":" + s
+    def elementValue(): String =
+      in.readUnsignedByte().toChar match {
+        case 'e' => poolStr(in.readUnsignedShort()) + "." + poolStr(in.readUnsignedShort())
+        case 'c' => poolStr(in.readUnsignedShort())
+        case '@' => annotationString()
+        case '[' =>
+          val n = in.readUnsignedShort()
+          (0 until n).map(_ => lp(elementValue())).mkString("[", "", "]")
+        case _ => poolStr(in.readUnsignedShort())
+      }
+    def annotationString(): String = {
+      val tpe = poolStr(in.readUnsignedShort()).stripPrefix("L").stripSuffix(";").replace('/', '.')
+      val pairs = in.readUnsignedShort()
+      val args =
+        (0 until pairs).map(_ => lp(poolStr(in.readUnsignedShort()) + "=" + elementValue()))
+      if (args.isEmpty) tpe else args.mkString(tpe + "(", "", ")")
+    }
+    annotationString()
+  }
+
   /**
    * Declared annotations rendered as `type(name=value,...)` strings, from RuntimeVisible/Invisible
-   * attributes (JVMS 4.7.16) — capturing element values too, so `@A("a")` differs from `@A("b")`.
+   * attributes (JVMS 4.7.16).
    */
   private def annotationStrings(cf: ClassFile, attrs: Seq[AttributeInfo]): Seq[String] = {
     val out = ArrayBuffer.empty[String]
     for (a <- attrs if a.isRuntimeVisibleAnnotations || a.isRuntimeInvisibleAnnotations) {
       try {
         val in = new DataInputStream(new ByteArrayInputStream(a.value))
-        def poolStr(i: Int): String = cf.constantPool(i).value.fold("")(_.toString)
-        // Length-prefix each composed value so concatenation can't collide (e.g. {"a,b","c"} vs
-        // {"a","b,c"}); we only need distinct, deterministic strings for hashing, not parseability.
-        def lp(s: String): String = s.length.toString + ":" + s
-        def elementValue(): String =
-          in.readUnsignedByte().toChar match {
-            case 'e' => poolStr(in.readUnsignedShort()) + "." + poolStr(in.readUnsignedShort())
-            case 'c' => poolStr(in.readUnsignedShort())
-            case '@' => annotationString()
-            case '[' =>
-              val n = in.readUnsignedShort()
-              (0 until n).map(_ => lp(elementValue())).mkString("[", "", "]")
-            case _ => poolStr(in.readUnsignedShort())
-          }
-        def annotationString(): String = {
-          val tpe =
-            poolStr(in.readUnsignedShort()).stripPrefix("L").stripSuffix(";").replace('/', '.')
-          val pairs = in.readUnsignedShort()
-          val args =
-            (0 until pairs).map(_ => lp(poolStr(in.readUnsignedShort()) + "=" + elementValue()))
-          if (args.isEmpty) tpe else args.mkString(tpe + "(", "", ")")
-        }
         val num = in.readUnsignedShort()
-        (0 until num).foreach(_ => out += annotationString())
+        (0 until num).foreach(_ => out += decodeAnnotation(in, cf))
+      } catch { case NonFatal(_) => () }
+    }
+    out.toSeq
+  }
+
+  /**
+   * Parameter annotations rendered as `index:type(...)` strings, from RuntimeVisible/Invisible
+   * ParameterAnnotations attributes (JVMS 4.7.18–19). Position-prefixed so moving an annotation
+   * between parameters is a change. ClassToAPI carries these on the parameter type (api.Annotated);
+   * folding them into the method's synthetic annotation is enough to track changes for hashing.
+   */
+  private def parameterAnnotationStrings(cf: ClassFile, attrs: Seq[AttributeInfo]): Seq[String] = {
+    val out = ArrayBuffer.empty[String]
+    for (
+      a <- attrs
+      if a.isNamed("RuntimeVisibleParameterAnnotations") ||
+        a.isNamed("RuntimeInvisibleParameterAnnotations")
+    ) {
+      try {
+        val in = new DataInputStream(new ByteArrayInputStream(a.value))
+        val numParams = in.readUnsignedByte()
+        (0 until numParams).foreach { p =>
+          val n = in.readUnsignedShort()
+          (0 until n).foreach(_ => out += s"$p:" + decodeAnnotation(in, cf))
+        }
       } catch { case NonFatal(_) => () }
     }
     out.toSeq
@@ -147,7 +177,7 @@ object ClassfileToAPI {
     val mainClasses = ArrayBuffer.empty[String]
     for ((name, cf) <- named) {
       classApis ++= classLikes(name, cf, cachedResolve)
-      if (cf.methods.exists(_.isMain)) mainClasses += name
+      if (hasMain(cf, cachedResolve)) mainClasses += name
     }
     (classApis.toSeq, mainClasses.toSeq)
   }
@@ -314,7 +344,8 @@ object ClassfileToAPI {
     val annots = syntheticAnnotations(
       "signature" -> rawSignature(sigStr),
       "throws" -> exceptionNames(cf, m.attributes),
-      "annotations" -> annotationStrings(cf, m.attributes)
+      "annotations" -> annotationStrings(cf, m.attributes),
+      "paramAnnotations" -> parameterAnnotationStrings(cf, m.attributes)
     )
     val d = api.Def.of(name, acc, mods, annots, typeParams, Array(paramList), returnType)
     (m.isStatic, d)
@@ -501,6 +532,29 @@ object ClassfileToAPI {
   // interfaceNames (e.g. `pkg.Outer<String>.Inner` -> "pkg.Outer$Inner").
   private def erasedSigClassName(s: SigClass): String =
     (s.name +: s.inners.map(_.name)).mkString("$")
+
+  /**
+   * Whether the class has a `main` method — its own or one inherited from a superclass — mirroring
+   * ClassToAPI's use of `getMethods` (which includes inherited methods). The superclass chain is
+   * walked via parent classfiles; a static method declared on an interface is not inherited (matching
+   * getMethods and [[collectInherited]]), so it never counts. Cycle-safe and fail-soft.
+   */
+  private def hasMain(cf: ClassFile, resolveParent: String => Option[ClassFile]): Boolean =
+    cf.methods.exists(_.isMain) || {
+      val visited = scala.collection.mutable.Set(cf.className)
+      val queue = scala.collection.mutable.Queue.empty[String]
+      queue ++= superTypeNames(cf)
+      var found = false
+      while (!found && queue.nonEmpty) {
+        val n = queue.dequeue()
+        if (visited.add(n)) resolveParent(n).foreach { pcf =>
+          val isIface = Modifier.isInterface(pcf.accessFlags)
+          if (pcf.methods.exists(m => m.isMain && !isIface)) found = true
+          else queue ++= superTypeNames(pcf)
+        }
+      }
+      found
+    }
 
   private val ObjectRef = ClassToAPI.reference("java.lang.Object")
 

--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
@@ -47,6 +47,16 @@ import sbt.util.Logger
  * API byte-for-byte (e.g. type-variable names are unqualified, and wildcards keep only their bound);
  * it only needs to be deterministic and to change when the class's public shape changes. See
  * docs/design/classfile-based-java-api.md.
+ *
+ * Two differences from [[ClassToAPI]] are intentional and do not under-invalidate:
+ *   - Annotations are read from both the RuntimeVisible and RuntimeInvisible attributes, so
+ *     CLASS-retention annotations are captured here even though reflection's `getAnnotations` (which
+ *     sees only RUNTIME retention) would miss them. This is strictly more conservative — it can only
+ *     add hash sensitivity, never remove it.
+ *   - A member class referenced in its *outer's* declared members ([[nestedClassDefs]]) carries no
+ *     type parameters or annotations, whereas reflection's reference does. The member class's own
+ *     `ClassLike` entry models them in full, so a change there still invalidates its dependents; only
+ *     the outer's view of it is abbreviated.
  */
 object ClassfileToAPI {
   import api.DefinitionType.{ ClassDef, Module, Trait }

--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
@@ -50,9 +50,16 @@ import sbt.util.Logger
  *
  * Two differences from [[ClassToAPI]] are intentional and do not under-invalidate:
  *   - Annotations are read from both the RuntimeVisible and RuntimeInvisible attributes, so
- *     CLASS-retention annotations are captured here even though reflection's `getAnnotations` (which
- *     sees only RUNTIME retention) would miss them. This is strictly more conservative — it can only
- *     add hash sensitivity, never remove it.
+ *     CLASS-retention annotations (the default when no `@Retention` is given) are captured here even
+ *     though reflection's `getAnnotations` does not see them. The relevant criterion for invalidation
+ *     is whether compiling a *dependent* against this classfile can observe the annotation, not
+ *     whether it survives to runtime: javac exposes RuntimeInvisible annotations through
+ *     `javax.lang.model` (`getAnnotationMirrors`), so an annotation processor introspecting this type
+ *     during a dependent's compilation can act on a CLASS-retained annotation and emit different
+ *     output. Reflection's omission is thus a limitation of its runtime-only lens, not a designed
+ *     semantic — capturing these here is closer to what a dependent compiler can actually see. (SOURCE
+ *     retention is absent from the classfile, so neither path sees it, correctly.) The cost is mild
+ *     over-invalidation: a CLASS-retained annotation that no processor reads still bumps the hash.
  *   - A member class referenced in its *outer's* declared members ([[nestedClassDefs]]) carries no
  *     type parameters or annotations, whereas reflection's reference does. The member class's own
  *     `ClassLike` entry models them in full, so a change there still invalidates its dependents; only

--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
@@ -194,9 +194,11 @@ object ClassfileToAPI {
     val acc = ClassToAPI.access(cf.accessFlags, enclPkg)
     val isInterface = Modifier.isInterface(cf.accessFlags)
     val tpe = if (isInterface) Trait else ClassDef
-    // Top-level unless the classfile's InnerClasses attribute lists itself as a member of another.
-    val topLevel =
-      !cf.innerClasses.exists(i => i.innerClassName == cf.className && i.outerClassName.nonEmpty)
+    // Top-level unless the InnerClasses attribute has a self entry — present for member, local, and
+    // anonymous classes (JVMS 4.7.6 requires it for any non-package-member). Matches reflection's
+    // `getEnclosingClass == null`. Local/anonymous self entries have an empty outer (outer index 0),
+    // so the entry's presence — not its outer — is what marks the class as nested.
+    val topLevel = !cf.innerClasses.exists(_.innerClassName == cf.className)
 
     val fields = cf.fields.toIndexedSeq.map(fieldDef(cf, _, enclPkg))
     val methods = cf.methods.toIndexedSeq.collect {

--- a/internal/zinc-apiinfo/src/test/resources/fbound/FBoundedStress.java
+++ b/internal/zinc-apiinfo/src/test/resources/fbound/FBoundedStress.java
@@ -1,0 +1,378 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+import java.io.Serializable;
+import java.util.*;
+import java.lang.annotation.*;
+
+// ---------------------------------------------------------------------------
+// Annotations used as metadata (stresses annotation-attribute parser)
+// ---------------------------------------------------------------------------
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@interface Stress {
+    Class<? extends Comparable<?>>[] comparators() default {};
+    Class<?>[] witnesses()                          default {};
+    String     note()                               default "";
+}
+
+// ---------------------------------------------------------------------------
+// 1. Deep single-parameter F-bound chain
+//    Each level adds one more layer to the Signature attribute.
+// ---------------------------------------------------------------------------
+
+interface L0<T extends L0<T>> {
+    T self();
+
+    // Signature cycle through method return types. `companion()` names Mirror,
+    // and Mirror.origin() names L0 again — so following method signatures without
+    // memoizing visited types loops forever:
+    //   L0.companion -> Mirror<T> -> Mirror.origin -> L0<T> -> L0.companion -> ...
+    Mirror<T> companion();
+
+    default int depth() { return 0; }
+}
+
+// The other half of the cycle: every method here references back to L0 (the
+// first/parent type of the chain), closing the loop a naive parser would chase.
+interface Mirror<T extends L0<T>> {
+    L0<T> origin();
+    T     pivot();
+}
+
+interface L1<T extends L1<T>> extends L0<T> {
+    @Override default int depth() { return 1; }
+}
+
+interface L2<T extends L2<T>> extends L1<T> {
+    @Override default int depth() { return 2; }
+}
+
+interface L3<T extends L3<T>> extends L2<T> {
+    @Override default int depth() { return 3; }
+}
+
+interface L4<T extends L4<T>> extends L3<T> {
+    @Override default int depth() { return 4; }
+}
+
+interface L5<T extends L5<T>> extends L4<T> {
+    @Override default int depth() { return 5; }
+}
+
+interface L6<T extends L6<T>> extends L5<T> {
+    @Override default int depth() { return 6; }
+}
+
+interface L7<T extends L7<T>> extends L6<T> {
+    @Override default int depth() { return 7; }
+}
+
+interface L8<T extends L8<T>> extends L7<T> {
+    @Override default int depth() { return 8; }
+}
+
+// Concrete leaf — produces a Signature like:
+//   Ljava/lang/Object;LL8<TLeaf;>;  (simplified)
+// plus bridge methods from every covariant self() override.
+@Stress(note = "deep single-param F-bound leaf")
+final class Leaf implements L8<Leaf> {
+    @Override public Leaf self() { return this; }
+
+    // Closes the L0 <-> Mirror signature cycle for the concrete leaf. The
+    // anonymous Mirror also adds another InnerClasses entry to chew on.
+    @Override public Mirror<Leaf> companion() {
+        return new Mirror<Leaf>() {
+            @Override public L0<Leaf> origin() { return Leaf.this; }
+            @Override public Leaf     pivot()  { return Leaf.this; }
+        };
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Multi-parameter mutually-constrained F-bounds
+//    A <-> B mutual reference via a shared carrier interface.
+// ---------------------------------------------------------------------------
+
+interface Carrier<A extends Carrier<A, B>, B extends Carrier<B, A>> {
+    A left();
+    B right();
+}
+
+@Stress(note = "mutual F-bound left")
+final class LeftNode implements Carrier<LeftNode, RightNode> {
+    @Override public LeftNode  left()  { return this; }
+    @Override public RightNode right() { return new RightNode(); }
+}
+
+@Stress(note = "mutual F-bound right")
+final class RightNode implements Carrier<RightNode, LeftNode> {
+    @Override public RightNode left()  { return this; }
+    @Override public LeftNode  right() { return new LeftNode(); }
+}
+
+// ---------------------------------------------------------------------------
+// 2b. Mutually recursive type parameters across two type constructors.
+//     Type *variables* can't cycle directly (`<A extends B, B extends A>` is
+//     rejected), but they CAN be mutually recursive *through* generic types:
+//     each interface's parameters are bounded by the other interface, and each
+//     is additionally F-bounded on itself. The bound graph has a 2-cycle
+//     (Yin <-> Yang) that a naive bound-resolver must break.
+// ---------------------------------------------------------------------------
+
+interface Yin<Y extends Yin<Y, Z>, Z extends Yang<Z, Y>> {
+    Z yang();   // crosses to the other constructor
+    Y self();   // F-bound on this one
+}
+
+interface Yang<Z extends Yang<Z, Y>, Y extends Yin<Y, Z>> {
+    Y yin();
+    Z self();
+}
+
+@Stress(note = "mutually recursive type params (yin)")
+final class ConcYin implements Yin<ConcYin, ConcYang> {
+    @Override public ConcYang yang() { return new ConcYang(); }
+    @Override public ConcYin  self() { return this; }
+}
+
+@Stress(note = "mutually recursive type params (yang)")
+final class ConcYang implements Yang<ConcYang, ConcYin> {
+    @Override public ConcYin  yin()  { return new ConcYin(); }
+    @Override public ConcYang self() { return this; }
+}
+
+// ---------------------------------------------------------------------------
+// 3. Wildcard capture inside F-bound + Comparable
+//    Signature explosion: <T:Ljava/lang/Comparable<-TT;>;>
+// ---------------------------------------------------------------------------
+
+@Stress(note = "wildcard in F-bound with Comparable")
+abstract class WildStress<T extends Comparable<? super T>>
+        implements Comparable<WildStress<T>> {
+
+    abstract T value();
+
+    @Override
+    public int compareTo(WildStress<T> other) {
+        return this.value().compareTo(other.value());
+    }
+
+    // Covariant return triggers a bridge method
+    abstract WildStress<T> copy();
+}
+
+final class WildInt extends WildStress<Integer> {
+    private final int v;
+    WildInt(int v) { this.v = v; }
+    @Override Integer value() { return v; }
+    @Override WildInt copy()  { return new WildInt(v); }  // bridge for WildStress.copy()
+}
+
+// ---------------------------------------------------------------------------
+// 4. Bridge-method proliferation via covariant overrides in a chain
+//    Each class overrides a method with a covariant return type, producing
+//    one synthetic bridge per level.
+// ---------------------------------------------------------------------------
+
+abstract class Base {
+    abstract Base produce();
+    Base consume(Base b) { return b; }
+}
+
+abstract class Mid extends Base {
+    @Override abstract Mid produce();   // bridge: Base produce()
+    @Override Mid consume(Base b) { return (Mid) b; }
+}
+
+abstract class Top extends Mid {
+    @Override abstract Top produce();   // bridge: Mid produce(), Base produce()
+    @Override Top consume(Base b) { return (Top) b; }
+}
+
+@Stress(note = "covariant bridge proliferation")
+final class Tip extends Top {
+    @Override public Tip produce() { return this; }  // 3 bridges total
+    @Override public Tip consume(Base b) { return (Tip) b; }
+}
+
+// ---------------------------------------------------------------------------
+// 5. Raw-type / generic mixed inheritance
+//    SomeRaw extends a raw generic; javac emits unchecked-cast bridge logic.
+// ---------------------------------------------------------------------------
+
+abstract class GenericBase<T> {
+    abstract T get();
+    abstract void set(T value);
+}
+
+@SuppressWarnings({"rawtypes", "unchecked"})
+final class SomeRaw extends GenericBase {  // raw supertype
+    private Object val;
+    @Override public Object get()         { return val; }
+    @Override public void   set(Object v) { val = v; }
+}
+
+// ---------------------------------------------------------------------------
+// 6. Deeply nested generic inner classes
+//    Signature of the innermost class encodes all enclosing type parameters.
+// ---------------------------------------------------------------------------
+
+@Stress(note = "nested generic inner class signatures")
+class Outer<A> {
+    class Middle<B extends Comparable<B>> {
+        class Inner<C extends L4<C>> {
+            // Signature references A, B, C plus their bounds
+            Map<A, Map<B, List<C>>> combined() { return Collections.emptyMap(); }
+
+            // Stress: method return type references all three levels
+            Inner<C> innerSelf() { return this; }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 7. Default method diamond
+//    Both Left7 and Right7 provide a default; concrete class must override.
+//    Produces synthetic accessor / forwarder methods in the class file.
+// ---------------------------------------------------------------------------
+
+interface DiamondTop {
+    default String name() { return "top"; }
+}
+
+interface DiamondLeft extends DiamondTop {
+    @Override default String name() { return "left"; }
+}
+
+interface DiamondRight extends DiamondTop {
+    @Override default String name() { return "right"; }
+}
+
+@Stress(note = "diamond default method forwarders")
+final class DiamondBottom implements DiamondLeft, DiamondRight {
+    @Override public String name() { return DiamondLeft.super.name() + "+" + DiamondRight.super.name(); }
+}
+
+// ---------------------------------------------------------------------------
+// 8. Generic method with multiple independent F-bounds + throws clause
+//    Stresses method-descriptor and exception-table parsing together.
+// ---------------------------------------------------------------------------
+
+@Stress(
+    comparators = { String.class, Integer.class },
+    witnesses   = { Leaf.class, WildInt.class },
+    note        = "multi-bound generic method"
+)
+final class Utilities {
+
+    /**
+     * Mutually recursive type parameters within a single method signature:
+     * A is bounded by Comparable&lt;B&gt; and B by Comparable&lt;A&gt;. Legal because the
+     * recursion passes through Comparable rather than being a bare variable cycle.
+     * The method Signature attribute encodes both bounds referencing each other.
+     */
+    public static <A extends Comparable<B>, B extends Comparable<A>>
+    int mutualCompare(A a, B b) {
+        return a.compareTo(b) - b.compareTo(a);
+    }
+
+    /**
+     * A method whose type parameter has two independent upper bounds (produces &-separator
+     * in the Signature attribute) plus a checked exception.
+     */
+    public static <T extends L8<T> & Serializable & Comparable<T>>
+    T roundTrip(T value) throws CloneNotSupportedException {
+        // The cast here is legal but forces the verifier to check bridge compatibility.
+        @SuppressWarnings("unchecked")
+        T copy = (T) value;
+        return copy.self();
+    }
+
+    /**
+     * Wildcard hell: nested wildcards in both parameter and return position.
+     * Exercises signature parsing of `? extends List<? super T>`.
+     */
+    public static <T extends Comparable<? super T>>
+    List<? extends T> sortedCopy(Collection<? extends T> src) {
+        List<T> result = new ArrayList<>(src);
+        Collections.sort(result);
+        return result;
+    }
+
+    /**
+     * Higher-kinded simulation via a Function interface chain.
+     * The Signature on this method is notably long.
+     */
+    public static <A extends L4<A>, B extends WildStress<? extends Comparable<? super A>>>
+    Map<A, B> crossProduct(List<A> as, List<B> bs) {
+        Map<A, B> out = new LinkedHashMap<>();
+        for (A a : as) for (B b : bs) out.put(a, b);
+        return out;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 9. Enum with abstract method + generic interface
+//    Each enum constant becomes an anonymous class in the class file.
+//    Parsers iterating InnerClasses attributes will see all of them.
+// ---------------------------------------------------------------------------
+
+@Stress(note = "enum anonymous-class inner entries")
+enum Transformer implements L0<Transformer> {
+    IDENTITY {
+        @Override public <T> T apply(T x) { return x; }
+        @Override public Transformer self() { return IDENTITY; }
+    },
+    BOXED {
+        @Override public <T> T apply(T x) { return x; }  // simplified
+        @Override public Transformer self() { return BOXED; }
+    };
+
+    public abstract <T> T apply(T x);
+
+    // Shared (non-abstract) — satisfies L0.companion() for every enum constant
+    // and re-enters the L0 <-> Mirror signature cycle.
+    @Override public Mirror<Transformer> companion() {
+        return new Mirror<Transformer>() {
+            @Override public L0<Transformer> origin() { return Transformer.this; }
+            @Override public Transformer     pivot()  { return Transformer.this; }
+        };
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Main — just enough to force class loading and expose any parse errors.
+// ---------------------------------------------------------------------------
+
+public class FBoundedStress {
+    public static void main(String[] args) throws Exception {
+        // Force class initialization (also ensures the class files are all valid)
+        System.out.println("Leaf depth      : " + new Leaf().depth());
+        // Walk the L0 <-> Mirror signature cycle one full lap at runtime.
+        System.out.println("Cycle lap       : " + new Leaf().companion().origin().companion().pivot().depth());
+        System.out.println("Carrier mutual  : " + new LeftNode().right().left().getClass().getSimpleName());
+        System.out.println("Yin/Yang        : " + new ConcYin().yang().yin().getClass().getSimpleName());
+        System.out.println("mutualCompare   : " + Utilities.mutualCompare("a", "b"));
+        System.out.println("WildInt cmp     : " + new WildInt(1).compareTo(new WildInt(2)));
+        System.out.println("Tip produce     : " + new Tip().produce().getClass().getSimpleName());
+        System.out.println("Diamond name    : " + new DiamondBottom().name());
+        System.out.println("SomeRaw get     : " + ((java.util.function.Supplier<Object>) () -> { var r = new SomeRaw(); r.set("x"); return r.get(); }).get());
+        System.out.println("Utilities sort  : " + Utilities.sortedCopy(List.of(3, 1, 2)));
+        System.out.println("Transformer     : " + Transformer.IDENTITY.apply("ok"));
+
+        // Nested inner — exercises Outer<A>.Middle<B>.Inner<C> signatures
+        Outer<String>.Middle<Integer>.Inner<Leaf> inner =
+            new Outer<String>().new Middle<Integer>().new Inner<Leaf>();
+        System.out.println("Inner self      : " + (inner.innerSelf() == inner));
+    }
+}

--- a/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/ClassfileToAPISpecification.scala
+++ b/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/ClassfileToAPISpecification.scala
@@ -217,6 +217,140 @@ class ClassfileToAPISpecification extends UnitSpec {
     }
   }
 
+  // Step 2: generic types are recovered from the Signature attribute as real api types, not folded.
+  it should "model generic types and type parameters from the Signature attribute" in {
+    IO.withTemporaryDirectory { temp =>
+      val src = new File(temp, "Box.java")
+      IO.write(
+        src,
+        """|import java.util.List;
+           |public class Box<T> {
+           |  public List<String> items;
+           |  public <U> U get(U u) { return u; }
+           |}
+           |""".stripMargin
+      )
+      JavaCompilerForUnitTesting.compileJava(Seq(src), temp, Seq.empty)
+      val cf = Parser(new File(temp, "Box.class").toPath, Logger.Null)
+      val cls = ClassfileToAPI
+        .process(Seq("Box" -> cf))
+        ._1
+        .find(_.definitionType == DefinitionType.ClassDef)
+        .get
+
+      // class type parameter T
+      assert(cls.typeParameters.map(_.id).toSeq == Seq("T"))
+
+      // field List<String> is a real Parameterized type, not erased or folded
+      val items = cls.structure.declared.collectFirst {
+        case f: xsbti.api.FieldLike if f.name == "items" => f
+      }.get
+      assert(items.tpe.isInstanceOf[xsbti.api.Parameterized])
+
+      // method <U> U get(U) has type parameter U and returns ParameterRef U
+      val get = cls.structure.declared.collectFirst {
+        case d: xsbti.api.Def if d.name == "get" => d
+      }.get
+      assert(get.typeParameters.map(_.id).toSeq == Seq("U"))
+      assert(get.returnType.asInstanceOf[xsbti.api.ParameterRef].id == "U")
+    }
+  }
+
+  // Step 2b: annotation element values are captured, so a value change is detected.
+  it should "detect annotation element value changes" in {
+    IO.withTemporaryDirectory { temp =>
+      val a = sampleApis(
+        temp,
+        "a",
+        "public class Sample { @Deprecated(since = \"1\") public void run() {} }"
+      )
+      val b = sampleApis(
+        temp,
+        "b",
+        "public class Sample { @Deprecated(since = \"2\") public void run() {} }"
+      )
+      assert(hashAll(a) != hashAll(b))
+    }
+  }
+
+  // Step 2c: a Java enum gets sealed-children modelled (mirroring ClassToAPI); a class does not.
+  it should "model enum children for an enum but not a plain class" in {
+    IO.withTemporaryDirectory { temp =>
+      def classDef(dirName: String, name: String, source: String): ClassLike = {
+        val dir = new File(temp, dirName)
+        dir.mkdir()
+        val src = new File(dir, name + ".java")
+        IO.write(src, source)
+        JavaCompilerForUnitTesting.compileJava(Seq(src), dir, Seq.empty)
+        val cf = Parser(new File(dir, name + ".class").toPath, Logger.Null)
+        ClassfileToAPI
+          .process(Seq(name -> cf))
+          ._1
+          .find(_.definitionType == DefinitionType.ClassDef)
+          .get
+      }
+      assert(classDef("e", "E", "public enum E { A, B }").childrenOfSealedClass.nonEmpty)
+      assert(classDef("c", "C", "public class C {}").childrenOfSealedClass.isEmpty)
+    }
+  }
+
+  // Step 2d: differential check vs the reflection path (ClassToAPI) on declared member names.
+  it should "agree with ClassToAPI on declared member names" in {
+    IO.withTemporaryDirectory { temp =>
+      val src = new File(temp, "Simple.java")
+      IO.write(
+        src,
+        "public class Simple { public int x; public String greet(int n) { return null; } }"
+      )
+      JavaCompilerForUnitTesting.compileJava(Seq(src), temp, Seq.empty)
+      val loader = new java.net.URLClassLoader(Array(temp.toURI.toURL), null)
+      val reflectApi = ClassToAPI
+        .process(Seq(loader.loadClass("Simple")))
+        ._1
+        .find(_.definitionType == DefinitionType.ClassDef)
+        .get
+      val cf = Parser(new File(temp, "Simple.class").toPath, Logger.Null)
+      val classfileApi = ClassfileToAPI
+        .process(Seq("Simple" -> cf))
+        ._1
+        .find(_.definitionType == DefinitionType.ClassDef)
+        .get
+      def names(c: ClassLike): Set[String] = c.structure.declared.map(_.name).toSet
+      assert(
+        names(classfileApi) == names(reflectApi),
+        s"classfile=${names(classfileApi)} vs reflect=${names(reflectApi)}"
+      )
+    }
+  }
+
+  // P2: varargs (`T...`) and array (`T[]`) parameters share a descriptor but differ via ACC_VARARGS.
+  it should "distinguish varargs from array parameters" in {
+    IO.withTemporaryDirectory { temp =>
+      val a = sampleApis(temp, "a", "public class Sample { public void m(String[] xs) {} }")
+      val b = sampleApis(temp, "b", "public class Sample { public void m(String... xs) {} }")
+      assert(hashAll(a) != hashAll(b))
+    }
+  }
+
+  // P2: constructors get an Empty return type (as ClassToAPI does), not void/Unit.
+  it should "give constructors an Empty return type" in {
+    IO.withTemporaryDirectory { temp =>
+      val src = new File(temp, "Sample.java")
+      IO.write(src, "public class Sample { public Sample(int x) {} }")
+      JavaCompilerForUnitTesting.compileJava(Seq(src), temp, Seq.empty)
+      val cf = Parser(new File(temp, "Sample.class").toPath, Logger.Null)
+      val cls = ClassfileToAPI
+        .process(Seq("Sample" -> cf))
+        ._1
+        .find(_.definitionType == DefinitionType.ClassDef)
+        .get
+      val ctor = cls.structure.declared.collectFirst {
+        case d: xsbti.api.Def if d.name.endsWith(";init;") => d
+      }.get
+      assert(ctor.returnType.isInstanceOf[xsbti.api.EmptyType])
+    }
+  }
+
   private def sampleApis(temp: File, dirName: String, source: String): Seq[ClassLike] = {
     val dir = new File(temp, dirName)
     dir.mkdir()

--- a/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/ClassfileToAPISpecification.scala
+++ b/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/ClassfileToAPISpecification.scala
@@ -84,8 +84,8 @@ class ClassfileToAPISpecification extends UnitSpec {
       val callback = JavaCompilerForUnitTesting.analyze(
         classesDir,
         Seq(outerFile),
-        (cb, src, named) => {
-          val (apis, _) = ClassfileToAPI.process(named)
+        (cb, src, named, resolve) => {
+          val (apis, _) = ClassfileToAPI.process(named, resolve)
           apis.foreach(cb.api(src, _))
         }
       )
@@ -99,6 +99,55 @@ class ClassfileToAPISpecification extends UnitSpec {
       val memberDefs =
         innerClass.structure.declared.collect { case d: xsbti.api.Def => d.name }.toSet
       assert(memberDefs.contains("answer"))
+    }
+  }
+
+  // Step D (de-reflection): with classfileApiOnly set, JavaAnalyze must route *loadable* classes
+  // through ClassfileToAPI instead of Class.forName, recovering declared members from the class's
+  // own bytes and inherited members from its parents' bytes — never loading anything.
+  it should "route loadable classes through the classfile path when classfileApiOnly is set" in {
+    IO.withTemporaryDirectory { temp =>
+      val classesDir = new File(temp, "classes")
+      classesDir.mkdir()
+      val baseFile = new File(temp, "Base.java")
+      IO.write(baseFile, "public class Base { public int baseM() { return 0; } }")
+      val greeterFile = new File(temp, "Greeter.java")
+      IO.write(
+        greeterFile,
+        "public class Greeter extends Base { public String hello(int n) { return null; } }"
+      )
+      JavaCompilerForUnitTesting.compileJava(Seq(baseFile, greeterFile), classesDir, Seq.empty)
+
+      // The classfile extractor is the only thing that records API here, so what it captures is
+      // exactly what JavaAnalyze routed to the classfile path.
+      def recordedApis(classfileApiOnly: Boolean): Set[ClassLike] =
+        JavaCompilerForUnitTesting
+          .analyze(
+            classesDir,
+            Seq(baseFile, greeterFile),
+            (cb, src, named, resolve) => {
+              val (apis, _) = ClassfileToAPI.process(named, resolve)
+              apis.foreach(cb.api(src, _))
+            },
+            classfileApiOnly = classfileApiOnly
+          )
+          .apis
+          .values
+          .flatten
+          .toSet
+
+      // Off: both classes load fine, so they take the reflection path and never reach ClassfileToAPI.
+      assert(recordedApis(classfileApiOnly = false).isEmpty)
+
+      // On: every class is extracted from its classfile instead of being loaded.
+      val recorded = recordedApis(classfileApiOnly = true)
+      val greeter = recorded
+        .find(c => c.name == "Greeter" && c.definitionType == DefinitionType.ClassDef)
+        .get
+      val declared = greeter.structure.declared.collect { case d: xsbti.api.Def => d.name }.toSet
+      val inherited = greeter.structure.inherited.collect { case d: xsbti.api.Def => d.name }.toSet
+      assert(declared.contains("hello")) // its own method, from Greeter.class
+      assert(inherited.contains("baseM")) // from Base.class, via the byte-reading resolver
     }
   }
 
@@ -159,6 +208,44 @@ class ClassfileToAPISpecification extends UnitSpec {
         temp,
         "b",
         "import java.util.List;\npublic class Sample { public List<Integer> answer() { return null; } }"
+      )
+      assert(hashAll(a) != hashAll(b))
+    }
+  }
+
+  // P1 (variance): the mapped api.Type drops wildcard variance, so `List<? extends Number>` and
+  // `List<? super Number>` collapse to the same type. The always-folded raw Signature must still
+  // distinguish them — otherwise a variance change would not invalidate dependents (under-compilation).
+  it should "detect wildcard variance changes that the mapped type collapses" in {
+    IO.withTemporaryDirectory { temp =>
+      val a = sampleApis(
+        temp,
+        "a",
+        "import java.util.List;\npublic class Sample { public List<? extends Number> f; }"
+      )
+      val b = sampleApis(
+        temp,
+        "b",
+        "import java.util.List;\npublic class Sample { public List<? super Number> f; }"
+      )
+      assert(hashAll(a) != hashAll(b))
+    }
+  }
+
+  // P1 (generic throws): only the erased `Exceptions` attribute is modelled, so two methods that
+  // throw different type variables sharing the same erased bound are distinguished only by the
+  // folded raw Signature.
+  it should "detect a generic throws change that shares an erased exception bound" in {
+    IO.withTemporaryDirectory { temp =>
+      val a = sampleApis(
+        temp,
+        "a",
+        "public class Sample { public <E extends Exception, F extends Exception> void run() throws E {} }"
+      )
+      val b = sampleApis(
+        temp,
+        "b",
+        "public class Sample { public <E extends Exception, F extends Exception> void run() throws F {} }"
       )
       assert(hashAll(a) != hashAll(b))
     }

--- a/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/DifferentialApiSpecification.scala
+++ b/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/DifferentialApiSpecification.scala
@@ -1,0 +1,243 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package sbt
+package internal
+package inc
+
+import java.io.File
+import java.net.URLClassLoader
+import sbt.internal.inc.classfile.{ ClassFile, JavaCompilerForUnitTesting, Parser }
+import sbt.io.IO
+import sbt.util.Logger
+import xsbt.api.HashAPI
+import xsbti.api.ClassLike
+
+/**
+ * Phase 3 differential audit: for a corpus of loadable Java classes, compare the reflection-derived
+ * API ([[ClassToAPI]], the current production path) with the classfile-derived API
+ * ([[ClassfileToAPI]]). Catalogs the differences so we can decide, before de-reflecting loadable
+ * classes, whether the classfile path is close enough — in particular how much the inherited-members
+ * gap matters. Prints a report and asserts the core invariant that *declared* members agree.
+ */
+class DifferentialApiSpecification extends UnitSpec {
+
+  // A corpus exercising the public-API surface ClassToAPI models (see ClassToAPI.scala): generics,
+  // bounds, wildcards (extends/super/unbounded), nested generics, enums, interfaces (default/static
+  // methods), annotations, varargs, throws, arrays, visibility levels, static vs instance, constants,
+  // abstract methods, multiple interfaces, and inheritance from both JDK and user supertypes. Each
+  // entry is a single .java file whose public type is `name` (helper types are package-private).
+  private val corpus: Seq[(String, String)] = Seq(
+    "Simple" -> "public class Simple { public int x; public String greet(int n) { return null; } }",
+    "Box" -> "public class Box<T> { public T get() { return null; } public void set(T t) {} }",
+    "Num" -> "public class Num<T extends Number> { public T value; }",
+    "Wild" -> "import java.util.List; public class Wild { public List<? extends Number> f; public List<?> g; }",
+    "Sup" -> "import java.util.List; public class Sup { public List<? super Integer> g; }",
+    "Deep" -> "import java.util.List; import java.util.Map; public class Deep { public Map<String, List<Integer>> m; }",
+    "Color" -> "public enum Color { RED, GREEN, BLUE }",
+    "Iface" -> "public interface Iface { int compute(int x); default int twice(int x) { return x * 2; } }",
+    "IfaceStatic" -> "public interface IfaceStatic { int inst(); static int helper() { return 0; } default int def() { return 1; } }",
+    "Anno" -> "public class Anno { @Deprecated public void old() {} }",
+    "Vararg" -> "public class Vararg { public void m(String... xs) {} }",
+    "ArraysC" -> "public class ArraysC { public int[] a; public String[][] b; public int[] m(long[] xs) { return null; } }",
+    "Thrower" -> "import java.io.IOException; public class Thrower { public void run() throws IOException {} }",
+    "Visibility" -> "public class Visibility { public int pub; protected int prot; private int priv; public void pubM() {} protected void protM() {} private void privM() {} }",
+    "Statics" -> "public class Statics { public static int s; public int i; public static void sm() {} public void im() {} }",
+    "Constants" -> "public class Constants { public static final int I = 1; public static final String S = \"x\"; public static final long L = 2L; }",
+    "GenericMethod" -> "import java.util.Map; public class GenericMethod { public <T, U> Map<T, U> pair(T t, U u) { return null; } }",
+    "Abstr" -> "public abstract class Abstr { public abstract int compute(int x); public int done() { return 0; } }",
+    "Child" -> "public class Child extends java.util.ArrayList<String> {}",
+    "Derived" -> """|class Base<T> { public T value; public T get() { return null; } }
+                    |public class Derived extends Base<String> { public int extra() { return 0; } }
+                    |""".stripMargin,
+    "MultiIface" -> """|interface I1 { void a(); }
+                       |interface I2 { void b(); }
+                       |public class MultiIface implements I1, I2 { public void a() {} public void b() {} }
+                       |""".stripMargin,
+    // A class implementing an interface that has a static method: the static method must NOT be
+    // inherited by either path (Java does not inherit static interface methods).
+    "ImplStatic" -> """|interface WithStatic { static int helper() { return 0; } int inst(); }
+                       |public class ImplStatic implements WithStatic { public int inst() { return 0; } }
+                       |""".stripMargin,
+    // Member classes (static nested, instance inner, nested interface) must appear among the outer's
+    // declared members, like ClassToAPI: static ones on the module, instance ones on the class.
+    "Nesting" -> ("public class Nesting { public static class StaticInner { public int s() { return 0; } } " +
+      "public class InstanceInner { public int i() { return 0; } } public interface NestedIface { void f(); } }"),
+    // A public nested class of a supertype is inherited by subclasses — both paths must list it.
+    "InheritNested" -> ("class HasNested { public static class Shared { public int v() { return 0; } } } " +
+      "public class InheritNested extends HasNested {}"),
+    // ...but a *parameterized* inner supertype (Outer<String>.Inner) is a ParameterizedType that
+    // reflection's inner-class walk filters out, so Inner.Member must NOT be inherited by either path
+    // — even though the erased superclass name (Outer$Inner) looks non-generic.
+    "GenericInnerSuper" -> ("class Outer<T> { public class Inner { public class Member {} } } " +
+      "public class GenericInnerSuper extends Outer<String>.Inner { " +
+      "GenericInnerSuper(Outer<String> o) { o.super(); } }")
+  )
+
+  private def declared(apis: Seq[ClassLike]): Set[String] =
+    apis.flatMap(_.structure.declared.map(_.name)).toSet
+  private def inherited(apis: Seq[ClassLike]): Set[String] =
+    apis.flatMap(_.structure.inherited.map(_.name)).toSet
+  private def kind(d: xsbti.api.ClassDefinition): String = d match {
+    case _: xsbti.api.Def       => "method"
+    case _: xsbti.api.FieldLike => "field"
+    case other                  => other.getClass.getSimpleName
+  }
+  // (member name, method-vs-field) — catches a member being modelled as the wrong kind.
+  private def declaredKinds(apis: Seq[ClassLike]): Set[(String, String)] =
+    apis.flatMap(_.structure.declared.map(d => d.name -> kind(d))).toSet
+
+  private def accessStr(a: xsbti.api.Access): String = a match {
+    case _: xsbti.api.Public    => "public"
+    case p: xsbti.api.Protected => "protected:" + qualifierStr(p.qualifier)
+    case p: xsbti.api.Private   => "private:" + qualifierStr(p.qualifier)
+  }
+  private def qualifierStr(q: xsbti.api.Qualifier): String = q match {
+    case i: xsbti.api.IdQualifier   => i.value
+    case _: xsbti.api.ThisQualifier => "this"
+    case _                          => "unqualified"
+  }
+  // Per-declared-method facts that MUST match exactly: name, access, parameter count, varargs
+  // (a parameter modifier), and type-parameter count. Type *strings* are intentionally excluded —
+  // they differ by design (unqualified vs qualified type-variable names, wildcard-bound collapse).
+  private def methodFacts(apis: Seq[ClassLike]): Set[(String, String, Int, Boolean, Int)] =
+    apis.flatMap(_.structure.declared.collect {
+      case d: xsbti.api.Def =>
+        val params = d.valueParameters.flatMap(_.parameters.toSeq)
+        val varargs = params.lastOption.exists(_.modifier == xsbti.api.ParameterModifier.Repeated)
+        (d.name, accessStr(d.access), params.length, varargs, d.typeParameters.length)
+    }).toSet
+  // Per-declared-field facts that must match: name + access.
+  private def fieldFacts(apis: Seq[ClassLike]): Set[(String, String)] =
+    apis.flatMap(_.structure.declared.collect {
+      case f: xsbti.api.FieldLike => (f.name, accessStr(f.access))
+    }).toSet
+
+  // Builds both the reflection-derived (ClassToAPI) and classfile-derived (ClassfileToAPI) APIs for
+  // the public type `name`, after compiling `source` into a fresh dir. The classfile path resolves
+  // parents by reading bytes (never loading), exactly as production does under classfileApiOnly.
+  private def buildApis(temp: File, idx: Int, name: String, source: String) = {
+    val dir = new File(temp, s"d$idx")
+    dir.mkdir()
+    val src = new File(dir, s"$name.java")
+    IO.write(src, source)
+    JavaCompilerForUnitTesting.compileJava(Seq(src), dir, Seq.empty)
+
+    val loader = new URLClassLoader(Array(dir.toURI.toURL), null)
+    val resolve: String => Option[ClassFile] = bn => {
+      val res = bn.replace('.', '/') + ".class"
+      Option(loader.getResource(res))
+        .orElse(Option(ClassLoader.getSystemResource(res)))
+        .flatMap(u =>
+          try Some(Parser(u, Logger.Null))
+          catch { case _: Throwable => None }
+        )
+    }
+    val reflect = ClassToAPI.process(Seq(loader.loadClass(name)))._1.filter(_.name == name)
+    val cf = Parser(new File(dir, s"$name.class").toPath, Logger.Null)
+    val classfile = ClassfileToAPI.process(Seq(name -> cf), resolve)._1.filter(_.name == name)
+    (reflect.toSeq, classfile.toSeq)
+  }
+
+  "ClassfileToAPI vs ClassToAPI" should "agree on declared and inherited members across the corpus" in {
+    IO.withTemporaryDirectory { temp =>
+      println("\n=== Phase 3 differential audit: ClassfileToAPI vs ClassToAPI (reflection) ===")
+      val failures = scala.collection.mutable.ListBuffer.empty[String]
+      corpus.zipWithIndex.foreach {
+        case ((name, source), idx) =>
+          val (reflect, classfile) = buildApis(temp, idx, name, source)
+          val (dR, dC) = (declared(reflect), declared(classfile))
+          val (iR, iC) = (inherited(reflect), inherited(classfile))
+          val (kR, kC) = (declaredKinds(reflect), declaredKinds(classfile))
+          val (mR, mC) = (methodFacts(reflect), methodFacts(classfile))
+          val (fR, fC) = (fieldFacts(reflect), fieldFacts(classfile))
+          val hashEq = reflect.map(HashAPI(_)).sum == classfile.map(HashAPI(_)).sum
+          println(
+            f"$name%-13s declared==:${dR == dC}%-6s inherited==:${iR == iC}%-6s " +
+              f"kinds==:${kR == kC}%-6s methods==:${mR == mC}%-6s fields==:${fR == fC}%-6s hashEq:$hashEq"
+          )
+          if (dR != dC)
+            failures += s"$name declared: onlyReflect=${dR -- dC} onlyClassfile=${dC -- dR}"
+          if (iR != iC)
+            failures += s"$name inherited: onlyReflect=${iR -- iC} onlyClassfile=${iC -- iR}"
+          if (kR != kC)
+            failures += s"$name kinds: onlyReflect=${kR -- kC} onlyClassfile=${kC -- kR}"
+          if (mR != mC)
+            failures += s"$name methods: onlyReflect=${mR -- mC} onlyClassfile=${mC -- mR}"
+          if (fR != fC)
+            failures += s"$name fields: onlyReflect=${fR -- fC} onlyClassfile=${fC -- fR}"
+      }
+      println("=== end audit ===\n")
+      assert(failures.isEmpty, "structural divergences:\n" + failures.mkString("\n"))
+    }
+  }
+
+  // Previously a known divergence, now closed: ClassToAPI lists a public nested class among the
+  // outer class's declared members (ClassToAPI.scala:256); ClassfileToAPI now mirrors this from the
+  // InnerClasses attribute, so the outer's declared set matches.
+  it should "list a nested class in the outer's declared members, matching reflection" in {
+    IO.withTemporaryDirectory { temp =>
+      val src =
+        "public class Outer { public class Inner { public int v() { return 0; } } public int x; }"
+      val (reflect, classfile) = buildApis(temp, 0, "Outer", src)
+      assert(
+        declared(classfile).contains("Outer.Inner"),
+        s"classfile path should list the nested class: ${declared(classfile)}"
+      )
+      assert(
+        declared(reflect) == declared(classfile),
+        s"declared differ — reflect=${declared(reflect)} classfile=${declared(classfile)}"
+      )
+    }
+  }
+
+  // Adversarial-hunt candidate: a non-static inner class's constructor carries a synthetic
+  // enclosing-instance parameter (this$0) in its descriptor. Verify the two paths agree on the
+  // constructor's parameter count — if they don't, ClassfileToAPI must drop the synthetic leading
+  // parameter to match ClassToAPI.
+  it should "agree on a non-static inner class constructor's parameter count" in {
+    IO.withTemporaryDirectory { temp =>
+      val dir = new File(temp, "d")
+      dir.mkdir()
+      val src = new File(dir, "Outer.java")
+      IO.write(src, "public class Outer { public class Inner { public Inner() {} } }")
+      JavaCompilerForUnitTesting.compileJava(Seq(src), dir, Seq.empty)
+
+      val loader = new URLClassLoader(Array(dir.toURI.toURL), null)
+      val resolve: String => Option[ClassFile] = bn => {
+        val res = bn.replace('.', '/') + ".class"
+        Option(loader.getResource(res))
+          .orElse(Option(ClassLoader.getSystemResource(res)))
+          .flatMap(u =>
+            try Some(Parser(u, Logger.Null))
+            catch { case _: Throwable => None }
+          )
+      }
+      val innerName = "Outer.Inner"
+      val reflect =
+        ClassToAPI.process(Seq(loader.loadClass("Outer$Inner")))._1.filter(_.name == innerName).toSeq
+      val innerCf = Parser(new File(dir, "Outer$Inner.class").toPath, Logger.Null)
+      val classfile =
+        ClassfileToAPI.process(Seq(innerName -> innerCf), resolve)._1.filter(_.name == innerName).toSeq
+
+      def ctorParamCounts(apis: Seq[ClassLike]): Seq[Int] =
+        apis.flatMap(_.structure.declared.collect {
+          case d: xsbti.api.Def if d.name.contains("init") =>
+            d.valueParameters.flatMap(_.parameters.toSeq).length
+        })
+
+      val r = ctorParamCounts(reflect)
+      val c = ctorParamCounts(classfile)
+      println(s"[inner-ctor] reflect ctor params=$r  classfile ctor params=$c")
+      assert(r == c, s"inner-class ctor param count differs — reflect=$r classfile=$c")
+    }
+  }
+}

--- a/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/DifferentialApiSpecification.scala
+++ b/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/DifferentialApiSpecification.scala
@@ -240,4 +240,53 @@ class DifferentialApiSpecification extends UnitSpec {
       assert(r == c, s"inner-class ctor param count differs — reflect=$r classfile=$c")
     }
   }
+
+  // The simple (Projection) name of a parent type reference, e.g. "Marker"/"Object". ClassToAPI and
+  // ClassfileToAPI both build parent references via ClassToAPI.reference, which yields a Projection.
+  private def parentSimpleName(t: xsbti.api.Type): Option[String] = t match {
+    case p: xsbti.api.Projection    => Some(p.id)
+    case p: xsbti.api.Parameterized => parentSimpleName(p.baseType)
+    case _                          => None
+  }
+  private def parentNames(apis: Seq[ClassLike]): Set[String] =
+    apis.flatMap(_.structure.parents.toSeq.flatMap(parentSimpleName)).toSet
+
+  // KNOWN-BUG WITNESS (deviation #1): ClassToAPI lists the *transitive* supertype closure in a
+  // class's `parents` (ClassToAPI.allSuperTypes), whereas ClassfileToAPI lists only the *direct*
+  // supertypes (ClassfileToAPI.classLikes: superclass +: interfaces). So a subtyping relationship
+  // that `C` holds only through an intermediate `B` is invisible to the classfile path. With a
+  // member-less marker interface there is nothing for collectInherited to surface either, so C's
+  // classfile API — and thus its hash — does not change when B stops implementing the marker, even
+  // though C is no longer a Marker. Reflection's hash does change. This pins that gap empirically;
+  // once #1 is fixed (walk the transitive closure in classLikes), the two classfile hashes below
+  // will differ and this test should be updated to assert agreement with reflection.
+  it should "(known bug #1) miss a transitive-supertype change that reflection catches" in {
+    IO.withTemporaryDirectory { temp =>
+      // v1: C -> B -> Marker (C is transitively a Marker).  v2: B no longer implements Marker.
+      val v1 = "interface Marker {} class B implements Marker {} public class C extends B {}"
+      val v2 = "interface Marker {} class B {} public class C extends B {}"
+      val (reflect1, classfile1) = buildApis(temp, 100, "C", v1)
+      val (reflect2, classfile2) = buildApis(temp, 101, "C", v2)
+
+      // Structural witness: reflection's parents for C include the transitive Marker; classfile's
+      // direct-only parents do not.
+      val (pR, pC) = (parentNames(reflect1), parentNames(classfile1))
+      println(s"[parents] reflect C parents=$pR  classfile C parents=$pC")
+      assert(pR.contains("Marker"), s"reflection should list transitive Marker: $pR")
+      assert(!pC.contains("Marker"), s"classfile (direct-only) should NOT list Marker yet: $pC")
+
+      // Consequence witness: reflection invalidates (hash changes when B drops Marker); the
+      // classfile path does not (C's bytes and member-less inherited set are identical across v1/v2).
+      val (hR1, hR2) = (reflect1.map(HashAPI(_)).sum, reflect2.map(HashAPI(_)).sum)
+      val (hC1, hC2) = (classfile1.map(HashAPI(_)).sum, classfile2.map(HashAPI(_)).sum)
+      println(s"[hash] reflect $hR1 -> $hR2 (changed=${hR1 != hR2}); " +
+        s"classfile $hC1 -> $hC2 (changed=${hC1 != hC2})")
+      assert(hR1 != hR2, "reflection hash must change when B drops `implements Marker`")
+      assert(
+        hC1 == hC2,
+        "BUG #1 witness: classfile hash does NOT change on the transitive-supertype change " +
+          s"(under-invalidation) — got $hC1 vs $hC2"
+      )
+    }
+  }
 }

--- a/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/DifferentialApiSpecification.scala
+++ b/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/DifferentialApiSpecification.scala
@@ -283,4 +283,80 @@ class DifferentialApiSpecification extends UnitSpec {
       )
     }
   }
+
+  // Deviation #2 (fixed): ClassfileToAPI now reads RuntimeVisible/InvisibleParameterAnnotations and
+  // folds them into the method's synthetic annotation, so a parameter-annotation-only change changes
+  // its hash — matching reflection (which carries them on the parameter type via api.Annotated). Was
+  // a green known-bug witness before the fix; now asserts both paths invalidate.
+  it should "detect a parameter-annotation change, matching reflection" in {
+    IO.withTemporaryDirectory { temp =>
+      val pa =
+        "import java.lang.annotation.*;\n" +
+          "@Retention(RetentionPolicy.RUNTIME) @Target(ElementType.PARAMETER) @interface PA {}\n"
+      val v1 = pa + "public class C { public void m(@PA String x) {} }"
+      val v2 = pa + "public class C { public void m(String x) {} }"
+      val (reflect1, classfile1) = buildApis(temp, 110, "C", v1)
+      val (reflect2, classfile2) = buildApis(temp, 111, "C", v2)
+      val (hR1, hR2) = (reflect1.map(HashAPI(_)).sum, reflect2.map(HashAPI(_)).sum)
+      val (hC1, hC2) = (classfile1.map(HashAPI(_)).sum, classfile2.map(HashAPI(_)).sum)
+      println(s"[param-anno hash] reflect changed=${hR1 != hR2}; classfile changed=${hC1 != hC2}")
+      assert(hR1 != hR2, "reflection hash must change when the parameter annotation is removed")
+      assert(
+        hC1 != hC2,
+        s"classfile hash must now change on a param-annotation change — $hC1 vs $hC2"
+      )
+    }
+  }
+
+  // The names of classes `process` reports as having a `main`, from each path.
+  private def mainClasses(temp: File, idx: Int, names: Seq[(String, String)], query: String) = {
+    val dir = new File(temp, s"m$idx")
+    dir.mkdir()
+    val srcs = names.map {
+      case (n, src) =>
+        val f = new File(dir, s"$n.java"); IO.write(f, src); f
+    }
+    JavaCompilerForUnitTesting.compileJava(srcs, dir, Seq.empty)
+    val loader = new URLClassLoader(Array(dir.toURI.toURL), null)
+    val resolve: String => Option[ClassFile] = bn => {
+      val res = bn.replace('.', '/') + ".class"
+      Option(loader.getResource(res))
+        .orElse(Option(ClassLoader.getSystemResource(res)))
+        .flatMap(u =>
+          try Some(Parser(u, Logger.Null))
+          catch { case _: Throwable => None }
+        )
+    }
+    val reflectMains = ClassToAPI.process(Seq(loader.loadClass(query)))._2
+    val cf = Parser(new File(dir, s"$query.class").toPath, Logger.Null)
+    val classfileMains = ClassfileToAPI.process(Seq(query -> cf), resolve)._2
+    (reflectMains, classfileMains)
+  }
+
+  // Deviation #3 (fixed): ClassfileToAPI.hasMain now also checks the inherited (superclass-chain)
+  // public static main, mirroring ClassToAPI's use of c.getMethods, so a subclass that inherits
+  // `main` is reported as a main class. Was a green known-bug witness before the fix; now asserts
+  // agreement with reflection.
+  it should "report an inherited main, matching reflection" in {
+    IO.withTemporaryDirectory { temp =>
+      val (reflectMains, classfileMains) = mainClasses(
+        temp,
+        0,
+        Seq(
+          "A" -> "public class A { public static void main(String[] a) {} }",
+          "B" -> "public class B extends A {}"
+        ),
+        query = "B"
+      )
+      println(s"[main] reflect=$reflectMains classfile=$classfileMains")
+      assert(
+        reflectMains.contains("B"),
+        s"reflection should report inherited main on B: $reflectMains"
+      )
+      assert(
+        classfileMains.contains("B"),
+        s"classfile should now report inherited main on B: $classfileMains"
+      )
+    }
+  }
 }

--- a/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/DifferentialApiSpecification.scala
+++ b/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/DifferentialApiSpecification.scala
@@ -359,4 +359,40 @@ class DifferentialApiSpecification extends UnitSpec {
       )
     }
   }
+
+  // Deviation #4 (fixed): reflection's topLevel is `getEnclosingClass == null`, false for member,
+  // local, AND anonymous classes. ClassfileToAPI now marks a class non-top-level on the mere presence
+  // of an InnerClasses self entry (no longer requiring a non-empty outer), so anonymous/local classes
+  // — whose self entry has outer index 0 — agree with reflection. Was a green known-bug witness
+  // before the fix.
+  it should "mark an anonymous class as non-top-level, matching reflection" in {
+    IO.withTemporaryDirectory { temp =>
+      val dir = new File(temp, "d4")
+      dir.mkdir()
+      val src = new File(dir, "Outer.java")
+      IO.write(src, "public class Outer { Runnable r = new Runnable() { public void run() {} }; }")
+      JavaCompilerForUnitTesting.compileJava(Seq(src), dir, Seq.empty)
+      val loader = new URLClassLoader(Array(dir.toURI.toURL), null)
+      val resolve: String => Option[ClassFile] = bn => {
+        val res = bn.replace('.', '/') + ".class"
+        Option(loader.getResource(res))
+          .orElse(Option(ClassLoader.getSystemResource(res)))
+          .flatMap(u =>
+            try Some(Parser(u, Logger.Null))
+            catch { case _: Throwable => None }
+          )
+      }
+      val binary = "Outer$1" // the anonymous Runnable
+      val reflect = ClassToAPI.process(Seq(loader.loadClass(binary)))._1.filter(_.name == binary)
+      val cf = Parser(new File(dir, binary + ".class").toPath, Logger.Null)
+      val classfile = ClassfileToAPI.process(Seq(binary -> cf), resolve)._1.filter(_.name == binary)
+      val (rTop, cTop) = (reflect.map(_.topLevel).toSet, classfile.map(_.topLevel).toSet)
+      println(s"[topLevel] reflect=$rTop classfile=$cTop")
+      assert(rTop == Set(false), s"reflection: anon class is not top-level: $rTop")
+      assert(
+        cTop == rTop,
+        s"classfile topLevel must now match reflection — reflect=$rTop classfile=$cTop"
+      )
+    }
+  }
 }

--- a/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/DifferentialApiSpecification.scala
+++ b/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/DifferentialApiSpecification.scala
@@ -251,16 +251,13 @@ class DifferentialApiSpecification extends UnitSpec {
   private def parentNames(apis: Seq[ClassLike]): Set[String] =
     apis.flatMap(_.structure.parents.toSeq.flatMap(parentSimpleName)).toSet
 
-  // KNOWN-BUG WITNESS (deviation #1): ClassToAPI lists the *transitive* supertype closure in a
-  // class's `parents` (ClassToAPI.allSuperTypes), whereas ClassfileToAPI lists only the *direct*
-  // supertypes (ClassfileToAPI.classLikes: superclass +: interfaces). So a subtyping relationship
-  // that `C` holds only through an intermediate `B` is invisible to the classfile path. With a
-  // member-less marker interface there is nothing for collectInherited to surface either, so C's
-  // classfile API — and thus its hash — does not change when B stops implementing the marker, even
-  // though C is no longer a Marker. Reflection's hash does change. This pins that gap empirically;
-  // once #1 is fixed (walk the transitive closure in classLikes), the two classfile hashes below
-  // will differ and this test should be updated to assert agreement with reflection.
-  it should "(known bug #1) miss a transitive-supertype change that reflection catches" in {
+  // Deviation #1 (fixed): ClassfileToAPI now lists the *transitive* supertype closure in `parents`
+  // (ClassfileToAPI.collectParents), matching ClassToAPI.allSuperTypes — not just the direct
+  // supertypes. So a subtyping relationship `C` holds only through an intermediate `B` (here a
+  // member-less marker interface that `B` stops implementing) changes C's API on both paths, and the
+  // classfile path no longer under-invalidates C's dependents. This was a green known-bug witness
+  // before the fix; it now asserts agreement with reflection.
+  it should "model the transitive supertype closure in parents, matching reflection" in {
     IO.withTemporaryDirectory { temp =>
       // v1: C -> B -> Marker (C is transitively a Marker).  v2: B no longer implements Marker.
       val v1 = "interface Marker {} class B implements Marker {} public class C extends B {}"
@@ -268,24 +265,21 @@ class DifferentialApiSpecification extends UnitSpec {
       val (reflect1, classfile1) = buildApis(temp, 100, "C", v1)
       val (reflect2, classfile2) = buildApis(temp, 101, "C", v2)
 
-      // Structural witness: reflection's parents for C include the transitive Marker; classfile's
-      // direct-only parents do not.
+      // Structural: both paths list the transitive Marker among C's parents, and agree.
       val (pR, pC) = (parentNames(reflect1), parentNames(classfile1))
       println(s"[parents] reflect C parents=$pR  classfile C parents=$pC")
-      assert(pR.contains("Marker"), s"reflection should list transitive Marker: $pR")
-      assert(!pC.contains("Marker"), s"classfile (direct-only) should NOT list Marker yet: $pC")
+      assert(pC.contains("Marker"), s"classfile should now list transitive Marker: $pC")
+      assert(pR == pC, s"parents should match reflection — reflect=$pR classfile=$pC")
 
-      // Consequence witness: reflection invalidates (hash changes when B drops Marker); the
-      // classfile path does not (C's bytes and member-less inherited set are identical across v1/v2).
+      // Consequence: both paths invalidate (hash changes when B drops `implements Marker`).
       val (hR1, hR2) = (reflect1.map(HashAPI(_)).sum, reflect2.map(HashAPI(_)).sum)
       val (hC1, hC2) = (classfile1.map(HashAPI(_)).sum, classfile2.map(HashAPI(_)).sum)
       println(s"[hash] reflect $hR1 -> $hR2 (changed=${hR1 != hR2}); " +
         s"classfile $hC1 -> $hC2 (changed=${hC1 != hC2})")
       assert(hR1 != hR2, "reflection hash must change when B drops `implements Marker`")
       assert(
-        hC1 == hC2,
-        "BUG #1 witness: classfile hash does NOT change on the transitive-supertype change " +
-          s"(under-invalidation) — got $hC1 vs $hC2"
+        hC1 != hC2,
+        s"classfile hash must now change on the transitive-supertype change — got $hC1 vs $hC2"
       )
     }
   }

--- a/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/DifferentialApiSpecification.scala
+++ b/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/DifferentialApiSpecification.scala
@@ -79,7 +79,11 @@ class DifferentialApiSpecification extends UnitSpec {
     // — even though the erased superclass name (Outer$Inner) looks non-generic.
     "GenericInnerSuper" -> ("class Outer<T> { public class Inner { public class Member {} } } " +
       "public class GenericInnerSuper extends Outer<String>.Inner { " +
-      "GenericInnerSuper(Outer<String> o) { o.super(); } }")
+      "GenericInnerSuper(Outer<String> o) { o.super(); } }"),
+    // Field HIDING (not overriding): getFields keeps the hidden Base.x as inherited even though
+    // HiddenField declares its own x, so the classfile path must not dedup inherited fields by name.
+    "HiddenField" -> ("class HiddenBase { public int x; } " +
+      "public class HiddenField extends HiddenBase { public int x; }")
   )
 
   private def declared(apis: Seq[ClassLike]): Set[String] =
@@ -392,6 +396,52 @@ class DifferentialApiSpecification extends UnitSpec {
       assert(
         cTop == rTop,
         s"classfile topLevel must now match reflection — reflect=$rTop classfile=$cTop"
+      )
+    }
+  }
+
+  // Deviation #5 (fixed): field HIDING across two ancestor levels. Java fields hide rather than
+  // override, and getFields keeps every ancestor's public field — so with GrandBase.x and Base.x
+  // both hidden along the chain, reflection lists BOTH as inherited. The classfile path used to
+  // dedup inherited fields by bare name and kept only one; the name-SET corpus assertion cannot see
+  // that (both sides collapse to {x}), so this test compares inherited-field COUNTS.
+  it should "keep every hidden ancestor field as inherited, matching reflection" in {
+    IO.withTemporaryDirectory { temp =>
+      val dir = new File(temp, "d5")
+      dir.mkdir()
+      val src = new File(dir, "DeepHidden.java")
+      IO.write(
+        src,
+        "class GrandBase { public int x; } class MidBase extends GrandBase { public int x; } " +
+          "public class DeepHidden extends MidBase {}"
+      )
+      JavaCompilerForUnitTesting.compileJava(Seq(src), dir, Seq.empty)
+      val loader = new URLClassLoader(Array(dir.toURI.toURL), null)
+      val resolve: String => Option[ClassFile] = bn => {
+        val res = bn.replace('.', '/') + ".class"
+        Option(loader.getResource(res))
+          .orElse(Option(ClassLoader.getSystemResource(res)))
+          .flatMap(u =>
+            try Some(Parser(u, Logger.Null))
+            catch { case _: Throwable => None }
+          )
+      }
+      val name = "DeepHidden"
+      val reflect = ClassToAPI.process(Seq(loader.loadClass(name)))._1.filter(_.name == name)
+      val cf = Parser(new File(dir, name + ".class").toPath, Logger.Null)
+      val classfile = ClassfileToAPI.process(Seq(name -> cf), resolve)._1.filter(_.name == name)
+      def inheritedFieldCount(apis: Seq[ClassLike]): Int =
+        apis.map(_.structure.inherited.count {
+          case f: xsbti.api.FieldLike => f.name == "x"
+          case _                      => false
+        }).sum
+      val (rCount, cCount) =
+        (inheritedFieldCount(reflect.toSeq), inheritedFieldCount(classfile.toSeq))
+      println(s"[hidden-fields] reflect inherited x count=$rCount classfile=$cCount")
+      assert(rCount == 2, s"reflection keeps both hidden ancestor fields: $rCount")
+      assert(
+        cCount == rCount,
+        s"inherited hidden-field count differs — reflect=$rCount classfile=$cCount"
       )
     }
   }

--- a/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/FBoundStressSpecification.scala
+++ b/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/FBoundStressSpecification.scala
@@ -1,0 +1,128 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package sbt
+package internal
+package inc
+
+import java.io.File
+import java.net.URLClassLoader
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import sbt.internal.inc.classfile.{ ClassFile, JavaCompilerForUnitTesting, Parser }
+import sbt.io.IO
+import sbt.util.Logger
+import xsbt.api.HashAPI
+import xsbti.api.ClassLike
+
+/**
+ * Regression guard for the classfile-based Java API path against pathological generic signatures:
+ * a stress corpus of deep and mutually recursive F-bounds, `L0 <-> Mirror` signature cycles,
+ * covariant bridges, nested generic inners, and enum anonymous classes. The reflected `Type`
+ * graph for these is genuinely cyclic, so any extractor that expands a type variable into its bound,
+ * or chases method-return signatures, loops forever unless it stops at the variable. [[ClassfileToAPI]]
+ * is structurally safe (a `SigVar` maps to a by-name `ParameterRef`, never its bound; `collectInherited`
+ * carries a visited-set), and this test pins that: extraction must terminate, hash deterministically,
+ * and agree with reflection on declared/inherited member names.
+ */
+class FBoundStressSpecification extends UnitSpec {
+
+  // The corpus lives in test resources so the guard runs hermetically. One multi-type .java file
+  // (one public type, the rest package-private).
+  private def corpusSource: String = {
+    val url = getClass.getClassLoader.getResource("fbound/FBoundedStress.java")
+    assert(url != null, "fbound/FBoundedStress.java missing from test resources")
+    IO.readStream(url.openStream())
+  }
+
+  // Compile the whole corpus once and return (output dir, every compiled class as name -> ClassFile).
+  private def compileCorpus(temp: File): (File, Seq[(String, ClassFile)]) = {
+    val dir = new File(temp, "classes")
+    dir.mkdir()
+    val src = new File(temp, "FBoundedStress.java")
+    IO.write(src, corpusSource)
+    JavaCompilerForUnitTesting.compileJava(Seq(src), dir, Seq.empty)
+    val classes = (dir.listFiles().toSeq.filter(_.getName.endsWith(".class"))).map { f =>
+      val cf = Parser(f.toPath, Logger.Null)
+      cf.className -> cf
+    }
+    assert(classes.sizeIs > 20, s"expected the full corpus to compile, got ${classes.map(_._1)}")
+    (dir, classes)
+  }
+
+  // Byte-only parent resolver (no class loading), exactly as production uses under classfileJavaApi.
+  private def byteResolver(dir: File): String => Option[ClassFile] = binaryName => {
+    val res = binaryName.replace('.', '/') + ".class"
+    val loader = new URLClassLoader(Array(dir.toURI.toURL), null)
+    Option(loader.getResource(res))
+      .orElse(Option(ClassLoader.getSystemResource(res)))
+      .flatMap(u =>
+        try Some(Parser(u, Logger.Null))
+        catch { case _: Throwable => None }
+      )
+  }
+
+  "ClassfileToAPI on the F-bound stress corpus" should "terminate and hash deterministically" in {
+    IO.withTemporaryDirectory { temp =>
+      val (dir, classes) = compileCorpus(temp)
+      val resolve = byteResolver(dir)
+
+      // A non-terminating walk would hang the suite; bound it so a cycle bug surfaces as a failure.
+      def hashAll(): Int =
+        Await.result(
+          Future(ClassfileToAPI.process(classes, resolve)._1.map(HashAPI(_)).sum),
+          30.seconds
+        )
+
+      val h1 = hashAll()
+      val h2 = hashAll()
+      assert(h1 == h2, "hash must be deterministic across runs over cyclic F-bound signatures")
+    }
+  }
+
+  it should "agree with ClassToAPI (reflection) on declared and inherited member names" in {
+    IO.withTemporaryDirectory { temp =>
+      val (dir, classes) = compileCorpus(temp)
+      val resolve = byteResolver(dir)
+      val loader = new URLClassLoader(Array(dir.toURI.toURL), null)
+
+      val classfileApis = ClassfileToAPI.process(classes, resolve)._1
+      def declared(c: ClassLike): Set[String] = c.structure.declared.map(_.name).toSet
+      def inherited(c: ClassLike): Set[String] = c.structure.inherited.map(_.name).toSet
+
+      val failures = scala.collection.mutable.ListBuffer.empty[String]
+      for ((binaryName, _) <- classes) {
+        // Reflection keys by canonical name; the classfile API does too. Skip anything reflection
+        // can't model cleanly (anonymous classes have no canonical name) to keep the comparison fair.
+        val loaded =
+          try Some(loader.loadClass(binaryName))
+          catch { case _: Throwable => None }
+        loaded.filter(_.getCanonicalName != null).foreach { cls =>
+          val name = cls.getCanonicalName
+          val reflect = ClassToAPI.process(Seq(cls))._1.filter(_.name == name)
+          val classfile = classfileApis.filter(_.name == name)
+          if (reflect.nonEmpty && classfile.nonEmpty) {
+            val dR = reflect.flatMap(declared).toSet
+            val dC = classfile.flatMap(declared).toSet
+            val iR = reflect.flatMap(inherited).toSet
+            val iC = classfile.flatMap(inherited).toSet
+            if (dR != dC)
+              failures += s"$name declared: onlyReflect=${dR -- dC} onlyClassfile=${dC -- dR}"
+            if (iR != iC)
+              failures += s"$name inherited: onlyReflect=${iR -- iC} onlyClassfile=${iC -- iR}"
+          }
+        }
+      }
+      assert(failures.isEmpty, "divergences from reflection:\n" + failures.mkString("\n"))
+    }
+  }
+}

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/ClassFile.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/ClassFile.scala
@@ -29,6 +29,13 @@ private[sbt] trait ClassFile {
   val attributes: Array[AttributeInfo]
   def sourceFile: Option[String]
   def innerClasses: Array[InnerClassInfo]
+
+  /**
+   * The binary name of the immediately enclosing class from the `EnclosingMethod` attribute
+   * (JVMS 4.7.7), present on local and anonymous classes. `None` for other classes. Lets analysis
+   * map a local class to its enclosing class without reflectively loading it.
+   */
+  def enclosingClass: Option[String]
   def types: Set[String]
   def stringValue(a: AttributeInfo): String
 

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/JavaAnalyze.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/JavaAnalyze.scala
@@ -39,7 +39,8 @@ private[sbt] object JavaAnalyze {
       analysis: xsbti.AnalysisCallback,
       loader: ClassLoader,
       readAPI: (VirtualFileRef, Seq[Class[?]]) => Set[(String, String)],
-      readClassfileAPI: (VirtualFileRef, Seq[(String, ClassFile)]) => Unit = (_, _) => ()
+      readClassfileAPI: (VirtualFileRef, Seq[(String, ClassFile)]) => Unit = (_, _) => (),
+      classfileApiOnly: Boolean = false
   ): Unit = {
     val sourceMap = sources
       .toSet[VirtualFile]
@@ -91,7 +92,13 @@ private[sbt] object JavaAnalyze {
       if !binaryClassName.endsWith("module-info")
     } {
       val finalClassFile: Path = remapClassFile(newClass)
-      load(binaryClassName, Some("Error reading API from class file: " + binaryClassName)) match {
+      // Phase 3 (sbt/zinc#837, #151, #1697): when classfileApiOnly is set, skip reflective loading
+      // entirely so every class takes the classfile path below — no Class.forName, hence no
+      // static-initializer runs, inner-class load NPEs, or module access-check errors.
+      val loaded =
+        if (classfileApiOnly) None
+        else load(binaryClassName, Some("Error reading API from class file: " + binaryClassName))
+      loaded match {
         case Some(loadedClass) =>
           binaryClassNameToLoadedClass.update(binaryClassName, loadedClass)
           loadEnclosingClass(loadedClass) match {
@@ -124,13 +131,24 @@ private[sbt] object JavaAnalyze {
         loadedClasses.partition(_.getCanonicalName != null)
 
       // Map local classes to the sources of their enclosing classes
-      val localClassesToSources = {
-        val localToSourcesSeq = for {
-          cls <- localClassesOrStale
-          sourceOfEnclosing <- loadEnclosingClass(cls)
-        } yield (cls.getName, sourceOfEnclosing)
-        localToSourcesSeq.toMap
-      }
+      val localClassesToSources =
+        if (classfileApiOnly) {
+          // Classfile-only path: there are no loaded classes, so derive each local/anonymous class's
+          // enclosing source from the EnclosingMethod attribute instead of reflection. A local class
+          // shares its source with the enclosing class, so this source's classfiles suffice.
+          val cfByName = classFiles.iterator.map(cf => cf.className -> cf).toMap
+          (for {
+            cf <- classFiles
+            if canonicalClassName(cf).isEmpty // local or anonymous
+            enclosing <- enclosingNonLocalSourceName(cf.className, cfByName)
+          } yield cf.className -> enclosing).toMap
+        } else {
+          val localToSourcesSeq = for {
+            cls <- localClassesOrStale
+            sourceOfEnclosing <- loadEnclosingClass(cls)
+          } yield (cls.getName, sourceOfEnclosing)
+          localToSourcesSeq.toMap
+        }
 
       /* Get the mapped source file from a given class name. */
       def getMappedSource(className: String): Option[String] = {
@@ -330,6 +348,31 @@ private[sbt] object JavaAnalyze {
       }
     canonical(classFile.className)
   }
+
+  /**
+   * The source (canonical) name of the nearest non-local class enclosing `binaryName`, derived from
+   * classfiles alone (the EnclosingMethod attribute walked up via [[canonicalClassName]]) — the
+   * classfile analogue of reflection's [[loadEnclosingClass]] for local/anonymous classes. `cfByName`
+   * indexes the current source's classfiles; a local class shares its source with its enclosing
+   * class, so they are all present. `None` if the chain can't be resolved (degrades gracefully).
+   */
+  @tailrec
+  private def enclosingNonLocalSourceName(
+      binaryName: String,
+      cfByName: Map[String, ClassFile]
+  ): Option[String] =
+    cfByName.get(binaryName) match {
+      case None => None
+      case Some(cf) =>
+        canonicalClassName(cf) match {
+          case named @ Some(_) => named // a non-local (member/top-level) enclosing class
+          case None =>
+            cf.enclosingClass match {
+              case Some(enclosing) => enclosingNonLocalSourceName(enclosing, cfByName)
+              case None            => None
+            }
+        }
+    }
 
   /*
    * given mapping between getName and sources, try to guess

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/JavaAnalyze.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/JavaAnalyze.scala
@@ -254,7 +254,13 @@ private[sbt] object JavaAnalyze {
         .toSeq
       // Best-effort: never let classfile-based API extraction fail a compile that would otherwise
       // succeed (these classes already couldn't be loaded), matching load()/loadInnerClass.
-      if (unloadableNamed.nonEmpty) trapAndLog(log)(readClassfileAPI(source, unloadableNamed))
+      // Exception: under classfileApiOnly the classfile path is the *primary* one for every class,
+      // so a failure there is a real regression, not a tolerable gap. -Dzinc.classfileJavaApi.strict
+      // makes it propagate (the scripted CI matrix sets it) so such breakage fails the build.
+      if (unloadableNamed.nonEmpty) {
+        if (classfileApiOnly && strictClassfileApi) readClassfileAPI(source, unloadableNamed)
+        else trapAndLog(log)(readClassfileAPI(source, unloadableNamed))
+      }
     }
   }
 
@@ -303,6 +309,12 @@ private[sbt] object JavaAnalyze {
       }
     }
   }
+
+  // Test/CI affordance: make classfile-API extraction failures fatal under classfileApiOnly so the
+  // scripted matrix (CONTRIBUTING.md) catches crashes in that path instead of silently swallowing
+  // them. Off in production, where the path stays best-effort.
+  private def strictClassfileApi: Boolean =
+    java.lang.Boolean.getBoolean("zinc.classfileJavaApi.strict")
 
   private def trapAndLog(log: Logger)(execute: => Unit): Unit = {
     try {

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Parser.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Parser.scala
@@ -107,6 +107,16 @@ private[sbt] object Parser {
         }
       }
 
+      override lazy val enclosingClass: Option[String] =
+        attributes
+          .find(_.isNamed("EnclosingMethod"))
+          .map { a =>
+            // EnclosingMethod: { u2 class_index; u2 method_index; } — class_index -> CONSTANT_Class.
+            val data = new DataInputStream(new ByteArrayInputStream(a.value))
+            getClassConstantName(data.readUnsignedShort())
+          }
+          .filter(_.nonEmpty)
+
       override lazy val sourceFile: Option[String] =
         for (sourceFileAttribute <- attributes.find(_.isSourceFile))
           yield toUTF8(entryIndex(sourceFileAttribute))

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/SignatureParser.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/SignatureParser.scala
@@ -30,7 +30,8 @@ private[sbt] object SignatureModel {
   sealed trait SigType
 
   /** `Lpkg/Outer<args>.Inner<args>;` — `name` is the dotted outer class name; `inners` the suffixes. */
-  final case class SigClass(name: String, args: List[SigArg], inners: List[SigInner]) extends SigType
+  final case class SigClass(name: String, args: List[SigArg], inners: List[SigInner])
+      extends SigType
 
   /** `TX;` — a reference to a type variable named `X`. */
   final case class SigVar(name: String) extends SigType
@@ -96,7 +97,8 @@ private[sbt] object SignatureParser {
       val params = ListBuffer.empty[SigType]
       while (c.peek != ')') params += parseJavaType(c)
       c.expect(')')
-      val result = if (c.peek == 'V') { c.next(); SigVoid } else parseJavaType(c)
+      val result = if (c.peek == 'V') { c.next(); SigVoid }
+      else parseJavaType(c)
       val throws = ListBuffer.empty[SigType]
       while (!c.atEnd && c.peek == '^') { c.next(); throws += parseThrowsSignature(c) }
       MethodSignature(typeParams, params.toList, result, throws.toList)
@@ -172,9 +174,9 @@ private[sbt] object SignatureParser {
   // TypeArgument: [+|-] ReferenceTypeSignature | *
   private def parseTypeArg(c: Cursor): SigArg =
     c.peek match {
-      case '*'           => c.next(); SigWildcard
+      case '*'             => c.next(); SigWildcard
       case v @ ('+' | '-') => c.next(); SigBounded(v, parseReferenceType(c))
-      case _             => SigBounded('=', parseReferenceType(c))
+      case _               => SigBounded('=', parseReferenceType(c))
     }
 
   // TypeParameters: < (Identifier ClassBound InterfaceBound*)+ >

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/SignatureParser.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/SignatureParser.scala
@@ -1,0 +1,219 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package sbt
+package internal
+package inc
+package classfile
+
+import scala.collection.mutable.ListBuffer
+import scala.util.control.NonFatal
+
+/**
+ * A neutral AST for JVMS §4.7.9.1 generic signatures. Kept independent of `xsbti.api` so the parser
+ * stays pure syntax; the mapping to `xsbti.api` types lives in `ClassfileToAPI` (zinc-apiinfo),
+ * which reuses `ClassToAPI`'s type helpers. Used by Phase 3 of the classfile-based Java API work
+ * (docs/design/classfile-based-java-api.md) to recover the generic types that erased descriptors
+ * drop.
+ */
+private[sbt] object SignatureModel {
+
+  /** A type that can appear as a field type, parameter, return, bound, or type argument. */
+  sealed trait SigType
+
+  /** `Lpkg/Outer<args>.Inner<args>;` — `name` is the dotted outer class name; `inners` the suffixes. */
+  final case class SigClass(name: String, args: List[SigArg], inners: List[SigInner]) extends SigType
+
+  /** `TX;` — a reference to a type variable named `X`. */
+  final case class SigVar(name: String) extends SigType
+
+  /** `[elem` — an array type. */
+  final case class SigArray(elem: SigType) extends SigType
+
+  /** `B C D F I J S Z` — a primitive (the JVM type descriptor character). */
+  final case class SigPrimitive(tag: Char) extends SigType
+
+  /** `V` — only valid as a method result. */
+  case object SigVoid extends SigType
+
+  /** A `.Inner<args>` suffix of a [[SigClass]]. */
+  final case class SigInner(name: String, args: List[SigArg])
+
+  /** A type argument inside `<...>`. */
+  sealed trait SigArg
+  case object SigWildcard extends SigArg // `*` (unbounded)
+
+  /** A type argument with a variance marker: `=` invariant, `+` `? extends`, `-` `? super`. */
+  final case class SigBounded(variance: Char, tpe: SigType) extends SigArg
+
+  /** A declared type parameter with its (class + interface) bounds. */
+  final case class SigTypeParam(name: String, bounds: List[SigType])
+
+  final case class ClassSignature(
+      typeParams: List[SigTypeParam],
+      superclass: SigType,
+      interfaces: List[SigType]
+  )
+  final case class MethodSignature(
+      typeParams: List[SigTypeParam],
+      params: List[SigType],
+      result: SigType,
+      throws: List[SigType]
+  )
+}
+
+/**
+ * Recursive-descent parser for JVMS §4.7.9.1 signatures. Entry points are fail-soft (return `None`
+ * on malformed input) so callers can degrade gracefully.
+ */
+private[sbt] object SignatureParser {
+  import SignatureModel._
+
+  def fieldSignature(s: String): Option[SigType] =
+    tryParse(s)(c => parseReferenceType(c))
+
+  def classSignature(s: String): Option[ClassSignature] =
+    tryParse(s) { c =>
+      val typeParams = if (c.peek == '<') parseTypeParams(c) else Nil
+      val superclass = parseClassType(c)
+      val interfaces = ListBuffer.empty[SigType]
+      while (!c.atEnd) interfaces += parseClassType(c)
+      ClassSignature(typeParams, superclass, interfaces.toList)
+    }
+
+  def methodSignature(s: String): Option[MethodSignature] =
+    tryParse(s) { c =>
+      val typeParams = if (c.peek == '<') parseTypeParams(c) else Nil
+      c.expect('(')
+      val params = ListBuffer.empty[SigType]
+      while (c.peek != ')') params += parseJavaType(c)
+      c.expect(')')
+      val result = if (c.peek == 'V') { c.next(); SigVoid } else parseJavaType(c)
+      val throws = ListBuffer.empty[SigType]
+      while (!c.atEnd && c.peek == '^') { c.next(); throws += parseThrowsSignature(c) }
+      MethodSignature(typeParams, params.toList, result, throws.toList)
+    }
+
+  private def tryParse[T](s: String)(p: Cursor => T): Option[T] =
+    try {
+      val c = new Cursor(s)
+      val result = p(c)
+      if (!c.atEnd) sys.error(s"trailing input in $s") // must consume the whole signature
+      Some(result)
+    } catch { case NonFatal(_) => None } // malformed signatures -> None; fatal errors propagate
+
+  // JavaTypeSignature: ReferenceTypeSignature | BaseType
+  private def parseJavaType(c: Cursor): SigType =
+    c.peek match {
+      case 'B' | 'C' | 'D' | 'F' | 'I' | 'J' | 'S' | 'Z' => SigPrimitive(c.next())
+      case _                                             => parseReferenceType(c)
+    }
+
+  // ReferenceTypeSignature: ClassTypeSignature | TypeVariableSignature | ArrayTypeSignature
+  private def parseReferenceType(c: Cursor): SigType =
+    c.peek match {
+      case 'L'   => parseClassType(c)
+      case 'T'   => parseTypeVar(c)
+      case '['   => c.next(); SigArray(parseJavaType(c))
+      case other => sys.error(s"unexpected signature char '$other'")
+    }
+
+  // TypeVariableSignature: T Identifier ;
+  private def parseTypeVar(c: Cursor): SigVar = {
+    c.expect('T')
+    val name = c.readIdentifier()
+    c.expect(';')
+    SigVar(name)
+  }
+
+  // ThrowsSignature: ^ (ClassTypeSignature | TypeVariableSignature) — no arrays/primitives.
+  private def parseThrowsSignature(c: Cursor): SigType =
+    c.peek match {
+      case 'L'   => parseClassType(c)
+      case 'T'   => parseTypeVar(c)
+      case other => sys.error(s"invalid throws signature char '$other'")
+    }
+
+  // ClassTypeSignature: L [pkg/] Identifier [<args>] {. Identifier [<args>]} ;
+  private def parseClassType(c: Cursor): SigClass = {
+    c.expect('L')
+    var name = c.readIdentifier()
+    while (c.peek == '/') { c.next(); name = name + "." + c.readIdentifier() }
+    val args = if (c.peek == '<') parseTypeArgs(c) else Nil
+    val inners = ListBuffer.empty[SigInner]
+    while (c.peek == '.') {
+      c.next()
+      val innerName = c.readIdentifier()
+      val innerArgs = if (c.peek == '<') parseTypeArgs(c) else Nil
+      inners += SigInner(innerName, innerArgs)
+    }
+    c.expect(';')
+    SigClass(name, args, inners.toList)
+  }
+
+  // TypeArguments: < TypeArgument+ >
+  private def parseTypeArgs(c: Cursor): List[SigArg] = {
+    c.expect('<')
+    val args = ListBuffer.empty[SigArg]
+    while (c.peek != '>') args += parseTypeArg(c)
+    c.expect('>')
+    if (args.isEmpty) sys.error("empty type arguments") // JVMS requires at least one
+    args.toList
+  }
+
+  // TypeArgument: [+|-] ReferenceTypeSignature | *
+  private def parseTypeArg(c: Cursor): SigArg =
+    c.peek match {
+      case '*'           => c.next(); SigWildcard
+      case v @ ('+' | '-') => c.next(); SigBounded(v, parseReferenceType(c))
+      case _             => SigBounded('=', parseReferenceType(c))
+    }
+
+  // TypeParameters: < (Identifier ClassBound InterfaceBound*)+ >
+  private def parseTypeParams(c: Cursor): List[SigTypeParam] = {
+    c.expect('<')
+    val params = ListBuffer.empty[SigTypeParam]
+    while (c.peek != '>') {
+      val name = c.readIdentifier()
+      val bounds = ListBuffer.empty[SigType]
+      c.expect(':') // ClassBound colon; the class bound itself may be absent
+      if (c.peek != ':' && c.peek != '>') bounds += parseReferenceType(c)
+      while (c.peek == ':') { c.next(); bounds += parseReferenceType(c) } // InterfaceBound*
+      params += SigTypeParam(name, bounds.toList)
+    }
+    c.expect('>')
+    if (params.isEmpty) sys.error("empty type parameters") // JVMS requires at least one
+    params.toList
+  }
+
+  /** A delimiter character that cannot appear in a signature identifier (JVMS §4.7.9.1). */
+  private def isDelimiter(ch: Char): Boolean = ch match {
+    case '<' | '>' | '.' | ':' | ';' | '/' | '[' => true
+    case _                                       => false
+  }
+
+  private final class Cursor(s: String) {
+    private var idx = 0
+    def atEnd: Boolean = idx >= s.length
+    def peek: Char = s.charAt(idx)
+    def next(): Char = { val ch = s.charAt(idx); idx += 1; ch }
+    def expect(ch: Char): Unit = {
+      if (atEnd || peek != ch) sys.error(s"expected '$ch' at $idx in $s")
+      idx += 1
+    }
+    def readIdentifier(): String = {
+      val start = idx
+      while (!atEnd && !isDelimiter(peek)) idx += 1
+      if (idx == start) sys.error(s"empty identifier at $idx in $s") // identifiers are non-empty
+      s.substring(start, idx)
+    }
+  }
+}

--- a/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/AnalyzeSpecification.scala
+++ b/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/AnalyzeSpecification.scala
@@ -310,4 +310,45 @@ class AnalyzeSpecification extends UnitSpec {
     }
   }
 
+  // Step D: under classfileApiOnly there are no loaded classes, so a local/anonymous class's
+  // enclosing source must be recovered from the EnclosingMethod attribute — otherwise a dependency
+  // referenced only inside the local class body (here `Dep`, used only in the anonymous Runnable)
+  // would be dropped, under-compiling. Before the EnclosingMethod mapping this assertion failed.
+  "Analyze" should "map local-class member-ref dependencies to the enclosing source under classfileApiOnly" in {
+    IO.withTemporaryDirectory { temp =>
+      val classesDir = new File(temp, "classes")
+      classesDir.mkdir()
+
+      val depFile = new File(temp, "Dep.java")
+      IO.write(depFile, "public class Dep {}")
+      val holderFile = new File(temp, "Holder.java")
+      IO.write(
+        holderFile,
+        """|public class Holder {
+           |  public Runnable make() {
+           |    return new Runnable() { public void run() { Dep d = new Dep(); } };
+           |  }
+           |}
+           |""".stripMargin
+      )
+      JavaCompilerForUnitTesting.compileJava(Seq(depFile, holderFile), classesDir, Seq.empty)
+
+      val callback =
+        JavaCompilerForUnitTesting.analyze(
+          classesDir,
+          Seq(depFile, holderFile),
+          classfileApiOnly = true
+        )
+
+      // The anonymous class is recorded as a local product (no canonical name).
+      val products = callback.productClassesToSources.keySet.map(_.getFileName.toString)
+      assert(products.contains("Holder$1.class"))
+
+      // `Dep` is referenced only inside the anonymous class, yet its member-ref dependency is
+      // attributed to the enclosing `Holder` source — proving the local→enclosing mapping works
+      // without loading any class.
+      assert(callback.classDependencies.contains(("Dep", "Holder", DependencyByMemberRef)))
+    }
+  }
+
 }

--- a/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/JavaCompilerForUnitTesting.scala
+++ b/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/JavaCompilerForUnitTesting.scala
@@ -123,13 +123,28 @@ object JavaCompilerForUnitTesting {
   def analyze(
       classesDir: File,
       srcFiles: Seq[File],
-      readClassfileAPI: (AnalysisCallback, VirtualFileRef, Seq[(String, ClassFile)]) => Unit =
-        (_, _, _) => ()
+      readClassfileAPI: (
+          AnalysisCallback,
+          VirtualFileRef,
+          Seq[(String, ClassFile)],
+          String => Option[ClassFile]
+      ) => Unit = (_, _, _, _) => (),
+      classfileApiOnly: Boolean = false
   ): TestCallback = {
     val srcs: List[VirtualFile] = srcFiles.toList.map(f => new TestVirtualFile(f.toPath))
     val analysisCallback = new TestCallback
     val classFiles = (sbt.io.PathFinder(classesDir) ** "*.class").get().map(_.toPath)
     val classloader = new URLClassLoader(Array(classesDir.toURI.toURL), null)
+    // Read a parent class's bytes (for inherited members) without loading/linking it.
+    val resolve: String => Option[ClassFile] = binaryName => {
+      val resource = binaryName.replace('.', '/') + ".class"
+      Option(classloader.getResource(resource))
+        .orElse(Option(ClassLoader.getSystemResource(resource)))
+        .flatMap(u =>
+          try Some(Parser(u, ConsoleLogger()))
+          catch { case _: Throwable => None }
+        )
+    }
     val output = new SingleOutput {
       override def getOutputDirectoryAsPath: Path = classesDir.toPath
       override def getOutputDirectory: File = classesDir
@@ -138,7 +153,8 @@ object JavaCompilerForUnitTesting {
       analysisCallback,
       classloader,
       (_, classes) => extractParents(classes),
-      readClassfileAPI(analysisCallback, _, _)
+      readClassfileAPI(analysisCallback, _, _, resolve),
+      classfileApiOnly
     )
     analysisCallback
   }

--- a/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/SignatureParserSpecification.scala
+++ b/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/SignatureParserSpecification.scala
@@ -1,0 +1,139 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package sbt
+package internal
+package inc
+package classfile
+
+class SignatureParserSpecification extends UnitSpec {
+  import SignatureModel._
+
+  private def cls(name: String, args: SigArg*): SigClass = SigClass(name, args.toList, Nil)
+  private def inv(t: SigType): SigArg = SigBounded('=', t)
+  private val Str = cls("java.lang.String")
+  private val Obj = cls("java.lang.Object")
+
+  "SignatureParser" should "parse a parameterized field type" in {
+    assert(
+      SignatureParser.fieldSignature("Ljava/util/List<Ljava/lang/String;>;")
+        == Some(cls("java.util.List", inv(Str)))
+    )
+  }
+
+  it should "parse type variables, arrays, and primitive-element arrays" in {
+    assert(SignatureParser.fieldSignature("TT;") == Some(SigVar("T")))
+    assert(SignatureParser.fieldSignature("[Ljava/lang/String;") == Some(SigArray(Str)))
+    assert(SignatureParser.fieldSignature("[[I") == Some(SigArray(SigArray(SigPrimitive('I')))))
+  }
+
+  it should "parse wildcards (unbounded, extends, super)" in {
+    assert(
+      SignatureParser.fieldSignature("Ljava/util/List<*>;")
+        == Some(cls("java.util.List", SigWildcard))
+    )
+    assert(
+      SignatureParser.fieldSignature("Ljava/util/List<+Ljava/lang/Number;>;")
+        == Some(cls("java.util.List", SigBounded('+', cls("java.lang.Number"))))
+    )
+    assert(
+      SignatureParser.fieldSignature("Ljava/util/List<-Ljava/lang/Integer;>;")
+        == Some(cls("java.util.List", SigBounded('-', cls("java.lang.Integer"))))
+    )
+  }
+
+  it should "parse an inner class with type arguments on the outer" in {
+    assert(
+      SignatureParser.fieldSignature("Lpkg/Outer<Ljava/lang/String;>.Inner;")
+        == Some(SigClass("pkg.Outer", List(inv(Str)), List(SigInner("Inner", Nil))))
+    )
+  }
+
+  it should "parse a class signature with type params, superclass, and interface" in {
+    val sig = "<T:Ljava/lang/Object;>Ljava/lang/Object;Ljava/lang/Comparable<TT;>;"
+    assert(
+      SignatureParser.classSignature(sig) == Some(
+        ClassSignature(
+          List(SigTypeParam("T", List(Obj))),
+          Obj,
+          List(cls("java.lang.Comparable", inv(SigVar("T"))))
+        )
+      )
+    )
+  }
+
+  it should "parse an interface-only bounded type parameter (the '::' case)" in {
+    val sig = "<T::Ljava/lang/Comparable<TT;>;>Ljava/lang/Object;"
+    assert(
+      SignatureParser.classSignature(sig).map(_.typeParams)
+        == Some(List(SigTypeParam("T", List(cls("java.lang.Comparable", inv(SigVar("T")))))))
+    )
+  }
+
+  it should "parse a generic method signature with params, return, and throws" in {
+    val sig = "<T:Ljava/lang/Object;>(TT;I)Ljava/util/List<TT;>;^Ljava/io/IOException;"
+    assert(
+      SignatureParser.methodSignature(sig) == Some(
+        MethodSignature(
+          List(SigTypeParam("T", List(Obj))),
+          List(SigVar("T"), SigPrimitive('I')),
+          cls("java.util.List", inv(SigVar("T"))),
+          List(cls("java.io.IOException"))
+        )
+      )
+    )
+  }
+
+  it should "parse a void result" in {
+    assert(SignatureParser.methodSignature("()V").map(_.result) == Some(SigVoid))
+  }
+
+  it should "return None on malformed or truncated input" in {
+    assert(SignatureParser.fieldSignature("not-a-signature").isEmpty)
+    assert(SignatureParser.fieldSignature("Ljava/util/List<").isEmpty)
+    assert(SignatureParser.methodSignature("(I").isEmpty)
+  }
+
+  it should "reject trailing input after a complete signature" in {
+    assert(SignatureParser.fieldSignature("Ljava/lang/String;xxx").isEmpty)
+    assert(SignatureParser.methodSignature("()Vxxx").isEmpty)
+  }
+
+  it should "reject empty identifiers and empty type-argument/parameter lists" in {
+    assert(SignatureParser.fieldSignature("L;").isEmpty) // empty class name
+    assert(SignatureParser.fieldSignature("T;").isEmpty) // empty type-variable name
+    assert(SignatureParser.fieldSignature("Ljava/util/List<>;").isEmpty) // empty type args
+    assert(SignatureParser.classSignature("<>Ljava/lang/Object;").isEmpty) // empty type params
+  }
+
+  it should "parse multiple bounds on a type parameter" in {
+    val sig = "<T:Ljava/lang/Object;:Ljava/lang/Comparable<TT;>;>Ljava/lang/Object;"
+    assert(
+      SignatureParser.classSignature(sig).map(_.typeParams)
+        == Some(List(SigTypeParam("T", List(Obj, cls("java.lang.Comparable", inv(SigVar("T")))))))
+    )
+  }
+
+  it should "parse a type-variable throws and reject an array throws" in {
+    val tv = "<T:Ljava/lang/Throwable;>()V^TT;"
+    assert(SignatureParser.methodSignature(tv).map(_.throws) == Some(List(SigVar("T"))))
+    assert(SignatureParser.methodSignature("()V^[Ljava/lang/Exception;").isEmpty)
+  }
+
+  it should "parse type arguments on both the outer and inner of an inner class" in {
+    val k = inv(SigVar("K"))
+    val v = inv(SigVar("V"))
+    assert(
+      SignatureParser.fieldSignature("Ljava/util/Map<TK;TV;>.Entry<TK;TV;>;")
+        == Some(SigClass("java.util.Map", List(k, v), List(SigInner("Entry", List(k, v)))))
+    )
+  }
+}

--- a/internal/zinc-core/src/main/java/xsbti/compile/IncOptionsUtil.java
+++ b/internal/zinc-core/src/main/java/xsbti/compile/IncOptionsUtil.java
@@ -45,6 +45,7 @@ public class IncOptionsUtil {
     public static final String STORE_APIS = "storeApis";
     public static final String ALLOW_MACHINE_PATH = "allowMachinePath";
     public static final String PIPELINING = "pipelining";
+    public static final String CLASSFILE_JAVA_API = "classfileJavaApi";
     private static final String XSBTI_NOTHING = "NOTHING";
 
     // Small utility function for logging
@@ -175,6 +176,11 @@ public class IncOptionsUtil {
         if (values.containsKey(PIPELINING)) {
             logger.debug(f0("PIPELINING value was read."));
             base = base.withPipelining(Boolean.parseBoolean(values.get(PIPELINING)));
+        }
+
+        if (values.containsKey(CLASSFILE_JAVA_API)) {
+            logger.debug(f0("CLASSFILE_JAVA_API value was read."));
+            base = base.withClassfileJavaApi(Boolean.parseBoolean(values.get(CLASSFILE_JAVA_API)));
         }
 
         return base;

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -358,10 +358,16 @@ case class ProjectStructure(
         xsbti.compile.TransactionalManagerType
           .of((targetDir / "classes.bak").toFile, sbt.util.Logger.Null)
       )
+    // -Dzinc.scripted.classfileJavaApi=true|false forces the classfile-based Java API path for the
+    // whole scripted run (the CI matrix runs the suite both ways); absent, the per-test value stands.
+    val classfileJavaApi = Option(System.getProperty("zinc.scripted.classfileJavaApi"))
+      .map(_.toBoolean)
+      .getOrElse(incOptions0.classfileJavaApi())
     val incO =
       incOptions0
         .withClassfileManagerType(transactional)
         .withStoreApis(storeApis)
+        .withClassfileJavaApi(classfileJavaApi)
     (incO, sco)
   }
   val exportPipelining = incOptions.pipelining

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -84,7 +84,8 @@ final class MixedAnalyzingCompiler(
               incToolOptions,
               config.reporter,
               log,
-              config.progress
+              config.progress,
+              config.incOptions.classfileJavaApi()
             )
             putJavacOutputInJar(outputJar.toFile, outputDir.toFile)
           case _ =>
@@ -100,7 +101,8 @@ final class MixedAnalyzingCompiler(
                 incToolOptions,
                 config.reporter,
                 log,
-                config.progress
+                config.progress,
+                config.incOptions.classfileJavaApi()
               )
             }
         }

--- a/zinc/src/main/scala/sbt/internal/inc/javac/AnalyzingJavaCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/javac/AnalyzingJavaCompiler.scala
@@ -17,7 +17,7 @@ package javac
 import java.nio.file.Path
 import java.net.URLClassLoader
 
-import sbt.internal.inc.classfile.{ ClassFile, JavaAnalyze }
+import sbt.internal.inc.classfile.{ ClassFile, JavaAnalyze, Parser }
 import sbt.internal.inc.classpath.ClasspathUtil
 import xsbti.compile._
 import xsbti.{
@@ -97,6 +97,9 @@ final class AnalyzingJavaCompiler private[sbt] (
    * @param log       A place where we can log debugging/error messages.
    * @param progressOpt An optional compilation progress reporter to report
    *                    back what files are currently under compilation.
+   * @param classfileApiOnly When true, extract each Java class's API from its classfile instead of
+   *                    by reflectively loading it (IncOptions.classfileJavaApi); avoids the class
+   *                    loading that triggers sbt/zinc#837, #151, and #1697.
    */
   def compile(
       sources: Seq[VirtualFile],
@@ -109,7 +112,8 @@ final class AnalyzingJavaCompiler private[sbt] (
       incToolOptions: IncToolOptions,
       reporter: XReporter,
       log: XLogger,
-      progressOpt: Option[CompileProgress]
+      progressOpt: Option[CompileProgress],
+      classfileApiOnly: Boolean
   ): Unit = {
     val sourceDirs = collection.mutable.Map.empty[Path, VirtualFileRef]
 
@@ -182,6 +186,12 @@ final class AnalyzingJavaCompiler private[sbt] (
         }
       }
 
+      // Construct class loader to analyze dependencies of generated class files
+      val loader = ClasspathUtil.toLoader(
+        output.getSingleOutputAsPath.toScala.toSeq ++
+          (extraClasspath ++ searchClasspath).map(converter.toPath)
+      )
+
       // Read the API information from [[Class]] to analyze dependencies.
       def readAPI(source: VirtualFileRef, classes: Seq[Class[?]]): Set[(String, String)] = {
         val (apis, mainClasses, inherits) = ClassToAPI.process(classes, log)
@@ -192,10 +202,21 @@ final class AnalyzingJavaCompiler private[sbt] (
         }
       }
 
+      // Read a parent class's bytes (for inherited members) without loading/linking it — so this
+      // stays immune to the module/classpath issues that motivated the classfile path (sbt/zinc#837).
+      def resolveParent(binaryName: String): Option[ClassFile] = {
+        val resource = binaryName.replace('.', '/') + ".class"
+        Option(loader.getResource(resource))
+          .orElse(Option(ClassLoader.getSystemResource(resource)))
+          .flatMap(u =>
+            try Some(Parser(u, log))
+            catch { case _: Throwable => None }
+          )
+      }
       // Read the API of classes that couldn't be reflectively loaded, from their classfiles
       // (sbt/zinc#837), so name-hashing still tracks changes to their own public shape.
       def readClassfileAPI(source: VirtualFileRef, classFiles: Seq[(String, ClassFile)]): Unit = {
-        val (apis, mainClasses) = ClassfileToAPI.process(classFiles, log)
+        val (apis, mainClasses) = ClassfileToAPI.process(classFiles, resolveParent(_), log)
         apis.foreach(callback.api(source, _))
         mainClasses.foreach(callback.mainClass(source, _))
       }
@@ -206,12 +227,6 @@ final class AnalyzingJavaCompiler private[sbt] (
         progress.startUnit(javaAnalysisPhase, "")
         progress.advance(1, 2, javaCompilationPhase, javaAnalysisPhase)
       }
-      // Construct class loader to analyze dependencies of generated class files
-      val loader = ClasspathUtil.toLoader(
-        output.getSingleOutputAsPath.toScala.toSeq ++
-          (extraClasspath ++ searchClasspath).map(converter.toPath)
-      )
-
       timed(javaAnalysisPhase, log) {
         for {
           (classFinder, oldClasses, srcs) <- memo
@@ -223,7 +238,8 @@ final class AnalyzingJavaCompiler private[sbt] (
               callback,
               loader,
               readAPI,
-              readClassfileAPI
+              readClassfileAPI,
+              classfileApiOnly
             )
           } finally classes.close()
         }

--- a/zinc/src/test/scala/sbt/inc/IncrementalCompilerSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/IncrementalCompilerSpec.scala
@@ -14,7 +14,14 @@ package sbt.inc
 import sbt.internal.inc._
 import sbt.io.IO.{ withTemporaryDirectory => withTmpDir }
 import sbt.io.syntax._
-import xsbti.compile.{ AnalysisStore, CompileAnalysis, DefaultExternalHooks, Inputs, Output }
+import xsbti.compile.{
+  AnalysisStore,
+  CompileAnalysis,
+  DefaultExternalHooks,
+  IncOptions,
+  Inputs,
+  Output
+}
 import java.util.Optional
 
 import xsbti.VirtualFile
@@ -203,6 +210,56 @@ class IncrementalCompilerSpec extends BaseCompilerSpec {
     } finally {
       comp.close()
     }
+  }
+
+  // Step D end-to-end: with IncOptions.classfileJavaApi on, a change to a Java method's public
+  // signature must invalidate its dependents — and produce the *same* recompiled set as the default
+  // reflection path — all without loading any class. The flag is a per-invocation option (no global
+  // state), so the two scenarios just use different IncOptions.
+  it should "drive the same Java invalidation under classfileJavaApi as reflection" in withTmpDir {
+    tmp =>
+      val a1 = "public class A { public int value() { return 1; } }"
+      val a2 = "public class A { public long value() { return 1L; } }" // public signature change
+      // B depends on A.value(); its own source is unchanged and compiles against both versions.
+      val b = "public class B { public long use() { return new A().value(); } }"
+
+      def scenario(subdir: String, opts: IncOptions): Set[String] = {
+        val comp = VirtualSubproject(tmp.toPath / subdir).setup.createCompiler(scalaVersion, opts)
+        try {
+          def compileJava(sources: VirtualFile*) =
+            comp.doCompileWithStore(newInputs =
+              (in: Inputs) =>
+                comp.withSrcs(sources.toArray)(
+                  in.withOptions(
+                    in.options
+                      .withEarlyOutput(Optional.empty[Output])
+                      .withScalacOptions(comp.scalacOptions.toArray) // drop -Ypickle* args
+                  ).withSetup(
+                    in.setup.withIncrementalCompilerOptions(
+                      in.setup.incrementalCompilerOptions.withPipelining(false)
+                    )
+                  )
+                )
+            )
+          val res1 = compileJava(StringVirtualFile("A.java", a1), StringVirtualFile("B.java", b))
+          val res2 = compileJava(StringVirtualFile("A.java", a2), StringVirtualFile("B.java", b))
+          recompiled(res1, res2)
+        } finally comp.close()
+      }
+
+      val withReflection = scenario("reflect", incOptions)
+      val withClassfile = scenario("classfile", incOptions.withClassfileJavaApi(true))
+
+      // The dependent B is invalidated by A's API change ...
+      assert(
+        withClassfile.contains("A") && withClassfile.contains("B"),
+        s"classfile path under-invalidated: $withClassfile"
+      )
+      // ... and the classfile path matches the reflection path exactly.
+      assert(
+        withClassfile == withReflection,
+        s"invalidation differs — classfile=$withClassfile reflect=$withReflection"
+      )
   }
 
   it should "track dependencies on constants" in withTmpDir { tmp =>


### PR DESCRIPTION
Builds on #1714 and #1729 (both merged). Completes the classfile-based Java API path so analysis can avoid reflective class loading entirely — the root cause of #837 / #151 / #1697 — behind a new opt-in `IncOptions.classfileJavaApi` (off by default).

- JVMS generic-`Signature` parser → real `xsbti.api` types (generics, bounds, wildcards); annotation element values, enum children, varargs, ctor `Empty` return.
- Inherited public members (incl. nested classes) recovered by reading parent classfiles as **bytes** — no class loading; matches reflection's structure (incl. its non-generic-supertype rule for inherited member classes).
- `IncOptions.classfileJavaApi` routes all Java classes through the classfile path (per-invocation option, parallel-safe, settable via `incOptions.properties`); local/anonymous classes mapped via the `EnclosingMethod` attribute.

Validated by a differential audit asserting structural parity with the reflection path (`ClassToAPI`) — member set, kind, access, arity, varargs, type-params, declared + inherited nested classes — plus an end-to-end incremental test (same recompiled set with the option on). Whole-class hashes intentionally differ (accepted one-time re-hash); flipping the default is a separate maintainer decision.
