### PR TITLE
[2.x] Intern directory item conversions in `MappedFileConverter`

### DIFF
--- a/internal/zinc-benchmarks/src/test/scala/xsbt/FileConverterBenchmark.scala
+++ b/internal/zinc-benchmarks/src/test/scala/xsbt/FileConverterBenchmark.scala
@@ -1,0 +1,117 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package xsbt
+
+import java.lang.management.ManagementFactory
+import java.nio.file.{ Files, Path }
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
+import sbt.internal.inc.MappedFileConverter
+import sbt.io.IO
+import xsbti.VirtualFile
+
+@State(Scope.Benchmark)
+class FileConverterState {
+  @Param(Array("2000"))
+  var fileCount: Int = 0
+
+  @Param(Array("100"))
+  var consumers: Int = 0
+
+  var rootDir: Path = null
+  var classesDir: Path = null
+  var shared: MappedFileConverter = null
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    rootDir = Files.createTempDirectory("file-converter-benchmark")
+    classesDir = Files.createDirectories(rootDir.resolve("classes"))
+    (0 until fileCount).foreach { i =>
+      val pkg = Files.createDirectories(classesDir.resolve(s"pkg${i % 50}"))
+      Files.write(pkg.resolve(s"Class$i.class"), Array.fill[Byte](1024)((i % 127).toByte))
+    }
+    shared = newConverter
+  }
+
+  @TearDown(Level.Trial)
+  def teardown(): Unit = IO.delete(rootDir.toFile)
+
+  def newConverter: MappedFileConverter = MappedFileConverter(Map("BASE" -> rootDir), true)
+}
+
+/**
+ * Conversion cost of one shared classes directory.
+ * `freshConverterPerConversion` approximates the pre-interning behavior (every consumer
+ * re-materializes all items); `sharedConverter` is the interned steady state.
+ */
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(1)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 5, time = 2)
+class FileConverterBenchmark {
+
+  @Benchmark
+  def freshConverterPerConversion(state: FileConverterState): VirtualFile =
+    state.newConverter.toVirtualFile(state.classesDir)
+
+  @Benchmark
+  def sharedConverter(state: FileConverterState): VirtualFile =
+    state.shared.toVirtualFile(state.classesDir)
+}
+
+object HeapMeter {
+  def usedHeap(): Long = {
+    val bean = ManagementFactory.getMemoryMXBean
+    (1 to 5).foreach { _ =>
+      System.gc(); Thread.sleep(50)
+    }
+    bean.getHeapMemoryUsage.getUsed
+  }
+}
+
+@AuxCounters(AuxCounters.Type.EVENTS)
+@State(Scope.Thread)
+class RetainedCounters {
+  var retainedKB: Long = 0
+}
+
+/** Heap retained while `consumers` conversions of the same directory are held simultaneously. */
+@BenchmarkMode(Array(Mode.SingleShotTime))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(1)
+class FileConverterRetainedBenchmark {
+
+  @Benchmark
+  def retainedFreshConverters(
+      state: FileConverterState,
+      counters: RetainedCounters
+  ): Array[VirtualFile] = {
+    val before = HeapMeter.usedHeap()
+    val held =
+      Array.tabulate(state.consumers)(_ => state.newConverter.toVirtualFile(state.classesDir))
+    counters.retainedKB = (HeapMeter.usedHeap() - before) / 1024
+    held
+  }
+
+  @Benchmark
+  def retainedSharedConverter(
+      state: FileConverterState,
+      counters: RetainedCounters
+  ): Array[VirtualFile] = {
+    val before = HeapMeter.usedHeap()
+    val converter = state.newConverter
+    val held = Array.tabulate(state.consumers)(_ => converter.toVirtualFile(state.classesDir))
+    counters.retainedKB = (HeapMeter.usedHeap() - before) / 1024
+    held
+  }
+}

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/MappedVirtualFile.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/MappedVirtualFile.scala
@@ -13,9 +13,12 @@ package sbt
 package internal
 package inc
 
-import java.io.{ ByteArrayInputStream, InputStream }
+import java.io.{ ByteArrayInputStream, IOException, InputStream }
+import java.lang.ref.SoftReference
 import java.nio.ByteBuffer
 import java.nio.file.{ Files, Path, Paths }
+import java.nio.file.attribute.{ BasicFileAttributes, FileTime }
+import java.util.concurrent.ConcurrentHashMap
 import xsbti.{ BasicVirtualFileRef, FileConverter, PathBasedFile, VirtualFile, VirtualFileRef }
 import sbt.nio.file.{ FileTreeView, Glob, IsNotHidden, IsRegularFile, RecursiveGlob }
 
