### PR TITLE
[2.x] fix: Track transitive supertypes of member-referenced Java types (#148)

### DIFF
--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/JavaAnalyze.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/JavaAnalyze.scala
@@ -17,6 +17,7 @@ package classfile
 import scala.collection.mutable
 import mutable.{ ArrayBuffer, Buffer }
 import scala.annotation.tailrec
+import scala.util.control.NonFatal
 import java.io.File
 import java.net.URL
 
@@ -115,6 +116,74 @@ private[sbt] object JavaAnalyze {
       sourceToClassFiles(source) += classFile
     }
 
+    // sbt/zinc#148: javac (since JDK 8) requires every transitive superclass and superinterface of a
+    // referenced type to be on the compile classpath, even though the referencing classfile's constant
+    // pool names only the referenced type itself. We record those ancestors as member-ref dependencies
+    // of the referencing class so the dependency graph reflects what javac actually needs — in
+    // particular for build tools that minimize the classpath from Zinc's analysis. Ancestors are read
+    // from classfile bytes (the already-parsed classfile for compiled classes, otherwise via the
+    // classloader) — never by loading the class — and memoized across the whole analysis.
+    val classFileByBinaryName: Map[String, ClassFile] =
+      sourceToClassFiles.valuesIterator.flatten.map(cf => cf.className -> cf).toMap
+    val resourceUrls = mutable.Map.empty[String, Option[URL]]
+    val resolvedClassFiles = mutable.Map.empty[String, Option[ClassFile]]
+    val transitiveAncestorsCache = mutable.Map.empty[String, Set[String]]
+
+    def resourceUrl(binaryName: String): Option[URL] =
+      resourceUrls.getOrElseUpdate(
+        binaryName,
+        Option(loader.getResource(classNameToClassFile(binaryName)))
+      )
+
+    // A "platform" class is always on the bootclasspath, so it never needs dependency tracking and its
+    // (deep) ancestry must not be walked. This is decided by ORIGIN, not by package name: many javax.*
+    // APIs (servlet, JAX-RS, JAXB, javax.annotation) ship as ordinary classpath jars and MUST stay
+    // tracked for build tools that minimize the classpath from Zinc's analysis (sbt/zinc#148). A class is
+    // platform iff its classfile is served from the JDK runtime image (`jrt:`); `java.*` is a reserved
+    // namespace (always the JDK), so we skip the lookup for it. Classes compiled in this run are never
+    // platform.
+    def isPlatformClass(binaryName: String): Boolean =
+      binaryName.startsWith("java.") ||
+        (!classFileByBinaryName.contains(binaryName) &&
+          resourceUrl(binaryName).exists(_.getProtocol == "jrt"))
+
+    def resolveClassFile(binaryName: String): Option[ClassFile] =
+      classFileByBinaryName
+        .get(binaryName)
+        .orElse(
+          resolvedClassFiles.getOrElseUpdate(
+            binaryName,
+            resourceUrl(binaryName).flatMap { url =>
+              try Some(Parser(url, log))
+              catch {
+                case NonFatal(e) =>
+                  log.debug(s"[zinc] sbt/zinc#148: couldn't read parents of $binaryName ($e)")
+                  None
+              }
+            }
+          )
+        )
+
+    // Transitive super/interface closure of `binaryName`, excluding `binaryName` itself and the
+    // JDK/platform classes that are always on the bootclasspath (so never need tracking).
+    def transitiveAncestors(binaryName: String): Set[String] =
+      transitiveAncestorsCache.getOrElseUpdate(
+        binaryName, {
+          val acc = mutable.Set.empty[String]
+          val queue = mutable.Queue(binaryName)
+          while (queue.nonEmpty) {
+            val directParents = resolveClassFile(queue.dequeue()) match {
+              case Some(cf) =>
+                (cf.superClassName +: cf.interfaceNames.toIndexedSeq).filter(_.nonEmpty)
+              case None => IndexedSeq.empty[String]
+            }
+            for (parent <- directParents if !isPlatformClass(parent) && acc.add(parent))
+              queue.enqueue(parent)
+          }
+          acc.toSet
+        }
+      )
+
     // get class to class dependencies and map back to source to class dependencies
     for ((source, classFiles) <- sourceToClassFiles) {
       analysis.startSource(source)
@@ -193,6 +262,16 @@ private[sbt] object JavaAnalyze {
       typesInSource foreach {
         case (binaryClassName, binaryClassNameDeps) =>
           processDependencies(binaryClassNameDeps, DependencyByMemberRef, binaryClassName)
+          // sbt/zinc#148: also depend on the transitive ancestry of each referenced type (see above).
+          val ancestors = binaryClassNameDeps.iterator
+            .filterNot(isPlatformClass)
+            .flatMap(transitiveAncestors)
+            .toSet
+          processDependencies(
+            ancestors -- binaryClassNameDeps,
+            DependencyByMemberRef,
+            binaryClassName
+          )
       }
 
       def readInheritanceDependencies(classes: Seq[Class[?]]) = {

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/JavaAnalyze.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/JavaAnalyze.scala
@@ -116,13 +116,11 @@ private[sbt] object JavaAnalyze {
       sourceToClassFiles(source) += classFile
     }
 
-    // sbt/zinc#148: javac (since JDK 8) requires every transitive superclass and superinterface of a
-    // referenced type to be on the compile classpath, even though the referencing classfile's constant
-    // pool names only the referenced type itself. We record those ancestors as member-ref dependencies
-    // of the referencing class so the dependency graph reflects what javac actually needs — in
-    // particular for build tools that minimize the classpath from Zinc's analysis. Ancestors are read
-    // from classfile bytes (the already-parsed classfile for compiled classes, otherwise via the
-    // classloader) — never by loading the class — and memoized across the whole analysis.
+    // sbt/zinc#148: since JDK 8, javac requires every transitive superclass/superinterface of a
+    // referenced type on the classpath, even though the referencing classfile names only the type
+    // itself. We record that ancestry as member-ref deps of the referencing class, chiefly for
+    // build tools that minimize the classpath from Zinc's analysis. Parents are read from classfile
+    // bytes (never by loading the class) and memoized.
     val classFileByBinaryName: Map[String, ClassFile] =
       sourceToClassFiles.valuesIterator.flatten.map(cf => cf.className -> cf).toMap
     val resourceUrls = mutable.Map.empty[String, Option[URL]]
@@ -135,13 +133,11 @@ private[sbt] object JavaAnalyze {
         Option(loader.getResource(classNameToClassFile(binaryName)))
       )
 
-    // A "platform" class is always on the bootclasspath, so it never needs dependency tracking and its
-    // (deep) ancestry must not be walked. This is decided by ORIGIN, not by package name: many javax.*
-    // APIs (servlet, JAX-RS, JAXB, javax.annotation) ship as ordinary classpath jars and MUST stay
-    // tracked for build tools that minimize the classpath from Zinc's analysis (sbt/zinc#148). A class is
-    // platform iff its classfile is served from the JDK runtime image (`jrt:`); `java.*` is a reserved
-    // namespace (always the JDK), so we skip the lookup for it. Classes compiled in this run are never
-    // platform.
+    // Whether a class is "platform" (on the JDK runtime, so never tracked and not walked) is
+    // decided by ORIGIN, not package name: many javax.* APIs (servlet, JAX-RS, JAXB) ship as
+    // ordinary classpath jars and must stay tracked. A class is platform iff its classfile is
+    // served from the runtime image (`jrt:`); `java.*` is reserved (always the JDK) so we skip the
+    // lookup. Compiled classes are never platform.
     def isPlatformClass(binaryName: String): Boolean =
       binaryName.startsWith("java.") ||
         (!classFileByBinaryName.contains(binaryName) &&
@@ -164,8 +160,7 @@ private[sbt] object JavaAnalyze {
           )
         )
 
-    // Transitive super/interface closure of `binaryName`, excluding `binaryName` itself and the
-    // JDK/platform classes that are always on the bootclasspath (so never need tracking).
+    // Transitive super/interface closure of `binaryName`, excluding itself and platform classes.
     def transitiveAncestors(binaryName: String): Set[String] =
       transitiveAncestorsCache.getOrElseUpdate(
         binaryName, {

--- a/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/AnalyzeSpecification.scala
+++ b/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/AnalyzeSpecification.scala
@@ -310,10 +310,8 @@ class AnalyzeSpecification extends UnitSpec {
     }
   }
 
-  // sbt/zinc#148: JDK8+ javac requires every transitive superclass and superinterface of a referenced
-  // type on the compile classpath, even though the referencing classfile names only the type itself.
-  // JavaAnalyze records that ancestry as member-ref deps of the referencing class, so `Test` (which only
-  // calls `Foo.other()`) depends on Foo AND on Base/IFoo/IBase.
+  // sbt/zinc#148: Test only names Foo, but javac needs Foo's whole ancestry present, so it is
+  // recorded as member-ref deps of Test.
   "Analyze" should "record the transitive ancestry of a member-referenced type (sbt/zinc#148)" in {
     val srcIBase = "public interface IBase { void base(); }\n"
     val srcIFoo = "public interface IFoo extends IBase { void foo(); }\n"
@@ -339,8 +337,7 @@ class AnalyzeSpecification extends UnitSpec {
       "Test.java" -> srcTest,
     )
 
-    // Test depends on Foo and its full transitive ancestry by member-ref (the #148 fix), recorded as
-    // member-ref (not inheritance) since Test references Foo without inheriting from it.
+    // Recorded as member-ref, not inheritance: Test uses Foo without inheriting from it.
     assert(deps.memberRef("Test") === Set("Foo", "Base", "IFoo", "IBase"))
     assert(deps.inheritance("Test") === Set.empty)
 
@@ -350,9 +347,8 @@ class AnalyzeSpecification extends UnitSpec {
     assert(deps.inheritance("IFoo") === Set("IBase"))
   }
 
-  // sbt/zinc#148: the transitive ancestry of a referenced *library* type (resolved from the classpath,
-  // not compiled here) is recorded too — as binary member-ref deps — which is what classpath-minimizing
-  // build tools need. JDK ancestors are not walked (they are always on the bootclasspath).
+  // sbt/zinc#148: the ancestry of a referenced classpath (library) type is recorded too, as
+  // binary deps.
   "Analyze" should "record transitive ancestry of a referenced classpath type as binary deps (sbt/zinc#148)" in {
     IO.withTemporaryDirectory { temp =>
       val classesDir = new File(temp, "classes")
@@ -391,16 +387,15 @@ class AnalyzeSpecification extends UnitSpec {
     }
   }
 
-  // sbt/zinc#148: "platform" must be decided by origin, not package name. Many javax.* APIs (servlet,
-  // JAX-RS, JAXB, javax.annotation) are ordinary classpath jars, so their ancestors must still be
-  // tracked — a package-prefix filter that drops javax.* would re-introduce the very #148 miss.
+  // sbt/zinc#148 regression: javax.* ancestors are ordinary classpath jars, so origin-based (not
+  // package-prefix) platform detection must keep tracking them.
   "Analyze" should "track a javax.* ancestor served from the classpath, not the JDK (sbt/zinc#148)" in {
     IO.withTemporaryDirectory { temp =>
       val classesDir = new File(temp, "classes")
       classesDir.mkdir()
 
-      // A user class in a javax.* package (allowed; only java.* is a reserved namespace) — i.e. exactly
-      // the shape of a servlet/JAX-RS base class shipped as a normal dependency jar.
+      // A user class in a javax.* package (only java.* is reserved) — like a servlet base in a
+      // dependency jar.
       val base = new File(temp, "Base.java")
       IO.write(base, "package javax.foo; public class Base {}")
       val foo = new File(temp, "Foo.java")

--- a/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/AnalyzeSpecification.scala
+++ b/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/AnalyzeSpecification.scala
@@ -310,4 +310,113 @@ class AnalyzeSpecification extends UnitSpec {
     }
   }
 
+  // sbt/zinc#148: JDK8+ javac requires every transitive superclass and superinterface of a referenced
+  // type on the compile classpath, even though the referencing classfile names only the type itself.
+  // JavaAnalyze records that ancestry as member-ref deps of the referencing class, so `Test` (which only
+  // calls `Foo.other()`) depends on Foo AND on Base/IFoo/IBase.
+  "Analyze" should "record the transitive ancestry of a member-referenced type (sbt/zinc#148)" in {
+    val srcIBase = "public interface IBase { void base(); }\n"
+    val srcIFoo = "public interface IFoo extends IBase { void foo(); }\n"
+    val srcBase = "public abstract class Base implements IFoo {}\n"
+    val srcFoo =
+      """|public class Foo extends Base {
+         |  public void base() {}
+         |  public void foo() {}
+         |  public void other() {}
+         |}
+         |""".stripMargin
+    val srcTest =
+      """|public class Test {
+         |  void m(Foo f) { f.other(); }
+         |}
+         |""".stripMargin
+
+    val deps = JavaCompilerForUnitTesting.extractDependenciesFromSrcs(
+      "IBase.java" -> srcIBase,
+      "IFoo.java" -> srcIFoo,
+      "Base.java" -> srcBase,
+      "Foo.java" -> srcFoo,
+      "Test.java" -> srcTest,
+    )
+
+    // Test depends on Foo and its full transitive ancestry by member-ref (the #148 fix), recorded as
+    // member-ref (not inheritance) since Test references Foo without inheriting from it.
+    assert(deps.memberRef("Test") === Set("Foo", "Base", "IFoo", "IBase"))
+    assert(deps.inheritance("Test") === Set.empty)
+
+    // The hierarchy is also still tracked as direct-parent inheritance edges on each owner.
+    assert(deps.inheritance("Foo") === Set("Base"))
+    assert(deps.inheritance("Base") === Set("IFoo"))
+    assert(deps.inheritance("IFoo") === Set("IBase"))
+  }
+
+  // sbt/zinc#148: the transitive ancestry of a referenced *library* type (resolved from the classpath,
+  // not compiled here) is recorded too — as binary member-ref deps — which is what classpath-minimizing
+  // build tools need. JDK ancestors are not walked (they are always on the bootclasspath).
+  "Analyze" should "record transitive ancestry of a referenced classpath type as binary deps (sbt/zinc#148)" in {
+    IO.withTemporaryDirectory { temp =>
+      val classesDir = new File(temp, "classes")
+      classesDir.mkdir()
+
+      val libIface = new File(temp, "LibIface.java")
+      IO.write(libIface, "package pkg; public interface LibIface {}")
+      val libBase = new File(temp, "LibBase.java")
+      IO.write(libBase, "package pkg; public abstract class LibBase {}")
+      val lib = new File(temp, "Lib.java")
+      IO.write(
+        lib,
+        "package pkg; public class Lib extends LibBase implements LibIface { public void hello() {} }"
+      )
+      val client = new File(temp, "Client.java")
+      IO.write(client, "public class Client { void m(pkg.Lib x) { x.hello(); } }")
+
+      // Compile the library and the client together, then analyze ONLY Client — so the library types
+      // are resolved as classpath classfiles (via the classloader), exactly like a real dependency jar.
+      JavaCompilerForUnitTesting.compileJava(
+        Seq(libIface, libBase, lib, client),
+        classesDir,
+        Seq.empty
+      )
+      val callback = JavaCompilerForUnitTesting.analyze(classesDir, Seq(client))
+
+      def hasBinaryMemberRef(on: String): Boolean =
+        callback.binaryDependencies.exists {
+          case (_, onName, fromName, ctx) =>
+            onName == on && fromName == "Client" && ctx == DependencyByMemberRef
+        }
+
+      assert(hasBinaryMemberRef("pkg.Lib")) // the directly referenced type
+      assert(hasBinaryMemberRef("pkg.LibBase")) // transitive superclass
+      assert(hasBinaryMemberRef("pkg.LibIface")) // transitive interface
+    }
+  }
+
+  // sbt/zinc#148: "platform" must be decided by origin, not package name. Many javax.* APIs (servlet,
+  // JAX-RS, JAXB, javax.annotation) are ordinary classpath jars, so their ancestors must still be
+  // tracked — a package-prefix filter that drops javax.* would re-introduce the very #148 miss.
+  "Analyze" should "track a javax.* ancestor served from the classpath, not the JDK (sbt/zinc#148)" in {
+    IO.withTemporaryDirectory { temp =>
+      val classesDir = new File(temp, "classes")
+      classesDir.mkdir()
+
+      // A user class in a javax.* package (allowed; only java.* is a reserved namespace) — i.e. exactly
+      // the shape of a servlet/JAX-RS base class shipped as a normal dependency jar.
+      val base = new File(temp, "Base.java")
+      IO.write(base, "package javax.foo; public class Base {}")
+      val foo = new File(temp, "Foo.java")
+      IO.write(foo, "public class Foo extends javax.foo.Base { public void hi() {} }")
+      val client = new File(temp, "Client.java")
+      IO.write(client, "public class Client { void m(Foo f) { f.hi(); } }")
+
+      JavaCompilerForUnitTesting.compileJava(Seq(base, foo, client), classesDir, Seq.empty)
+      val callback = JavaCompilerForUnitTesting.analyze(classesDir, Seq(client))
+
+      // javax.foo.Base resolves to a classpath classfile (not `jrt:`), so the ancestry walk records it.
+      assert(callback.binaryDependencies.exists {
+        case (_, onName, fromName, ctx) =>
+          onName == "javax.foo.Base" && fromName == "Client" && ctx == DependencyByMemberRef
+      })
+    }
+  }
+
 }


### PR DESCRIPTION
Fixes #148. Since JDK 8, `javac` needs every transitive super/interface of a referenced type on the classpath, even when the source never names it. `JavaAnalyze` recorded only the direct member-ref (`Test → Foo`), not `Foo`'s ancestors — so classpath-minimizing build tools (strict/direct-deps) can drop them and hit the `javac` failure. (Invisible under normal sbt, where the full output is always on the classpath.)

**Change:** `JavaAnalyze` now records each member-referenced type's transitive super/interface closure as member-ref deps of the referencer. Parents are read from classfile bytes (no class loading), memoized; the walk stops at JDK classes by origin (`jrt:`), so external `javax.*` jars stay tracked.

**Scope:** javac-only (`JavaAnalyze`) path; the scalac `-Ypickle-java` path is a follow-up.

**Tests:** new `AnalyzeSpecification` cases (project, classpath, and classpath-`javax.*` ancestors); existing exact inner-class test unchanged; Java invalidation scripted tests pass (no over-invalidation).
