### PR TITLE
[1.x] Make libraryClassName relation deterministic under concurrency

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -740,7 +740,12 @@ private final class AnalysisCallback(
       source: VirtualFileRef,
       context: DependencyContext
   ): Unit = {
-    binaryClassName.put(binary, className)
+    // Break ties via lexicographic ordering on the className, which ensures a stable
+    // representative class name is picked for each binary avoiding non-deterministic output
+    binaryClassName.get(binary) match {
+      case Some(existing) if className.compareTo(existing) >= 0 => ()
+      case _ => binaryClassName.put(binary, className)
+    }
     add(libraryDeps, source, binary)
   }
 


### PR DESCRIPTION
Fixes https://github.com/scala/scala3/issues/26434
This is a 1.12.x backport of #1638

Previously, Zinc could produce nondeterministic analysis output because `binaryClassName` used `put(binary, className)` from concurrent `externalLibraryDependency` callbacks. The final value depended on callback scheduling, so `binaryClassName` stores one representative class per binary JAR in a concurrent map, but representative selection was non-deterministic.

This PR replaces `put` with deterministic merge using `updateWith`, choosing the lexicographically smallest class name for each binary.