@@ -50,7 +53,7 @@ object MappedVirtualFile {
 class MappedDirectory(
     encodedPath: String,
     rootPathsMap: Map[String, Path],
-    items: List[VirtualFile]
+    val items: List[VirtualFile]
 ) extends BasicVirtualFileRef(encodedPath)
     with PathBasedFile {
   private def path: Path = MappedVirtualFile.toPath(encodedPath, rootPathsMap)
@@ -141,11 +144,36 @@ class MappedFileConverter(val rootPaths: Map[String, Path], allowMachinePath: Bo
     }
   }
 
+  // Consumers of a shared classpath each convert its entries independently, and a directory entry
+  // wraps every contained file, so without interning a shared classes directory is re-materialized
+  // once per consumer - value-identical MappedVirtualFiles then accumulate on the heap on large
+  // multi-project builds (#1750). Keying by (lastModified, size) keeps a memoized content hash from
+  // being served across a content change, and the SoftReference bounds retention of this long-lived
+  // shared converter. Top-level conversions are deliberately excluded so they stay per-consumer:
+  // their lazy hashes must read content at first access, which incremental source change detection
+  // relies on.
+  private val itemCache =
+    new ConcurrentHashMap[Path, ((FileTime, Long), SoftReference[VirtualFile])]
+
+  private def toItem(path: Path): VirtualFile =
+    try {
+      val attrs = Files.readAttributes(path, classOf[BasicFileAttributes])
+      val metadata = (attrs.lastModifiedTime(), attrs.size())
+      val cached = itemCache.get(path)
+      val hit = if (cached != null && cached._1 == metadata) cached._2.get() else null
+      if (hit != null) hit
+      else {
+        val vf = toVirtualFileForRegularFile(path)
+        itemCache.put(path, (metadata, new SoftReference(vf)))
+        vf
+      }
+    } catch { case _: IOException => toVirtualFileForRegularFile(path) }
+
   def toDirectory(path: Path, encodedPath: String) = {
     val list = view.list(Glob(path, RecursiveGlob), IsRegularFile && IsNotHidden)
       .map(_._1)
       .sorted
-    val items = list.map(toVirtualFileForRegularFile)
+    val items = list.map(toItem)
     MappedDirectory(encodedPath, rootPaths, items.toList)
   }
 }

--- a/internal/zinc-core/src/test/scala/sbt/internal/inc/MappedFileConverterInterningSpec.scala
+++ b/internal/zinc-core/src/test/scala/sbt/internal/inc/MappedFileConverterInterningSpec.scala
@@ -1,0 +1,91 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package sbt
+package internal
+package inc
+
+import java.nio.file.{ Files, Path }
+import java.nio.file.attribute.FileTime
+import sbt.io.IO
+import xsbti.VirtualFile
+
+class MappedFileConverterInterningSpec extends UnitSpec {
+
+  behavior of "MappedFileConverter directory item interning"
+
+  it should "share interned items across repeated directory conversions" in withTempDir { dir =>
+    val classes = Files.createDirectories(dir.resolve("classes"))
+    Files.write(classes.resolve("A.class"), "a".getBytes("UTF-8"))
+    Files.write(classes.resolve("B.class"), "bb".getBytes("UTF-8"))
+    val converter = MappedFileConverter.empty
+    val first = directory(converter.toVirtualFile(classes))
+    val second = directory(converter.toVirtualFile(classes))
+    assert(second ne first)
+    first.items should have size 2
+    first.items.lazyZip(second.items).foreach((a, b) => assert(b eq a))
+  }
+
+  it should "convert an item fresh once its file is rewritten" in withTempDir { dir =>
+    val classes = Files.createDirectories(dir.resolve("classes"))
+    val file = Files.write(classes.resolve("A.class"), "aaaa".getBytes("UTF-8"))
+    val converter = MappedFileConverter.empty
+    val first = directory(converter.toVirtualFile(classes)).items.head
+    val firstHash = first.contentHash
+    Files.write(file, "bbbb".getBytes("UTF-8")) // same size
+    Files.setLastModifiedTime(file, FileTime.fromMillis(System.currentTimeMillis() + 5000))
+    val second = directory(converter.toVirtualFile(classes)).items.head
+    assert(second ne first)
+    assert(second.contentHash != firstHash)
+  }
+
+  it should "reflect directory content changes in a fresh conversion" in withTempDir { dir =>
+    val classes = Files.createDirectories(dir.resolve("classes"))
+    Files.write(classes.resolve("A.class"), "a".getBytes("UTF-8"))
+    val converter = MappedFileConverter.empty
+    val first = directory(converter.toVirtualFile(classes))
+    Files.write(classes.resolve("B.class"), "bb".getBytes("UTF-8"))
+    val second = directory(converter.toVirtualFile(classes))
+    first.items should have size 1
+    second.items should have size 2
+  }
+
+  it should "convert fresh once a missing path exists" in withTempDir { dir =>
+    val classes = dir.resolve("out").resolve("classes")
+    val converter = MappedFileConverter.empty
+    val missing = directory(converter.toVirtualFile(classes))
+    missing.items shouldBe empty
+    Files.createDirectories(classes)
+    Files.write(classes.resolve("A.class"), "a".getBytes("UTF-8"))
+    val second = directory(converter.toVirtualFile(classes))
+    second.items should have size 1
+  }
+
+  it should "keep fresh-instance semantics for top-level conversions" in withTempDir { dir =>
+    val file = Files.write(dir.resolve("A.scala"), "object A".getBytes("UTF-8"))
+    val converter = MappedFileConverter.empty
+    val first = converter.toVirtualFile(file)
+    val second = converter.toVirtualFile(file)
+    assert(second ne first)
+  }
+
+  private def withTempDir(f: Path => Unit): Unit = {
+    val dir = Files.createTempDirectory("mapped-file-converter-interning")
+    try f(dir)
+    finally IO.delete(dir.toFile)
+  }
+
+  private def directory(vf: VirtualFile): MappedDirectory =
+    vf match {
+      case dir: MappedDirectory => dir
+      case other                => fail(s"expected a MappedDirectory, got $other")
+    }
+}


