### PR TITLE
[2.x] Split classfile access-flag tables by JVMS context; separate FieldInfo / MethodInfo

### DIFF
--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
@@ -14,11 +14,10 @@ package internal
 package inc
 
 import java.io.{ ByteArrayInputStream, DataInputStream }
-import java.lang.reflect.Modifier
 import scala.collection.mutable.ArrayBuffer
 import xsbti.api
 import xsbti.api.SafeLazyProxy
-import sbt.internal.inc.classfile.{ AttributeInfo, ClassFile, FieldOrMethodInfo }
+import sbt.internal.inc.classfile.{ AttributeInfo, ClassFile, FieldInfo, MethodInfo }
 import sbt.util.Logger
 
 /**
@@ -133,7 +132,7 @@ object ClassfileToAPI {
     val enclPkg = ClassToAPI.packageAndName(cf.className)._1
     val mods = ClassToAPI.modifiers(cf.accessFlags)
     val acc = ClassToAPI.access(cf.accessFlags, enclPkg)
-    val isInterface = Modifier.isInterface(cf.accessFlags)
+    val isInterface = cf.isInterface
     val tpe = if (isInterface) Trait else ClassDef
     // Top-level unless the classfile's InnerClasses attribute lists itself as a member of another.
     val topLevel =
@@ -198,7 +197,7 @@ object ClassfileToAPI {
   /** (isStatic, FieldLike) for a classfile field. */
   private def fieldDef(
       cf: ClassFile,
-      f: FieldOrMethodInfo,
+      f: FieldInfo,
       enclPkg: Option[String]
   ): (Boolean, api.ClassDefinition) = {
     val name = f.name.getOrElse("")
@@ -230,7 +229,7 @@ object ClassfileToAPI {
   /** (isStatic, Def) for a classfile method; `<init>` is named like [[ClassToAPI]]'s constructors. */
   private def methodDef(
       cf: ClassFile,
-      m: FieldOrMethodInfo,
+      m: MethodInfo,
       binaryName: String,
       enclPkg: Option[String]
   ): (Boolean, api.ClassDefinition) = {

--- a/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/ClassfileToAPISpecification.scala
+++ b/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/ClassfileToAPISpecification.scala
@@ -130,6 +130,29 @@ class ClassfileToAPISpecification extends UnitSpec {
     }
   }
 
+  // Covers the `cf.isInterface` switch in ClassfileToAPI (replacing the previous
+  // `Modifier.isInterface(cf.accessFlags)`). The ClassDef vs Trait distinction is what
+  // makes name-hashing track interface implementations correctly.
+  it should "tag an interface input as DefinitionType.Trait, not ClassDef" in {
+    IO.withTemporaryDirectory { temp =>
+      val src = new File(temp, "IFace.java")
+      IO.write(src, "public interface IFace { int answer(); }")
+      JavaCompilerForUnitTesting.compileJava(Seq(src), temp, Seq.empty)
+      val cf = Parser(new File(temp, "IFace.class").toPath, Logger.Null)
+      assert(cf.isInterface, "precondition: fixture is an interface at the classfile level")
+
+      val (apis, _) = ClassfileToAPI.process(Seq("IFace" -> cf))
+      val ifaceApi = apis
+        .find(a => a.name == "IFace" && a.definitionType == DefinitionType.Trait)
+        .getOrElse {
+          fail(s"IFace not recorded as Trait: ${apis.map(a => a.name -> a.definitionType).toSeq}")
+        }
+      // The trait should still expose the abstract method.
+      val defs = ifaceApi.structure.declared.collect { case d: xsbti.api.Def => d.name }.toSet
+      assert(defs.contains("answer"))
+    }
+  }
+
   // The fallback runs only for classes that already failed to load, so it must never throw on an
   // odd/truncated descriptor and turn a gracefully-skipped class into a compile failure.
   it should "degrade gracefully on malformed or truncated descriptors instead of throwing" in {

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/ClassFile.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/ClassFile.scala
@@ -24,13 +24,24 @@ private[sbt] trait ClassFile {
   val interfaceNames: Array[String]
   val accessFlags: Int
   val constantPool: Array[Constant]
-  val fields: Array[FieldOrMethodInfo]
-  val methods: Array[FieldOrMethodInfo]
+  val fields: Array[FieldInfo]
+  val methods: Array[MethodInfo]
   val attributes: Array[AttributeInfo]
   def sourceFile: Option[String]
   def innerClasses: Array[InnerClassInfo]
   def types: Set[String]
   def stringValue(a: AttributeInfo): String
+
+  // ----- Class-level access flag predicates -----
+  // JVMS Table 4.1-A:
+  // https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.1-200-E.1
+  def isPublic = (accessFlags & ClassAccessFlags.ACC_PUBLIC) != 0
+  def isFinal = (accessFlags & ClassAccessFlags.ACC_FINAL) != 0
+  def isInterface = (accessFlags & ClassAccessFlags.ACC_INTERFACE) != 0
+  def isAbstract = (accessFlags & ClassAccessFlags.ACC_ABSTRACT) != 0
+  def isSynthetic = (accessFlags & ClassAccessFlags.ACC_SYNTHETIC) != 0
+  def isAnnotation = (accessFlags & ClassAccessFlags.ACC_ANNOTATION) != 0
+  def isEnum = (accessFlags & ClassAccessFlags.ACC_ENUM) != 0
 
   /**
    * If the given fieldName represents a ConstantValue field, parses its representation from
@@ -82,18 +93,61 @@ private[sbt] final case class Constant(
   override def hashCode: Int =
     37 * (37 * (37 * (37 * (17 + tag.##) + nameIndex.##) + typeIndex.##) + value.##)
 }
-private[sbt] final case class FieldOrMethodInfo(
+
+/**
+ * A field entry in a classfile. Predicates read [[FieldAccessFlags]].
+ * JVMS Table 4.5-A:
+ * https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.5-200-A.1
+ */
+private[sbt] final case class FieldInfo(
     accessFlags: Int,
     name: Option[String],
     descriptor: Option[String],
     attributes: IndexedSeq[AttributeInfo]
 ) {
-  def isStatic = (accessFlags & ACC_STATIC) == ACC_STATIC
-  def isPublic = (accessFlags & ACC_PUBLIC) == ACC_PUBLIC
+  def isPublic = (accessFlags & FieldAccessFlags.ACC_PUBLIC) != 0
+  def isPrivate = (accessFlags & FieldAccessFlags.ACC_PRIVATE) != 0
+  def isProtected = (accessFlags & FieldAccessFlags.ACC_PROTECTED) != 0
+  def isStatic = (accessFlags & FieldAccessFlags.ACC_STATIC) != 0
+  def isFinal = (accessFlags & FieldAccessFlags.ACC_FINAL) != 0
+  def isVolatile = (accessFlags & FieldAccessFlags.ACC_VOLATILE) != 0
+  def isTransient = (accessFlags & FieldAccessFlags.ACC_TRANSIENT) != 0
+  def isSynthetic = (accessFlags & FieldAccessFlags.ACC_SYNTHETIC) != 0
+  def isEnum = (accessFlags & FieldAccessFlags.ACC_ENUM) != 0
+}
+
+/**
+ * A method entry in a classfile. Predicates read [[MethodAccessFlags]].
+ * JVMS Table 4.6-A:
+ * https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.6-200-A.1
+ */
+private[sbt] final case class MethodInfo(
+    accessFlags: Int,
+    name: Option[String],
+    descriptor: Option[String],
+    attributes: IndexedSeq[AttributeInfo]
+) {
+  def isPublic = (accessFlags & MethodAccessFlags.ACC_PUBLIC) != 0
+  def isPrivate = (accessFlags & MethodAccessFlags.ACC_PRIVATE) != 0
+  def isProtected = (accessFlags & MethodAccessFlags.ACC_PROTECTED) != 0
+  def isStatic = (accessFlags & MethodAccessFlags.ACC_STATIC) != 0
+  def isFinal = (accessFlags & MethodAccessFlags.ACC_FINAL) != 0
+  def isSynchronized = (accessFlags & MethodAccessFlags.ACC_SYNCHRONIZED) != 0
+  def isBridge = (accessFlags & MethodAccessFlags.ACC_BRIDGE) != 0
+  def isVarArgs = (accessFlags & MethodAccessFlags.ACC_VARARGS) != 0
+  def isNative = (accessFlags & MethodAccessFlags.ACC_NATIVE) != 0
+  def isAbstract = (accessFlags & MethodAccessFlags.ACC_ABSTRACT) != 0
+  def isStrict = (accessFlags & MethodAccessFlags.ACC_STRICT) != 0
+  def isSynthetic = (accessFlags & MethodAccessFlags.ACC_SYNTHETIC) != 0
+
+  // Name-based — safe by construction.
+  def isConstructor = name.exists(_ == "<init>")
+  def isStaticInit = name.exists(_ == "<clinit>")
   def isMain =
     isPublic && isStatic && name.contains("main") &&
       descriptor.exists(_ == "([Ljava/lang/String;)V")
 }
+
 private[sbt] final case class AttributeInfo(name: Option[String], value: Array[Byte]) {
   def isNamed(s: String) = name.exists(s == _)
   def isSignature = isNamed("Signature")
@@ -109,19 +163,98 @@ private[sbt] final case class AttributeInfo(name: Option[String], value: Array[B
   def isRuntimeInvisibleTypeAnnotations = isNamed("RuntimeInvisibleTypeAnnotations")
   def isAnnotationDefault = isNamed("AnnotationDefault")
 }
+
+/**
+ * An entry in a classfile's `InnerClasses` attribute. Predicates read
+ * [[InnerClassAccessFlags]]. JVMS Table 4.7.6-A:
+ * https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.7.6-300-D.2-5
+ */
 private[sbt] final case class InnerClassInfo(
     accessFlags: Int,
     innerName: Option[String],
     innerClassName: String,
     outerClassName: String
 ) {
-  def isStatic = (accessFlags & ACC_STATIC) == ACC_STATIC
-  def isPublic = (accessFlags & ACC_PUBLIC) == ACC_PUBLIC
+  def isPublic = (accessFlags & InnerClassAccessFlags.ACC_PUBLIC) != 0
+  def isPrivate = (accessFlags & InnerClassAccessFlags.ACC_PRIVATE) != 0
+  def isProtected = (accessFlags & InnerClassAccessFlags.ACC_PROTECTED) != 0
+  def isStatic = (accessFlags & InnerClassAccessFlags.ACC_STATIC) != 0
+  def isFinal = (accessFlags & InnerClassAccessFlags.ACC_FINAL) != 0
+  def isInterface = (accessFlags & InnerClassAccessFlags.ACC_INTERFACE) != 0
+  def isAbstract = (accessFlags & InnerClassAccessFlags.ACC_ABSTRACT) != 0
+  def isSynthetic = (accessFlags & InnerClassAccessFlags.ACC_SYNTHETIC) != 0
+  def isAnnotation = (accessFlags & InnerClassAccessFlags.ACC_ANNOTATION) != 0
+  def isEnum = (accessFlags & InnerClassAccessFlags.ACC_ENUM) != 0
 }
-private[sbt] object Constants {
-  final val ACC_STATIC = 0x0008
-  final val ACC_PUBLIC = 0x0001
 
+/**
+ * Class access and property flags. JVMS §4.1, Table 4.1-A.
+ * https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.1-200-E.1
+ */
+private[sbt] object ClassAccessFlags {
+  final val ACC_PUBLIC = 0x0001
+  final val ACC_FINAL = 0x0010
+  final val ACC_SUPER = 0x0020
+  final val ACC_INTERFACE = 0x0200
+  final val ACC_ABSTRACT = 0x0400
+  final val ACC_SYNTHETIC = 0x1000
+  final val ACC_ANNOTATION = 0x2000
+  final val ACC_ENUM = 0x4000
+}
+
+/**
+ * Field access and property flags. JVMS §4.5, Table 4.5-A.
+ * https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.5-200-A.1
+ */
+private[sbt] object FieldAccessFlags {
+  final val ACC_PUBLIC = 0x0001
+  final val ACC_PRIVATE = 0x0002
+  final val ACC_PROTECTED = 0x0004
+  final val ACC_STATIC = 0x0008
+  final val ACC_FINAL = 0x0010
+  final val ACC_VOLATILE = 0x0040
+  final val ACC_TRANSIENT = 0x0080
+  final val ACC_SYNTHETIC = 0x1000
+  final val ACC_ENUM = 0x4000
+}
+
+/**
+ * Method access and property flags. JVMS §4.6, Table 4.6-A.
+ * https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.6-200-A.1
+ */
+private[sbt] object MethodAccessFlags {
+  final val ACC_PUBLIC = 0x0001
+  final val ACC_PRIVATE = 0x0002
+  final val ACC_PROTECTED = 0x0004
+  final val ACC_STATIC = 0x0008
+  final val ACC_FINAL = 0x0010
+  final val ACC_SYNCHRONIZED = 0x0020
+  final val ACC_BRIDGE = 0x0040
+  final val ACC_VARARGS = 0x0080
+  final val ACC_NATIVE = 0x0100
+  final val ACC_ABSTRACT = 0x0400
+  final val ACC_STRICT = 0x0800
+  final val ACC_SYNTHETIC = 0x1000
+}
+
+/**
+ * Inner class access and property flags. JVMS §4.7.6, Table 4.7.6-A.
+ * https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.7.6-300-D.2-5
+ */
+private[sbt] object InnerClassAccessFlags {
+  final val ACC_PUBLIC = 0x0001
+  final val ACC_PRIVATE = 0x0002
+  final val ACC_PROTECTED = 0x0004
+  final val ACC_STATIC = 0x0008
+  final val ACC_FINAL = 0x0010
+  final val ACC_INTERFACE = 0x0200
+  final val ACC_ABSTRACT = 0x0400
+  final val ACC_SYNTHETIC = 0x1000
+  final val ACC_ANNOTATION = 0x2000
+  final val ACC_ENUM = 0x4000
+}
+
+private[sbt] object Constants {
   final val JavaMagic = 0xcafebabe
   final val ConstantUTF8 = 1
   final val ConstantUnicode = 2

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Parser.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/Parser.scala
@@ -76,8 +76,8 @@ private[sbt] object Parser {
       val interfaceNames =
         array(in.readUnsignedShort())(getClassConstantName(in.readUnsignedShort()))
 
-      val fields = readFieldsOrMethods()
-      val methods = readFieldsOrMethods()
+      val fields = array(in.readUnsignedShort())(parseField())
+      val methods = array(in.readUnsignedShort())(parseMethod())
 
       val attributes = array(in.readUnsignedShort())(parseAttribute())
 
@@ -114,7 +114,6 @@ private[sbt] object Parser {
 
       def stringValue(a: AttributeInfo) = toUTF8(entryIndex(a))
 
-      private def readFieldsOrMethods() = array(in.readUnsignedShort())(parseFieldOrMethodInfo())
       private def toUTF8(entryIndex: Int) = {
         val entry = constantPool(entryIndex)
         assume(entry.tag == ConstantUTF8, "Constant pool entry is not a UTF8 type: " + entryIndex)
@@ -129,8 +128,15 @@ private[sbt] object Parser {
         if (index <= 0) None
         else Some(toUTF8(index))
       }
-      private def parseFieldOrMethodInfo() =
-        FieldOrMethodInfo(
+      private def parseField(): FieldInfo =
+        FieldInfo(
+          in.readUnsignedShort(),
+          toString(in.readUnsignedShort()),
+          toString(in.readUnsignedShort()),
+          array(in.readUnsignedShort())(parseAttribute()).toIndexedSeq
+        )
+      private def parseMethod(): MethodInfo =
+        MethodInfo(
           in.readUnsignedShort(),
           toString(in.readUnsignedShort()),
           toString(in.readUnsignedShort()),
@@ -162,13 +168,8 @@ private[sbt] object Parser {
         (classConstantReferences ++ fieldTypes ++ methodTypes ++ annotationsReferencesCarefully).toSet
       }
 
-      private def getTypes(fieldsOrMethods: Array[FieldOrMethodInfo]) =
-        fieldsOrMethods.flatMap { fieldOrMethod =>
-          descriptorToTypes(fieldOrMethod.descriptor)
-        }
-
-      private def fieldTypes = getTypes(fields)
-      private def methodTypes = getTypes(methods)
+      private def fieldTypes = fields.flatMap(f => descriptorToTypes(f.descriptor))
+      private def methodTypes = methods.flatMap(m => descriptorToTypes(m.descriptor))
 
       private def annotationsReferences: List[String] = {
         // Annotation metadata lives in several attribute kinds, some nested: type annotations on

--- a/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/ParserSpecification.scala
+++ b/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/ParserSpecification.scala
@@ -64,4 +64,471 @@ class ParserSpecification extends UnitSpec {
     assert(entry.get.isPublic)
   }
 
+  // --- FieldInfo / MethodInfo predicate coverage ---
+  //
+  // We compile a single inline fixture rather than reaching for JDK classes, so the
+  // predicates aren't subject to JDK-version-dependent shapes (e.g. method finality on
+  // java.lang.Object changes between versions).
+
+  private val PredicateFixtureSrc =
+    """|public abstract class PredicateFixture {
+       |  static int initialized;
+       |  static { initialized = compute(); }   // forces <clinit>
+       |  private static int compute() { return 42; }
+       |
+       |  private String secretField;           // ACC_PRIVATE
+       |  protected int protectedField;         // ACC_PROTECTED
+       |  public final String finalField = "x"; // ACC_FINAL
+       |  public static final int CONSTANT = 7; // ACC_STATIC | ACC_FINAL | ACC_PUBLIC
+       |
+       |  public PredicateFixture() {}          // <init>
+       |
+       |  public abstract int abstractMethod(); // ACC_ABSTRACT
+       |  public final void finalMethod() {}    // ACC_FINAL
+       |  public void varargsMethod(String... args) {}  // ACC_VARARGS
+       |  private void privateMethod() {}       // ACC_PRIVATE
+       |  protected void protectedMethod() {}   // ACC_PROTECTED
+       |}
+       |""".stripMargin
+
+  private val BridgeFixtureSrc =
+    """|abstract class GenericBase<T> {
+       |  public T value() { return null; }
+       |}
+       |""".stripMargin
+
+  private val BridgeSubclassSrc =
+    """|public class GenericSub extends GenericBase<String> {
+       |  @Override public String value() { return "x"; }  // bridge + synthetic generated
+       |}
+       |""".stripMargin
+
+  private def withFixture[T](
+      srcs: (String, String)*
+  )(f: Map[String, ClassFile] => T): T = {
+    sbt.io.IO.withTemporaryDirectory { temp =>
+      val files = srcs.map { case (name, src) =>
+        val file = new java.io.File(temp, name)
+        sbt.io.IO.write(file, src)
+        file
+      }
+      val outDir = new java.io.File(temp, "out")
+      outDir.mkdir()
+      JavaCompilerForUnitTesting.compileJava(files, outDir, Seq.empty)
+      val logger = ConsoleLogger()
+      val byClass = (sbt.io.PathFinder(outDir) ** "*.class").get().iterator.map { f =>
+        val cf = Parser(f.toPath, logger)
+        cf.className -> cf
+      }.toMap
+      f(byClass)
+    }
+  }
+
+  it should "detect ACC_PRIVATE on a private method and field" in {
+    withFixture("PredicateFixture.java" -> PredicateFixtureSrc) { cfs =>
+      val cf = cfs("PredicateFixture")
+      val priv =
+        cf.methods.find(_.name.contains("privateMethod")).getOrElse(fail("no privateMethod"))
+      assert(priv.isPrivate)
+      assert(!priv.isPublic && !priv.isProtected)
+      val secret = cf.fields.find(_.name.contains("secretField")).getOrElse(fail("no secretField"))
+      assert(secret.isPrivate)
+    }
+  }
+
+  it should "detect ACC_PROTECTED on a protected method and field" in {
+    withFixture("PredicateFixture.java" -> PredicateFixtureSrc) { cfs =>
+      val cf = cfs("PredicateFixture")
+      val prot = cf.methods
+        .find(_.name.contains("protectedMethod"))
+        .getOrElse(fail("no protectedMethod"))
+      assert(prot.isProtected)
+      assert(!prot.isPublic && !prot.isPrivate)
+      val field = cf.fields
+        .find(_.name.contains("protectedField"))
+        .getOrElse(fail("no protectedField"))
+      assert(field.isProtected)
+    }
+  }
+
+  it should "detect ACC_FINAL on a final method and field" in {
+    withFixture("PredicateFixture.java" -> PredicateFixtureSrc) { cfs =>
+      val cf = cfs("PredicateFixture")
+      val fm = cf.methods.find(_.name.contains("finalMethod")).getOrElse(fail("no finalMethod"))
+      assert(fm.isFinal)
+      val ff = cf.fields.find(_.name.contains("finalField")).getOrElse(fail("no finalField"))
+      assert(ff.isFinal)
+    }
+  }
+
+  it should "detect ACC_ABSTRACT on an abstract method" in {
+    withFixture("PredicateFixture.java" -> PredicateFixtureSrc) { cfs =>
+      val cf = cfs("PredicateFixture")
+      val am = cf.methods
+        .find(_.name.contains("abstractMethod"))
+        .getOrElse(fail("no abstractMethod"))
+      assert(am.isAbstract)
+    }
+  }
+
+  it should "detect ACC_VARARGS on a varargs method" in {
+    withFixture("PredicateFixture.java" -> PredicateFixtureSrc) { cfs =>
+      val cf = cfs("PredicateFixture")
+      val vm = cf.methods
+        .find(_.name.contains("varargsMethod"))
+        .getOrElse(fail("no varargsMethod"))
+      assert(vm.isVarArgs)
+      // Descriptor still encodes the last param as an array; ACC_VARARGS is the
+      // only signal that this is a Java varargs.
+      assert(vm.descriptor.exists(_.endsWith(")V")))
+    }
+  }
+
+  it should "detect isConstructor on <init>" in {
+    withFixture("PredicateFixture.java" -> PredicateFixtureSrc) { cfs =>
+      val cf = cfs("PredicateFixture")
+      val ctor = cf.methods.find(_.isConstructor).getOrElse(fail("no <init>"))
+      assert(ctor.name.contains("<init>"))
+      assert(!ctor.isStaticInit)
+    }
+  }
+
+  it should "detect isStaticInit on <clinit>" in {
+    withFixture("PredicateFixture.java" -> PredicateFixtureSrc) { cfs =>
+      val cf = cfs("PredicateFixture")
+      val clinit = cf.methods.find(_.isStaticInit).getOrElse {
+        fail("no <clinit> — static block didn't produce one?")
+      }
+      assert(clinit.name.contains("<clinit>"))
+      assert(clinit.isStatic)
+      assert(!clinit.isConstructor)
+    }
+  }
+
+  it should "detect ACC_BRIDGE and ACC_SYNTHETIC on a generic-erasure bridge" in {
+    withFixture(
+      "GenericBase.java" -> BridgeFixtureSrc,
+      "GenericSub.java" -> BridgeSubclassSrc
+    ) { cfs =>
+      val sub = cfs("GenericSub")
+      // The real override returns String; javac generates a bridge that returns Object
+      // and forwards to it. Both are named `value`.
+      val values = sub.methods.filter(_.name.contains("value"))
+      assert(values.length === 2, s"expected 2 `value` methods (real + bridge), got $values")
+      val bridge = values.find(_.isBridge).getOrElse(fail(s"no bridge in $values"))
+      assert(bridge.isSynthetic)
+      assert(
+        bridge.descriptor.exists(_.endsWith("Ljava/lang/Object;")),
+        s"bridge return should be erased to Object: ${bridge.descriptor}"
+      )
+      val real = values.find(!_.isBridge).getOrElse(fail("no non-bridge"))
+      assert(!real.isSynthetic)
+      assert(
+        real.descriptor.exists(_.endsWith("Ljava/lang/String;")),
+        s"real method return should be String: ${real.descriptor}"
+      )
+    }
+  }
+
+  it should "report combined modifiers on a public static final field" in {
+    withFixture("PredicateFixture.java" -> PredicateFixtureSrc) { cfs =>
+      val cf = cfs("PredicateFixture")
+      val c = cf.fields.find(_.name.contains("CONSTANT")).getOrElse(fail("no CONSTANT"))
+      assert(c.isPublic && c.isStatic && c.isFinal)
+      assert(!c.isPrivate && !c.isProtected)
+    }
+  }
+
+  // --- FieldInfo-only predicates (FieldAccessFlags) ---
+  //
+  // These predicates only exist on FieldInfo, not on MethodInfo, so the bits 0x0040
+  // (ACC_VOLATILE / ACC_BRIDGE) and 0x0080 (ACC_TRANSIENT / ACC_VARARGS) can never be
+  // misread by calling the wrong predicate.
+
+  private val FieldOnlyFixtureSrc =
+    """|public class FieldOnlyFixture {
+       |  public volatile int volatileField;
+       |  public transient int transientField;
+       |}
+       |""".stripMargin
+
+  private val EnumFixtureSrc =
+    """|public enum EnumFixture { ONE, TWO }
+       |""".stripMargin
+
+  it should "detect ACC_VOLATILE on a volatile field" in {
+    withFixture("FieldOnlyFixture.java" -> FieldOnlyFixtureSrc) { cfs =>
+      val cf = cfs("FieldOnlyFixture")
+      val vol =
+        cf.fields.find(_.name.contains("volatileField")).getOrElse(fail("no volatileField"))
+      assert(vol.isVolatile)
+      assert(!vol.isTransient && !vol.isEnum)
+    }
+  }
+
+  it should "detect ACC_TRANSIENT on a transient field" in {
+    withFixture("FieldOnlyFixture.java" -> FieldOnlyFixtureSrc) { cfs =>
+      val cf = cfs("FieldOnlyFixture")
+      val tr =
+        cf.fields.find(_.name.contains("transientField")).getOrElse(fail("no transientField"))
+      assert(tr.isTransient)
+      assert(!tr.isVolatile && !tr.isEnum)
+    }
+  }
+
+  it should "detect ACC_ENUM on enum constant fields" in {
+    withFixture("EnumFixture.java" -> EnumFixtureSrc) { cfs =>
+      val cf = cfs("EnumFixture")
+      val one = cf.fields.find(_.name.contains("ONE")).getOrElse(fail("no ONE"))
+      assert(one.isEnum)
+      assert(one.isStatic && one.isFinal && one.isPublic)
+      assert(!one.isVolatile && !one.isTransient)
+    }
+  }
+
+  // --- MethodInfo-only predicates (MethodAccessFlags) ---
+
+  private val SynchronizedFixtureSrc =
+    """|public class SynchronizedFixture {
+       |  public synchronized void sync() {}
+       |  public native void nativeMethod();
+       |}
+       |""".stripMargin
+
+  it should "detect ACC_SYNCHRONIZED on a synchronized method" in {
+    withFixture("SynchronizedFixture.java" -> SynchronizedFixtureSrc) { cfs =>
+      val cf = cfs("SynchronizedFixture")
+      val sync = cf.methods.find(_.name.contains("sync")).getOrElse(fail("no sync"))
+      assert(sync.isSynchronized)
+    }
+  }
+
+  it should "detect ACC_NATIVE on a native method" in {
+    withFixture("SynchronizedFixture.java" -> SynchronizedFixtureSrc) { cfs =>
+      val cf = cfs("SynchronizedFixture")
+      val nat = cf.methods.find(_.name.contains("nativeMethod")).getOrElse(fail("no nativeMethod"))
+      assert(nat.isNative)
+    }
+  }
+
+  // --- ClassFile class-level predicates (ClassAccessFlags) ---
+
+  it should "detect class-level ACC_PUBLIC, ACC_ABSTRACT on an abstract class" in {
+    withFixture("PredicateFixture.java" -> PredicateFixtureSrc) { cfs =>
+      val cf = cfs("PredicateFixture")
+      assert(cf.isPublic)
+      assert(cf.isAbstract)
+      assert(!cf.isInterface)
+      assert(!cf.isEnum)
+      assert(!cf.isAnnotation)
+    }
+  }
+
+  it should "detect class-level ACC_INTERFACE on an interface" in {
+    val src = "public interface InterfaceFixture { void m(); }"
+    withFixture("InterfaceFixture.java" -> src) { cfs =>
+      val cf = cfs("InterfaceFixture")
+      assert(cf.isInterface)
+      assert(cf.isAbstract) // interfaces are implicitly abstract in the classfile
+      assert(!cf.isAnnotation)
+      assert(!cf.isEnum)
+    }
+  }
+
+  it should "detect class-level ACC_ANNOTATION on an annotation type" in {
+    val src =
+      """|import java.lang.annotation.*;
+         |@Retention(RetentionPolicy.RUNTIME)
+         |public @interface AnnoFixture { String value() default ""; }
+         |""".stripMargin
+    withFixture("AnnoFixture.java" -> src) { cfs =>
+      val cf = cfs("AnnoFixture")
+      assert(cf.isAnnotation)
+      assert(cf.isInterface) // annotations are interfaces at the classfile level
+    }
+  }
+
+  it should "detect class-level ACC_ENUM on an enum class" in {
+    withFixture("EnumFixture.java" -> EnumFixtureSrc) { cfs =>
+      val cf = cfs("EnumFixture")
+      assert(cf.isEnum)
+      assert(cf.isPublic)
+      assert(cf.isFinal) // simple enums (no per-constant body) get ACC_FINAL
+    }
+  }
+
+  // --- InnerClassInfo extended predicates (InnerClassAccessFlags) ---
+
+  private val NestedFixtureSrc =
+    """|public class NestedFixture {
+       |  public static class StaticNested {}
+       |  private class PrivateInner {}
+       |  protected final class ProtectedFinalInner {}
+       |  public interface NestedInterface {}
+       |}
+       |""".stripMargin
+
+  it should "expose extended InnerClassInfo predicates" in {
+    withFixture("NestedFixture.java" -> NestedFixtureSrc) { cfs =>
+      val cf = cfs("NestedFixture")
+      val byName = cf.innerClasses.iterator.map(ic => ic.innerName.getOrElse("") -> ic).toMap
+
+      val staticNested = byName.getOrElse("StaticNested", fail("StaticNested not in InnerClasses"))
+      assert(staticNested.isStatic && staticNested.isPublic)
+
+      val privateInner = byName.getOrElse("PrivateInner", fail("PrivateInner not in InnerClasses"))
+      assert(privateInner.isPrivate)
+      assert(!privateInner.isStatic && !privateInner.isPublic && !privateInner.isProtected)
+
+      val protFinal =
+        byName.getOrElse("ProtectedFinalInner", fail("ProtectedFinalInner not in InnerClasses"))
+      assert(protFinal.isProtected && protFinal.isFinal)
+
+      val nestedIface =
+        byName.getOrElse("NestedInterface", fail("NestedInterface not in InnerClasses"))
+      assert(nestedIface.isInterface && nestedIface.isAbstract && nestedIface.isStatic)
+    }
+  }
+
+  // --- isMain (name + descriptor based) ---
+
+  it should "detect a main method via isMain" in {
+    // Three classes to exercise positive + negative paths together: the canonical main,
+    // a same-name overload with the wrong descriptor, and a method named main but on an
+    // instance (no static) — all separated into distinct classes since Java forbids
+    // overloads that differ only in `static` modifier or only in name/return-type combos.
+    val src =
+      """|public class MainFixture {
+         |  public static void main(String[] args) {}
+         |}
+         |class WrongDescriptor {
+         |  public static void main(int x) {}
+         |}
+         |class NotStatic {
+         |  public void main(String[] args) {}
+         |}
+         |""".stripMargin
+    withFixture("MainFixture.java" -> src) { cfs =>
+      val mainCf = cfs.getOrElse("MainFixture", fail(s"no MainFixture in ${cfs.keys}"))
+      val mains = mainCf.methods.filter(_.isMain)
+      assert(mains.length === 1, s"expected exactly one isMain match, got $mains")
+      val m = mains.head
+      assert(m.name.contains("main"))
+      assert(m.descriptor.contains("([Ljava/lang/String;)V"))
+      assert(m.isPublic && m.isStatic)
+
+      // Negative: a method named `main` with a different descriptor is not isMain.
+      val wrongDesc = cfs("WrongDescriptor")
+      val wrongDescMain = wrongDesc.methods.find(_.name.contains("main")).get
+      assert(!wrongDescMain.isMain)
+
+      // Negative: a method with the right name+descriptor but instance-level is not isMain.
+      val notStatic = cfs("NotStatic")
+      val instanceMain = notStatic.methods.find(_.name.contains("main")).get
+      assert(!instanceMain.isMain)
+    }
+  }
+
+  // --- InnerClassInfo: isAnnotation, isEnum ---
+
+  it should "detect ACC_ANNOTATION on a nested annotation type's InnerClasses entry" in {
+    val src =
+      """|public class NestedAnnoHost {
+         |  public @interface Nested { String value() default ""; }
+         |}
+         |""".stripMargin
+    withFixture("NestedAnnoHost.java" -> src) { cfs =>
+      val host = cfs("NestedAnnoHost")
+      val nested = host.innerClasses
+        .find(_.innerName.contains("Nested"))
+        .getOrElse(fail("Nested not in InnerClasses"))
+      assert(nested.isAnnotation)
+      assert(nested.isInterface) // annotations are interfaces
+      assert(nested.isStatic) // nested annotations are implicitly static
+    }
+  }
+
+  it should "detect ACC_ENUM on a nested enum's InnerClasses entry" in {
+    val src =
+      """|public class NestedEnumHost {
+         |  public enum Nested { A, B }
+         |}
+         |""".stripMargin
+    withFixture("NestedEnumHost.java" -> src) { cfs =>
+      val host = cfs("NestedEnumHost")
+      val nested = host.innerClasses
+        .find(_.innerName.contains("Nested"))
+        .getOrElse(fail("Nested not in InnerClasses"))
+      assert(nested.isEnum)
+      assert(nested.isStatic) // nested enums are implicitly static
+    }
+  }
+
+  // --- Synthetic markers ---
+  //
+  // For FieldInfo / cf (class-level), we have reliable javac triggers:
+  //   - Enum's auto-generated `$VALUES` static-final array is ACC_SYNTHETIC.
+  //   - `package-info.class` (compiled from package-info.java with a package
+  //     annotation) is ACC_INTERFACE | ACC_ABSTRACT | ACC_SYNTHETIC.
+  //
+  // For InnerClassInfo.isSynthetic and MethodInfo.isStrict, modern javac no
+  // longer emits these bits in source-compiled output — lambda capture moved to
+  // invokedynamic (no synthetic inner-class entries from javac), and JEP 306
+  // (Java 17) made strictfp implicit, so the bit is never set. Both still occur
+  // in bytecode produced by older javac or by bytecode rewriters (ASM, ProGuard,
+  // Mockito, etc.), so we still expose the predicates. The parser stores the
+  // raw access-flag int verbatim — the predicate's bit-mask is the only logic
+  // worth checking — so we exercise those via direct case-class construction.
+
+  it should "detect ACC_SYNTHETIC on a FieldInfo via enum's $VALUES" in {
+    val src = "public enum SyntheticFieldFixture { A, B }"
+    withFixture("SyntheticFieldFixture.java" -> src) { cfs =>
+      val cf = cfs("SyntheticFieldFixture")
+      val values = cf.fields.find(_.name.contains("$VALUES")).getOrElse {
+        fail(s"no $$VALUES in ${cf.fields.map(_.name).toSeq}")
+      }
+      assert(values.isSynthetic)
+      assert(values.isPrivate && values.isStatic && values.isFinal)
+    }
+  }
+
+  it should "detect class-level ACC_SYNTHETIC on a package-info classfile" in {
+    sbt.io.IO.withTemporaryDirectory { temp =>
+      val pkgDir = new java.io.File(temp, "annotated_pkg")
+      pkgDir.mkdir()
+      val src = new java.io.File(pkgDir, "package-info.java")
+      sbt.io.IO.write(src, "@Deprecated\npackage annotated_pkg;\n")
+      val outDir = new java.io.File(temp, "out")
+      outDir.mkdir()
+      JavaCompilerForUnitTesting.compileJava(Seq(src), outDir, Seq.empty)
+      val classFile =
+        (sbt.io.PathFinder(outDir) ** "package-info.class").get().headOption.getOrElse {
+          fail(s"package-info.class not produced under ${outDir.getAbsolutePath}")
+        }
+      val cf = Parser(classFile.toPath, ConsoleLogger())
+      assert(cf.isSynthetic, "package-info should be synthetic")
+      assert(cf.isInterface)
+      assert(cf.isAbstract)
+    }
+  }
+
+  it should "detect ACC_SYNTHETIC on an InnerClassInfo via the bit mask" in {
+    val info = InnerClassInfo(
+      accessFlags = InnerClassAccessFlags.ACC_SYNTHETIC,
+      innerName = Some("Synth"),
+      innerClassName = "Outer$Synth",
+      outerClassName = "Outer"
+    )
+    assert(info.isSynthetic)
+  }
+
+  it should "detect ACC_STRICT on a MethodInfo via the bit mask" in {
+    val m = MethodInfo(
+      accessFlags = MethodAccessFlags.ACC_STRICT,
+      name = Some("legacyStrict"),
+      descriptor = Some("()V"),
+      attributes = IndexedSeq.empty
+    )
+    assert(m.isStrict)
+  }
 }


### PR DESCRIPTION
  Prep work split out of #1711

  ## Summary

Decouples the JVMS classfile access-flag bit tables by context so consumers can't misread a flag in the wrong table — bit `0x0040` is `ACC_BRIDGE` for methods but `ACC_VOLATILE` for fields, and bit `0x0080` is `ACC_VARARGS` for methods but `ACC_TRANSIENT` for fields. The previous `Constants` object mixed method-table flags with constant-pool tags, leaving that collision unenforceable at the type level.

No behavior change — this is structural / type-safety plus a strict improvement in test coverage of the classfile parser surface.

  ## What changed

  ### `zinc-classfile`

  **One access-flag object per JVMS table**, each linked to the spec:

  | Object | Spec link |
  |--------|-----------|
  | `ClassAccessFlags` |
  https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.1-200-E.1 |
  | `FieldAccessFlags` |
  https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.5-200-A.1 |
  | `MethodAccessFlags` |
  https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.6-200-A.1 |
  | `InnerClassAccessFlags` |
  https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.7.6-300-D.2-5 |

  `Constants` keeps the non-access-flag entries (constant-pool tags, `JavaMagic`, `ClassDescriptor`) so `Parser.scala`'s wildcard import keeps working.

  **`FieldOrMethodInfo` replaced by two self-contained case classes** — no shared trait, each case class names its own context's flag object at every call site:

  `isTransient` / `isSynthetic` / `isEnum`, all reading `FieldAccessFlags`
  - `MethodInfo` — `isPublic` / `isPrivate` / `isProtected` / `isStatic` / `isFinal` / `isSynchronized` / `isBridge` / `isVarArgs` / `isNative` / `isAbstract` / `isStrict` / `isSynthetic` / `isConstructor` / `isStaticInit` / `isMain`, all reading `MethodAccessFlags`

  The previous `parseFieldOrMethodInfo[T]` / `getTypes[T]` helpers in `Parser.scala` are split into dedicated `parseField` / `parseMethod` and inlined `fieldTypes` / `methodTypes`.

  **`ClassFile` trait gains class-level predicates** from `ClassAccessFlags`: `isPublic` / `isFinal` / `isInterface` / `isAbstract` / `isSynthetic` / `isAnnotation` / `isEnum`.

  **`InnerClassInfo` expanded** from `isStatic` / `isPublic` to the full `InnerClassAccessFlags` surface (private / protected / final / interface / abstract / synthetic / annotation / enum).

  ### `zinc-apiinfo`

  `ClassfileToAPI.scala` drops `java.lang.reflect.Modifier.isInterface(cf.accessFlags)` in favor of
  `cf.isInterface`, giving `ClassAccessFlags` a real production consumer.

  ## Test coverage — 35 predicates, 35 covered

  - Most predicates: inline-compiled Java fixtures via `JavaCompilerForUnitTesting`, so they don't
  depend on JDK-version-specific shapes of `java.lang.*`.
  - `cf.isSynthetic`: `package-info.class` compiled from a `package-info.java` with a package
  annotation (reliable javac trigger).
  - `FieldInfo.isSynthetic`: enum's auto-generated `$VALUES` static-final array.
  - `InnerClassInfo.isSynthetic` and `MethodInfo.isStrict`: direct case-class construction. Modern
  javac no longer emits these bits in source-compiled output (invokedynamic moved lambda capture off
  synthetic helper classes; [JEP 306](https://openjdk.org/jeps/306) made `strictfp` implicit in 17+),
   but bytecode produced by older javac, ASM, ProGuard, Mockito etc. still sets them — so the
  predicates stay, exercised at the bit-mask level.
  - `ClassfileToAPI.cf.isInterface`: end-to-end test confirming an interface input is recorded as
  `DefinitionType.Trait`, not `ClassDef`.

  ## Test plan

  - [x] `sbt zincClassfile/Test/testOnly *` — **63 / 63 pass**
  - [x] `sbt zincApiInfo/Test/testOnly *` — **55 / 55 pass**

  ## Relationship to #1711

  #1711 ("Classfile fallback for the remaining `ClassToAPI` reflection sites") needs this
  infrastructure to filter and inspect `FieldInfo` / `MethodInfo` during the classfile-based
  fallback. Splitting it out lands the structural improvements on their own — they're useful
  independently and shrink #1711's review surface.

