### PR TITLE
[2.x] fix: Report missing classes during Java post-compile analysis (#149)

### DIFF
--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/JavaAnalyze.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/JavaAnalyze.scala
@@ -81,6 +81,11 @@ private[sbt] object JavaAnalyze {
     val binaryClassNameToSourceName = new mutable.HashMap[String, String]
 
     val classfilesCache = mutable.Map.empty[String, Path]
+    // sbt/zinc#149: referenced classes whose classfile could not be located, keyed to the classes
+    // that reached them; reported once per missing class after the analysis. Java analysis is
+    // deliberately best-effort: a compile that javac accepted never fails here — whatever cannot
+    // be recovered is reported and the corresponding dependency edges are simply absent.
+    val missingClassReferrers = mutable.Map.empty[String, mutable.Set[String]]
 
     // parse class files and assign classes to sources.  This must be done before dependencies, since the information comes
     // as class->class dependencies that must be mapped back to source->class dependencies using the source+class assignment
@@ -95,7 +100,13 @@ private[sbt] object JavaAnalyze {
       if !binaryClassName.endsWith("module-info")
     } {
       val finalClassFile: Path = remapClassFile(newClass)
-      load(binaryClassName, Some("Error reading API from class file: " + binaryClassName)) match {
+      load(
+        binaryClassName,
+        Some(
+          "While analyzing " + binaryClassName +
+            ": the class could not be loaded; falling back to classfile-based analysis"
+        )
+      ) match {
         case Some(loadedClass) =>
           binaryClassNameToLoadedClass.update(binaryClassName, loadedClass)
           loadEnclosingClass(loadedClass) match {
@@ -145,6 +156,14 @@ private[sbt] object JavaAnalyze {
       binaryName.startsWith("java.") ||
         (!classFileByBinaryName.contains(binaryName) &&
           resourceUrl(binaryName).exists(_.getProtocol == "jrt"))
+
+    // sbt/zinc#149: when a reflection failure names a class that is genuinely absent from the
+    // analysis classpath, report it like any other unlocatable referenced class.
+    def recordMissingClass(e: Throwable, referrer: String): Unit =
+      for {
+        missing <- missingClassName(e)
+        if !isPlatformClass(missing) && resourceUrl(missing).isEmpty
+      } missingClassReferrers.getOrElseUpdate(missing, mutable.Set.empty) += referrer
 
     def resolveClassFile(binaryName: String): Option[ClassFile] =
       classFileByBinaryName
@@ -230,15 +249,24 @@ private[sbt] object JavaAnalyze {
           case (Some(fromClassName), None) =>
             trapAndLog(log) {
               val cachedOrigin = classfilesCache.get(onBinaryName)
-              for (file <- cachedOrigin.orElse(loadFromClassloader())) {
-                val binaryFile: Path = remapClassFile(file)
-                analysis.binaryDependency(
-                  binaryFile,
-                  onBinaryName,
-                  fromClassName,
-                  source,
-                  context
-                )
+              cachedOrigin.orElse(loadFromClassloader()) match {
+                case Some(file) =>
+                  val binaryFile: Path = remapClassFile(file)
+                  analysis.binaryDependency(
+                    binaryFile,
+                    onBinaryName,
+                    fromClassName,
+                    source,
+                    context
+                  )
+                case None =>
+                  // sbt/zinc#149: the classfile is absent from the analysis classpath, so this
+                  // dependency cannot be tracked. Guard platform classes first (every classfile
+                  // references java.lang.*, and jrt-served classes are never tracked); a URL that
+                  // existed but couldn't be converted was already warned about in urlAsFile.
+                  if (!isPlatformClass(onBinaryName) && resourceUrl(onBinaryName).isEmpty)
+                    missingClassReferrers.getOrElseUpdate(onBinaryName, mutable.Set.empty) +=
+                      s"$fromClassName (${source.name})"
               }
             }
           case (None, _) => // It could be a stale class file, ignore
@@ -281,15 +309,55 @@ private[sbt] object JavaAnalyze {
         onBinaryName <- constantDeps.getOrElse(binaryClassName, Set.empty)
       } processDependency(onBinaryName, DependencyByMemberRef, binaryClassName)
 
-      def readInheritanceDependencies(classes: Seq[Class[?]]) = {
-        val api = readAPI(source, classes)
-        // avoid .mapValues(...) because of its viewness (scala/bug#10919)
-        api.groupBy(_._1).iterator.map { case (k, v) => k -> v.map(_._2) }
+      // sbt/zinc#149: reflecting over a class's signatures throws when a referenced class is
+      // missing from the classpath (javac itself succeeded). Never fail the compile for that:
+      // retry class-by-class to isolate failures; failing non-local classes are demoted to the
+      // classfile-based fallback (sbt/zinc#837 loops below), failing local classes are skipped.
+      // Structural errors (VerifyError, ClassFormatError) still propagate, matching
+      // ClassToAPI.loadInnerClass.
+      def readInheritanceDependencies(classes: Seq[Class[?]]): Map[String, Set[String]] = {
+        def group(pairs: collection.Set[(String, String)]): Map[String, Set[String]] =
+          // avoid .mapValues(...) because of its viewness (scala/bug#10919)
+          pairs.groupBy(_._1).map { case (k, v) => k -> v.iterator.map(_._2).toSet }
+        try group(readAPI(source, classes))
+        catch {
+          case e: (ClassNotFoundException | NoClassDefFoundError | TypeNotPresentException |
+                IllegalAccessError) =>
+            log.debug(
+              s"[zinc] sbt/zinc#149: API extraction failed for ${source.name} ($e); " +
+                "retrying per class"
+            )
+            val pairs = mutable.Set.empty[(String, String)]
+            for (cls <- classes)
+              try pairs ++= readAPI(source, Seq(cls))
+              catch {
+                case e: (ClassNotFoundException | NoClassDefFoundError | TypeNotPresentException |
+                      IllegalAccessError) =>
+                  Option(cls.getCanonicalName) match {
+                    case Some(canonical) =>
+                      log.warn(
+                        s"While analyzing $canonical (${source.name}), failed to extract its API " +
+                          s"by reflection: $e. Falling back to classfile-based analysis for this " +
+                          "class."
+                      )
+                      binaryClassNameToSourceName.update(cls.getName, canonical)
+                      recordMissingClass(e, s"$canonical (${source.name})")
+                    case None =>
+                      log.warn(
+                        s"While analyzing ${cls.getName} (${source.name}), failed to extract its " +
+                          s"API by reflection: $e. Inheritance dependencies of this local class " +
+                          "will not be tracked."
+                      )
+                      recordMissingClass(e, s"${cls.getName} (${source.name})")
+                  }
+              }
+            group(pairs)
+        }
       }
 
       // Read API of non-local classes and process dependencies by inheritance
       val nonLocalInherited: Map[String, Set[String]] =
-        readInheritanceDependencies(nonLocalClasses.toSeq).toMap
+        readInheritanceDependencies(nonLocalClasses.toSeq)
       nonLocalInherited foreach {
         case (className, inheritanceDeps) =>
           processDependencies(inheritanceDeps, DependencyByInheritance, className)
@@ -299,7 +367,7 @@ private[sbt] object JavaAnalyze {
       val localClasses =
         localClassesOrStale.filter(cls => localClassesToSources.contains(cls.getName))
       val localInherited: Map[String, Set[String]] =
-        readInheritanceDependencies(localClasses.toSeq).toMap
+        readInheritanceDependencies(localClasses.toSeq)
       localInherited foreach {
         case (className, inheritanceDeps) =>
           processDependencies(inheritanceDeps, LocalDependencyByInheritance, className)
@@ -323,6 +391,19 @@ private[sbt] object JavaAnalyze {
       // Best-effort: never let classfile-based API extraction fail a compile that would otherwise
       // succeed (these classes already couldn't be loaded), matching load()/loadInnerClass.
       if (unloadableNamed.nonEmpty) trapAndLog(log)(readClassfileAPI(source, unloadableNamed))
+    }
+
+    // sbt/zinc#149: one deterministic warning per missing class, naming the classes that reached
+    // it (capped), in the spirit of scalac's "symbol is missing from the classpath" stub errors.
+    for ((missing, referrers) <- missingClassReferrers.toSeq.sortBy(_._1)) {
+      val sorted = referrers.toSeq.sorted
+      val shown =
+        if (sorted.sizeIs <= 5) sorted.mkString(", ")
+        else sorted.take(5).mkString(", ") + s", and ${sorted.size - 5} more"
+      log.warn(
+        s"While analyzing $shown, failed to locate $missing. This class must be present on " +
+          "the classpath in order to track dependencies on it."
+      )
     }
   }
 
@@ -388,6 +469,18 @@ private[sbt] object JavaAnalyze {
   private def classNameToClassFile(name: String) = name.replace('.', '/') + ClassExt
   private def binaryToSourceName(loadedClass: Class[?]): Option[String] =
     Option(loadedClass.getCanonicalName)
+
+  /**
+   * Best-effort name of the class that a reflection failure reports as missing (sbt/zinc#149).
+   * The JVM names it in internal (com/b/B) or source form depending on the exception; sentence
+   * messages (e.g. IllegalAccessError's) yield None.
+   */
+  private def missingClassName(e: Throwable): Option[String] = e match {
+    case t: TypeNotPresentException => Some(t.typeName)
+    case _: ClassNotFoundException | _: NoClassDefFoundError =>
+      Option(e.getMessage).filter(m => m.nonEmpty && !m.contains(' ')).map(_.replace('/', '.'))
+    case _ => None
+  }
 
   @tailrec
   private def loadEnclosingClass(clazz: Class[?]): Option[String] = {

--- a/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/AnalyzeSpecification.scala
+++ b/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/AnalyzeSpecification.scala
@@ -16,6 +16,7 @@ package classfile
 
 import java.io.File
 import sbt.io.IO
+import sbt.util.Level
 import xsbti.api.DependencyContext._
 
 class AnalyzeSpecification extends UnitSpec {
@@ -532,6 +533,142 @@ class AnalyzeSpecification extends UnitSpec {
       "Foo.java" -> srcFoo,
     )
     assert(deps.memberRef("Foo").contains("Bar"))
+  }
+
+  // sbt/zinc#149: a referenced class whose classfile cannot be located on the analysis classpath
+  // is reported (once per missing class) instead of being silently dropped from the dependency
+  // graph.
+  "Analyze" should "warn when a referenced class is missing from the classpath (sbt/zinc#149)" in {
+    IO.withTemporaryDirectory { temp =>
+      val classesDir = new File(temp, "classes")
+      val libDir = new File(temp, "lib")
+      classesDir.mkdir()
+      libDir.mkdir()
+
+      val bFile = new File(temp, "B.java")
+      IO.write(bFile, "package pkg; public class B { public static void hello() {} }")
+      JavaCompilerForUnitTesting.compileJava(Seq(bFile), libDir, Seq.empty)
+
+      val aFile = new File(temp, "A.java")
+      IO.write(aFile, "public class A { void m() { pkg.B.hello(); } }")
+      val cFile = new File(temp, "C.java")
+      IO.write(cFile, "public class C { void m() { pkg.B.hello(); } }")
+      JavaCompilerForUnitTesting.compileJava(Seq(aFile, cFile), classesDir, Seq(libDir))
+      // pkg.B is only in libDir, so it is absent from the analysis classpath (classesDir).
+
+      val log = new CollectingLogger
+      val callback = JavaCompilerForUnitTesting.analyze(classesDir, Seq(aFile, cFile), log = log)
+
+      val warns = log.messages(Level.Warn)
+      val missingWarns = warns.filter(_.contains("pkg.B"))
+      // One aggregated warning for the missing class, naming every class that reached it.
+      assert(missingWarns.size === 1)
+      assert(
+        missingWarns.head ===
+          "While analyzing A (A.java), C (C.java), failed to locate pkg.B. This class must " +
+          "be present on the classpath in order to track dependencies on it."
+      )
+      // Platform classes are never reported (every classfile references java.lang.*).
+      assert(!warns.exists(_.contains("java.lang")))
+      // Diagnostic only: no dependency edge is fabricated for the missing class.
+      assert(!callback.binaryDependencies.exists(_._2 == "pkg.B"))
+    }
+  }
+
+  // sbt/zinc#149: when reflective API extraction crashes on a missing referenced class, the
+  // compile must not fail: the failing class falls back to classfile-based analysis
+  // (sbt/zinc#837) and its siblings from the same source are still analyzed reflectively.
+  "Analyze" should "fall back to classfile analysis when API extraction fails (sbt/zinc#149)" in {
+    IO.withTemporaryDirectory { temp =>
+      val classesDir = new File(temp, "classes")
+      classesDir.mkdir()
+
+      val baseFile = new File(temp, "Base.java")
+      IO.write(baseFile, "public class Base {}")
+      // Foo and Bar share one source: API extraction is batched per source, so this exercises
+      // the per-class retry that isolates the failing class from its sibling.
+      val fooFile = new File(temp, "Foo.java")
+      IO.write(
+        fooFile,
+        """|public class Foo extends Base {}
+           |class Bar extends Base {}
+           |""".stripMargin
+      )
+      JavaCompilerForUnitTesting.compileJava(Seq(baseFile, fooFile), classesDir, Seq.empty)
+
+      val log = new CollectingLogger
+      val demoted = scala.collection.mutable.Set.empty[String]
+      val callback = JavaCompilerForUnitTesting.analyze(
+        classesDir,
+        Seq(baseFile, fooFile),
+        readClassfileAPI = (_, _, named) => { demoted ++= named.map(_._1); () },
+        log = log,
+        readAPI = (_, _, classes) =>
+          if (classes.exists(_.getName == "Foo")) throw new NoClassDefFoundError("missing.B")
+          else JavaCompilerForUnitTesting.extractParents(classes)
+      )
+
+      val warns = log.messages(Level.Warn)
+      assert(
+        warns.exists(m => m.contains("While analyzing Foo") && m.contains("NoClassDefFoundError"))
+      )
+      assert(!warns.exists(_.contains("Bar")))
+      // The missing class extracted from the reflection failure joins the aggregated report.
+      assert(
+        warns.contains(
+          "While analyzing Foo (Foo.java), failed to locate missing.B. This class must " +
+            "be present on the classpath in order to track dependencies on it."
+        )
+      )
+      // The sibling from the same source is salvaged by the per-class retry ...
+      assert(callback.classDependencies.contains(("Base", "Bar", DependencyByInheritance)))
+      // ... and the failing class still gets its inheritance edge, from its classfile.
+      assert(callback.classDependencies.contains(("Base", "Foo", DependencyByInheritance)))
+      // Exactly the failing class is demoted to classfile-based API extraction.
+      assert(demoted.toSet === Set("Foo"))
+    }
+  }
+
+  // sbt/zinc#149: a local (anonymous) class whose API extraction fails is skipped with a warning;
+  // local classes have no canonical name and are not demoted to the classfile fallback.
+  "Analyze" should "skip local classes whose API extraction fails (sbt/zinc#149)" in {
+    IO.withTemporaryDirectory { temp =>
+      val classesDir = new File(temp, "classes")
+      classesDir.mkdir()
+
+      val fooFile = new File(temp, "Foo.java")
+      IO.write(
+        fooFile,
+        """|public class Foo {
+           |  Runnable r = new Runnable() { public void run() {} };
+           |}
+           |""".stripMargin
+      )
+      JavaCompilerForUnitTesting.compileJava(Seq(fooFile), classesDir, Seq.empty)
+
+      val log = new CollectingLogger
+      val demoted = scala.collection.mutable.Set.empty[String]
+      JavaCompilerForUnitTesting.analyze(
+        classesDir,
+        Seq(fooFile),
+        readClassfileAPI = (_, _, named) => { demoted ++= named.map(_._1); () },
+        log = log,
+        readAPI = (_, _, classes) =>
+          if (classes.exists(_.getName == "Foo$1")) throw new NoClassDefFoundError("missing.B")
+          else JavaCompilerForUnitTesting.extractParents(classes)
+      )
+
+      val warns = log.messages(Level.Warn)
+      assert(warns.exists(m => m.contains("Foo$1") && m.contains("local class")))
+      // The missing class is still reported, with the local class as the referrer.
+      assert(
+        warns.contains(
+          "While analyzing Foo$1 (Foo.java), failed to locate missing.B. This class must " +
+            "be present on the classpath in order to track dependencies on it."
+        )
+      )
+      assert(demoted.isEmpty)
+    }
   }
 
 }

--- a/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/CollectingLogger.scala
+++ b/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/CollectingLogger.scala
@@ -1,0 +1,26 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package sbt.internal.inc.classfile
+
+import sbt.util.{ Level, Logger }
+
+/** Collects logged messages by level, for asserting on diagnostics in tests. */
+class CollectingLogger extends Logger {
+  var messages: Map[Level.Value, Seq[String]] = Map.empty.withDefaultValue(Seq.empty)
+
+  override def trace(t: => Throwable): Unit = ()
+  override def success(message: => String): Unit = ()
+  override def log(level: Level.Value, message: => String): Unit =
+    synchronized {
+      messages = messages.updated(level, messages(level) :+ message)
+    }
+}

--- a/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/JavaCompilerForUnitTesting.scala
+++ b/internal/zinc-classfile/src/test/scala/sbt/internal/inc/classfile/JavaCompilerForUnitTesting.scala
@@ -21,6 +21,7 @@ import java.nio.file.{ Files, Path }
 
 import sbt.io.IO
 import sbt.internal.util.ConsoleLogger
+import sbt.util.Logger
 import xsbti.api.DependencyContext._
 import xsbti.{ AnalysisCallback, BasicVirtualFileRef, TestCallback, VirtualFile, VirtualFileRef }
 import xsbti.TestCallback.ExtractedClassDependencies
@@ -124,7 +125,10 @@ object JavaCompilerForUnitTesting {
       classesDir: File,
       srcFiles: Seq[File],
       readClassfileAPI: (AnalysisCallback, VirtualFileRef, Seq[(String, ClassFile)]) => Unit =
-        (_, _, _) => ()
+        (_, _, _) => (),
+      log: Logger = ConsoleLogger(),
+      readAPI: (AnalysisCallback, VirtualFileRef, Seq[Class[?]]) => Set[(String, String)] =
+        (_, _, classes) => extractParents(classes)
   ): TestCallback = {
     val srcs: List[VirtualFile] = srcFiles.toList.map(f => new TestVirtualFile(f.toPath))
     val analysisCallback = new TestCallback
@@ -134,10 +138,10 @@ object JavaCompilerForUnitTesting {
       override def getOutputDirectoryAsPath: Path = classesDir.toPath
       override def getOutputDirectory: File = classesDir
     }
-    JavaAnalyze(classFiles, srcs, ConsoleLogger(), output, finalJarOutput = None)(
+    JavaAnalyze(classFiles, srcs, log, output, finalJarOutput = None)(
       analysisCallback,
       classloader,
-      (_, classes) => extractParents(classes),
+      readAPI(analysisCallback, _, _),
       readClassfileAPI(analysisCallback, _, _)
     )
     analysisCallback
@@ -149,7 +153,7 @@ object JavaCompilerForUnitTesting {
     srcFile
   }
 
-  private val extractParents: Seq[Class[?]] => Set[(String, String)] = { classes =>
+  private[classfile] val extractParents: Seq[Class[?]] => Set[(String, String)] = { classes =>
     def canonicalNames(p: (Class[?], Class[?])): (String, String) =
       p._1.getCanonicalName -> p._2.getCanonicalName
     val parents =


### PR DESCRIPTION
Fixes #149. Previously a dependency on a class Zinc couldn't locate was silently dropped from the analysis, and a reflection failure in `ClassToAPI` failed the whole compile after `javac` had succeeded.

**Change:** `JavaAnalyze` warns once per missing class, naming its referrers:

```
While analyzing A (A.java), C (C.java), failed to locate pkg.B. This class must be present on the classpath in order to track dependencies on it.
```

API-extraction failures now retry per class and demote the failing class to the classfile-based fallback (#837) instead of failing the compile. Warning-only by design: a compile `javac` accepted never fails in analysis.