### PR DESCRIPTION
**Disclaimer**: Developed with Claude Code and human review in the loop

Fixes #1750

## Problem

`MappedFileConverter.toVirtualFile` expands a directory classpath entry into one
`MappedVirtualFile` per contained file. Because every consumer converts its classpath
independently and the `FileConverter` is shared build-wide, a directory that appears on many
consumers' classpaths is re-materialized once per consumer — producing large numbers of
value-identical `MappedVirtualFile` instances (encoded-path strings included) retained
simultaneously. See #1750 for the full write-up.

## Change

- Cache per-item conversions in `MappedFileConverter`, keyed by the file's
  `(lastModified, size)`, mirroring the metadata-keyed caching already used by
  `ClasspathCache`. Consumers sharing a classpath now share one `MappedVirtualFile` per
  contained file instead of each re-materializing a copy.
- **Directory conversions are still rebuilt from a fresh listing on every call** — only the
  *items* are shared. Directory membership is therefore always current (added/removed files
  are reflected), and each item is revalidated against its `(lastModified, size)` before reuse.
- Items are held through a `SoftReference`: while any live conversion references an item the
  reference cannot clear (simultaneously-held conversions keep sharing one instance); once no
  conversion holds it, the GC may reclaim it under memory pressure, bounding the retention of a
  long-lived shared converter. A reclaimed item is simply rebuilt on the next conversion.
- **Top-level conversions are intentionally left uncached.** Consumers hold a source
  conversion across edits and rely on its lazy `contentHash` reading the content of first
  access; interning those would fuse instances whose laziness must stay independent and break
  incremental source change detection.

## Why it's safe

- **Interned item hashes are never consumed by change detection.** Source stamps read
  `contentHash` only on top-level source files (fresh instances). Classpath/library change
  detection stamps *by path* (`forHashInRootPaths` → `FarmHash.ofPath`), re-resolving class
  files rather than reading `MappedDirectory.items` — even for directory classpath entries.
  So sharing item instances does not affect incremental correctness.
- A cached item is served only while its `(lastModified, size)` is unchanged, so a memoized
  `contentHash`/`contentHashStr` is never served across a detected content change (the same
  heuristic `ClasspathCache` already relies on).
- The cache is an instance field of the converter (not a global singleton), so its retention
  is bounded by the converter's lifetime, and further bounded under pressure by the soft
  references.

## Results

**Micro-benchmark** (`FileConverterBenchmark`, JMH; 2000-file directory, 100 consumers holding
conversions simultaneously): ~12% faster average conversion and ~4.5× less retained heap
(26.8 MB → 5.9 MB) for a shared converter vs a fresh converter per consumer.

**Macro** (real clean compile — fresh empty action cache, wiped target + boot, ~300-subproject
build, 132,362 class files):

| Build                    | wall time     | in-JVM peak | jstat peak | post-GC  | vs stock (peak)   |
|--------------------------|---------------|-------------|------------|----------|-------------------|
| Stock (no interning)     | 968 s         | 17,984 MB   | 16.41 GB   | 3,795 MB | —                 |
| Directory-item interning | 927 s (−4.2%) | 16,944 MB   | 15.48 GB   | 3,884 MB | −1,040 MB (−5.8%) |

`jstat` sample distribution corroborates the ordering (the interning build never exceeded
16 GB; stock touched 16.4 GB).

*Caveat:* one run per build; wall time and momentary heap peaks are both timing-noisy (treat
exact figures as ±a few percent), but the direction — lower peak heap and lower wall time — is
consistent across in-JVM peak, jstat peak, the distribution, and wall clock.

## Tests

`MappedFileConverterInterningSpec` covers:

- items shared across repeated directory conversions;
- an item re-converted fresh once its file is rewritten (same size, bumped mtime);
- directory content changes (add) reflected in a fresh conversion;
- a missing directory that later exists;
- top-level conversions keeping fresh-instance semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
