### PR TITLE
[2.x] Intern analysis values while deserializing

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/AnalysisInterner.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/AnalysisInterner.scala
@@ -1,0 +1,91 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package sbt.internal.inc
+
+import java.util.{ EnumSet => JEnumSet }
+
+import xsbti.UseScope
+
+/**
+ * The process-wide canonicalizer for strings and `UsedName`s: fresh
+ * (compiler-produced) and persisted (deserialized) analyses both route through
+ * it, so co-resident analyses share a single instance per distinct value.
+ *
+ * Strings are canonicalized through a weak interner: canonical instances are
+ * held only through weak references, so once every analysis referencing a
+ * string is released the canonical instance becomes eligible for GC.
+ *
+ * `UsedName`s are canonicalized without constructing a candidate first: a
+ * `UsedName` is fully determined by its (already canonical) name string and one
+ * of the eight possible `UseScope` combinations, so each combination gets a
+ * weak-valued name-keyed pool. A pool entry is removed once the canonical
+ * `UsedName` is no longer referenced by any analysis. On a pool hit no
+ * `UsedName` is constructed.
+ *
+ * Both pools make interning leak-free across the lifetime of a long-running
+ * build server. Benchmarks that need an uninterned baseline compare against a
+ * stock zinc checkout; production code always interns.
+ */
+object AnalysisInterner {
+
+  private[inc] final val DEFAULT_SCOPE = 1
+  private[inc] final val IMPLICIT_SCOPE = 2
+  private[inc] final val PAT_MAT_TARGET_SCOPE = 4
+  private final val SCOPE_COMBINATIONS = 8 // every subset of the three scopes above
+
+  private val stringPool = new WeakInterner[String]
+
+  // One weak-valued pool per UseScope combination, keyed by the canonical name.
+  private val usedNamePools: Array[WeakValuePool[String, UsedName]] =
+    Array.fill(SCOPE_COMBINATIONS)(new WeakValuePool[String, UsedName])
+
+  def internString(s: String): String = stringPool.intern(s)
+
+  /**
+   * The canonical `UsedName` for `name` used in the scope combination
+   * `scopeBits`, an or-ing of `DEFAULT_SCOPE`, `IMPLICIT_SCOPE` and
+   * `PAT_MAT_TARGET_SCOPE`. Constructs a `UsedName` only when the value is not
+   * pooled yet.
+   */
+  def usedName(name: String, scopeBits: Int): UsedName = {
+    // UsedName stores the escaped name, so the pool must be probed with it too;
+    // escaping is a no-op unless the name contains control characters.
+    val escaped = UsedName.escapeControlChars(name)
+    val pool = usedNamePools(scopeBits)
+    val existing = pool.get(escaped)
+    if (existing != null) existing
+    else {
+      val fresh = UsedName.make(escaped, scopeSets(scopeBits))
+      val prev = pool.putIfAbsent(fresh.name, fresh)
+      if (prev == null) fresh else prev
+    }
+  }
+
+  /**
+   * The eight possible scope sets, indexed by scope bits. Shared by every
+   * UsedName and treated as immutable -- they must never be mutated.
+   */
+  private[inc] val scopeSets: Array[JEnumSet[UseScope]] =
+    Array.tabulate(SCOPE_COMBINATIONS) { bits =>
+      val scopes = JEnumSet.noneOf(classOf[UseScope])
+      if ((bits & DEFAULT_SCOPE) != 0) scopes.add(UseScope.Default)
+      if ((bits & IMPLICIT_SCOPE) != 0) scopes.add(UseScope.Implicit)
+      if ((bits & PAT_MAT_TARGET_SCOPE) != 0) scopes.add(UseScope.PatMatTarget)
+      scopes
+    }
+
+  /** The inverse of `scopeSets`: also the encoding used by the persisted format. */
+  private[inc] def scopeBits(scopes: JEnumSet[UseScope]): Int =
+    (if (scopes.contains(UseScope.Default)) DEFAULT_SCOPE else 0) |
+      (if (scopes.contains(UseScope.Implicit)) IMPLICIT_SCOPE else 0) |
+      (if (scopes.contains(UseScope.PatMatTarget)) PAT_MAT_TARGET_SCOPE else 0)
+}

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -920,9 +920,18 @@ private final class AnalysisCallback(
   }
 
   def usedName(className: String, name: String, useScopes: EnumSet[UseScope]) = {
+    // Canonicalize freshly-produced used names and their strings into the
+    // process-wide pools, so a just-compiled analysis shares them with every
+    // other resident analysis. (Api tree nodes are deduped only when an
+    // analysis is deserialized, not on this fresh-compile path.)
     usedNames
       .getOrElseUpdate(className, ConcurrentHashMap.newKeySet[UsedName].asScala)
-      .add(UsedName.make(name, useScopes))
+      .add(
+        AnalysisInterner.usedName(
+          AnalysisInterner.internString(name),
+          AnalysisInterner.scopeBits(useScopes)
+        )
+      )
     ()
   }
 

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/UsedName.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/UsedName.scala
@@ -13,12 +13,23 @@ package sbt.internal.inc
 
 import java.{ util => ju }
 import scala.{ collection => sc }
+import scala.util.hashing.MurmurHash3
 import xsbti.compile.{ UsedName => XUsedName }
 import xsbti.UseScope
 
+/**
+ * `scopes` must never be mutated after construction: instances may share one
+ * scope set (`make` uses the set it is given, and interning aliases equal
+ * instances), and the hash below is computed once.
+ */
 case class UsedName private (name: String, scopes: ju.EnumSet[UseScope]) extends XUsedName {
   override def getName: String = name
   override def getScopes: ju.EnumSet[UseScope] = scopes
+
+  // A canonical (interned) instance is inserted into one name-set per class that
+  // uses it, and EnumSet.hashCode iterates its elements; caching makes each
+  // re-hash a field read. Fits in the object's existing alignment padding.
+  override val hashCode: Int = MurmurHash3.caseClassHash(this)
 }
 
 object UsedName {
@@ -33,7 +44,7 @@ object UsedName {
     new UsedName(escapedName, useScopes)
   }
 
-  private def escapeControlChars(name: String) = {
+  private[inc] def escapeControlChars(name: String): String = {
     if (name.indexOf('\n') > 0) // optimize for common case to regex overhead
       name.replace("\n", "\u26680A")
     else

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/WeakPools.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/WeakPools.scala
@@ -1,0 +1,117 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package sbt.internal.inc
+
+import java.lang.ref.{ ReferenceQueue, WeakReference }
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.annotation.tailrec
+
+/**
+ * Canonicalizing pool: `intern` returns one instance per distinct value
+ * (`equals`/`hashCode`), and holds it only through a weak reference, so a value
+ * becomes collectable as soon as the last caller drops it. Dead entries are
+ * expunged by the next pool operation.
+ */
+private[inc] final class WeakInterner[A <: AnyRef] {
+  private val stale = new ReferenceQueue[A]
+  private val pool = new ConcurrentHashMap[WeakValue[A], WeakValue[A]]
+
+  def intern(a: A): A = {
+    expunge()
+    val candidate = new WeakValue(a, stale)
+    @tailrec def publish(): A = pool.putIfAbsent(candidate, candidate) match {
+      case null => a
+      case existing =>
+        existing.get match {
+          case null => // collected since it matched: drop the dead entry and retry
+            pool.remove(existing, existing)
+            publish()
+          case canonical =>
+            candidate.clear() // never enqueue a reference that was not pooled
+            canonical
+        }
+    }
+    publish()
+  }
+
+  @tailrec private def expunge(): Unit = stale.poll() match {
+    case null => ()
+    case dead =>
+      pool.remove(dead, dead)
+      expunge()
+  }
+}
+
+/**
+ * Map that holds its values only through weak references: an entry disappears
+ * once its value is unreachable, releasing the strong reference to its key with
+ * it. Unlike an interner it is keyed by something cheaper than the value, so
+ * callers can probe the pool before constructing a candidate.
+ */
+private[inc] final class WeakValuePool[K, V <: AnyRef] {
+  private val stale = new ReferenceQueue[V]
+  private val pool = new ConcurrentHashMap[K, KeyedWeakValue[K, V]]
+
+  /** The pooled value for `key`, or `null` if there is none. */
+  def get(key: K): V = {
+    expunge()
+    pool.get(key) match {
+      case null  => null.asInstanceOf[V]
+      case entry => entry.get
+    }
+  }
+
+  /** Pools `value` under `key`, returning `null`, or the value already pooled. */
+  @tailrec def putIfAbsent(key: K, value: V): V = {
+    val candidate = new KeyedWeakValue(key, value, stale)
+    pool.putIfAbsent(key, candidate) match {
+      case null => null.asInstanceOf[V]
+      case existing =>
+        existing.get match {
+          case null => // collected since it was published: replace the dead entry
+            pool.remove(key, existing)
+            putIfAbsent(key, value)
+          case pooled =>
+            candidate.clear() // never enqueue a reference that was not pooled
+            pooled
+        }
+    }
+  }
+
+  @tailrec private def expunge(): Unit = stale.poll() match {
+    case null => ()
+    case dead =>
+      pool.remove(dead.asInstanceOf[KeyedWeakValue[K, V]].key, dead)
+      expunge()
+  }
+}
+
+/** Weak reference that hashes and compares by the value of its referent. */
+private final class WeakValue[A <: AnyRef](a: A, stale: ReferenceQueue[A])
+    extends WeakReference[A](a, stale) {
+  private val hash: Int = a.hashCode
+
+  override def hashCode(): Int = hash
+  override def equals(other: Any): Boolean = other match {
+    case that: WeakValue[?] =>
+      (this `eq` that) || {
+        val value = get
+        value != null && value == that.get
+      }
+    case _ => false
+  }
+}
+
+/** Weak reference that remembers the key its value was pooled under. */
+private final class KeyedWeakValue[K, V <: AnyRef](val key: K, v: V, stale: ReferenceQueue[V])
+    extends WeakReference[V](v, stale)

--- a/internal/zinc-core/src/test/scala/sbt/internal/inc/AnalysisInternerSpec.scala
+++ b/internal/zinc-core/src/test/scala/sbt/internal/inc/AnalysisInternerSpec.scala
@@ -1,0 +1,101 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package sbt.internal.inc
+
+import java.lang.ref.WeakReference
+import java.util.concurrent.{ Callable, CountDownLatch, Executors, TimeUnit }
+import xsbti.UseScope
+
+class AnalysisInternerSpec extends UnitSpec {
+
+  behavior of "AnalysisInterner"
+
+  it should "canonicalize equal strings to one instance" in {
+    val s1 = new String("com.example.Foo") // force distinct heap instances
+    val s2 = new String("com.example.Foo")
+    assert(s1 `ne` s2)
+    assert(AnalysisInterner.internString(s1) `eq` AnalysisInterner.internString(s2))
+  }
+
+  it should "return one UsedName instance per (name, scope) without construction on hit" in {
+    val a = AnalysisInterner.usedName("map", 1)
+    val b = AnalysisInterner.usedName(new String("map"), 1)
+    assert(a `eq` b)
+    assert(a.name == "map")
+    assert(a.scopes.contains(UseScope.Default))
+    assert(!a.scopes.contains(UseScope.Implicit))
+  }
+
+  it should "distinguish scope combinations for the same name" in {
+    val default = AnalysisInterner.usedName("map", 1)
+    val implicitScope = AnalysisInterner.usedName("map", 2)
+    val patMat = AnalysisInterner.usedName("map", 4)
+    assert(default `ne` implicitScope)
+    assert(default `ne` patMat)
+    assert(implicitScope.scopes.contains(UseScope.Implicit))
+    assert(patMat.scopes.contains(UseScope.PatMatTarget))
+  }
+
+  it should "pool names containing control characters under their escaped form" in {
+    val a = AnalysisInterner.usedName("weird\nname", 1)
+    val b = AnalysisInterner.usedName("weird\nname", 1)
+    assert(a `eq` b)
+    assert(a.name == "weird♨0Aname") // stored escaped, exactly as UsedName.make does
+  }
+
+  it should "converge on one canonical instance under concurrent interning" in {
+    // Parallel compilation interns from many threads at once. Every thread must
+    // observe the same canonical reference, and the pools must never deadlock.
+    val threads = 16
+    val start = new CountDownLatch(1)
+    val pool = Executors.newFixedThreadPool(threads)
+    try {
+      val futures = (1 to threads).map { _ =>
+        pool.submit(new Callable[(String, UsedName)] {
+          def call(): (String, UsedName) = {
+            start.await() // release all threads together to maximize contention
+            (
+              AnalysisInterner.internString(new String("concurrent.value")),
+              AnalysisInterner.usedName(new String("concurrent.value"), 5)
+            )
+          }
+        })
+      }
+      start.countDown()
+      val results = futures.map(_.get(30, TimeUnit.SECONDS)).toList // deadlock => timeout
+      assert(results.forall(_._1 `eq` results.head._1))
+      assert(results.forall(_._2 `eq` results.head._2))
+    } finally pool.shutdownNow()
+  }
+
+  it should "release canonical instances once no analysis references them" in {
+    // The leak-free requirement: canonical instances are held only weakly, so
+    // once every analysis referencing a value is dropped it becomes GC-eligible.
+    val stringRef =
+      new WeakReference[String](AnalysisInterner.internString(new String("ephemeral.str")))
+    val usedNameRef =
+      new WeakReference[UsedName](AnalysisInterner.usedName("ephemeral.used", 1))
+    val released = (1 to 100).exists { _ =>
+      System.gc()
+      Thread.sleep(10)
+      stringRef.get() == null && usedNameRef.get() == null
+    }
+    assert(released, "weak pools must not retain values after they become unreachable")
+  }
+
+  it should "keep pooled values while an analysis still references them" in {
+    val held = AnalysisInterner.usedName("held", 1)
+    System.gc()
+    Thread.sleep(10)
+    assert(AnalysisInterner.usedName("held", 1) `eq` held)
+  }
+}

--- a/internal/zinc-core/src/test/scala/sbt/internal/inc/WeakPoolSpec.scala
+++ b/internal/zinc-core/src/test/scala/sbt/internal/inc/WeakPoolSpec.scala
@@ -1,0 +1,98 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package sbt.internal.inc
+
+import java.lang.ref.WeakReference
+import java.util.concurrent.{ Callable, CountDownLatch, Executors, TimeUnit }
+
+class WeakPoolSpec extends UnitSpec {
+
+  /** GC is not obliged to collect on the first attempt, so retry for a while. */
+  private def gcUntil(cond: => Boolean): Boolean =
+    (1 to 100).exists { _ =>
+      System.gc()
+      Thread.sleep(10)
+      cond
+    }
+
+  behavior of "WeakInterner"
+
+  it should "return one canonical instance per equal value" in {
+    val interner = new WeakInterner[String]
+    val first = interner.intern(new String("value")) // force distinct heap instances
+    val second = interner.intern(new String("value"))
+    assert(first `eq` second)
+    assert(first == "value")
+  }
+
+  it should "keep values that are not equal apart" in {
+    val interner = new WeakInterner[String]
+    assert(interner.intern("a") `ne` interner.intern("b"))
+  }
+
+  it should "release canonical instances once they are unreachable" in {
+    val interner = new WeakInterner[String]
+    val ref = new WeakReference(interner.intern(new String("ephemeral")))
+    // Any pool operation drains the reference queue; without that the pool would
+    // keep growing for the lifetime of a build server.
+    assert(gcUntil { interner.intern("probe"); ref.get() == null })
+  }
+
+  it should "converge on one instance under concurrent interning" in {
+    val interner = new WeakInterner[String]
+    val threads = 16
+    val start = new CountDownLatch(1)
+    val executor = Executors.newFixedThreadPool(threads)
+    try {
+      val futures = (1 to threads).map { _ =>
+        executor.submit(new Callable[String] {
+          def call(): String = {
+            start.await() // release all threads together to maximize contention
+            interner.intern(new String("contended"))
+          }
+        })
+      }
+      start.countDown()
+      val results = futures.map(_.get(30, TimeUnit.SECONDS)).toList // deadlock => timeout
+      assert(results.forall(_ `eq` results.head))
+    } finally executor.shutdownNow()
+  }
+
+  behavior of "WeakValuePool"
+
+  it should "return null for an absent key" in {
+    val pool = new WeakValuePool[String, StringBuilder]
+    assert(pool.get("absent") == null)
+  }
+
+  it should "keep the first value published for a key" in {
+    val pool = new WeakValuePool[String, StringBuilder]
+    val first = new StringBuilder("v")
+    assert(pool.putIfAbsent("k", first) == null)
+    assert(pool.putIfAbsent("k", new StringBuilder("v")) `eq` first)
+    assert(pool.get("k") `eq` first)
+  }
+
+  it should "drop the entry, including its key, once the value is unreachable" in {
+    val pool = new WeakValuePool[String, StringBuilder]
+    var key: String = new String("transient.key") // a literal would live in the string table
+    var value: StringBuilder = new StringBuilder("transient.value")
+    pool.putIfAbsent(key, value)
+    val keyRef = new WeakReference(key)
+    val valueRef = new WeakReference(value)
+    key = null
+    value = null
+    // The entry holds its key strongly, so releasing the value must release the
+    // key with it -- otherwise the pool leaks one key per dead value.
+    assert(gcUntil { pool.get("other"); keyRef.get() == null && valueRef.get() == null })
+  }
+}

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/consistent/ConsistentAnalysisFormat.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/consistent/ConsistentAnalysisFormat.scala
@@ -12,7 +12,7 @@
 package sbt.internal.inc.consistent
 
 import java.nio.file.Paths
-import java.util.{ Arrays, Comparator, EnumSet }
+import java.util.{ Arrays, Comparator }
 import sbt.internal.inc.{ UsedName, Stamp => StampImpl, _ }
 import sbt.internal.util.Relation
 import sbt.util.InterfaceUtil
@@ -192,7 +192,7 @@ class ConsistentAnalysisFormat(val mappers: ReadWriteMappers, reproducible: Bool
       val bh = in.long()
       val ebh = in.long()
       val nhNames = in.readStringArray()
-      val nhScopes = in.readArray[UseScope]() { UseScope.values()(in.byte().toInt) }
+      val nhScopes = in.readArray[UseScope]() { useScopeValues(in.byte().toInt) }
       val nhHashes = in.readArray[Int]() { in.int() }
       val nameHashes = new Array[NameHash](nhNames.length)
       var i = 0
@@ -265,7 +265,7 @@ class ConsistentAnalysisFormat(val mappers: ReadWriteMappers, reproducible: Bool
   private def readSourceInfos(in: Deserializer): SourceInfos = {
     def readProblem(): Problem = in.readBlock {
       val category = in.string()
-      val severity = Severity.values.apply(in.byte().toInt)
+      val severity = severityValues(in.byte().toInt)
       val message = in.string()
       val rendered = Option(in.string())
       def io(): Option[Integer] = in.int() match { case -1 => None; case i => Some(i) }
@@ -339,7 +339,7 @@ class ConsistentAnalysisFormat(val mappers: ReadWriteMappers, reproducible: Bool
       val scalacOptions = in.readArray() { readMapper.mapScalacOption(in.string()) }
       val javacOptions = in.readArray() { readMapper.mapJavacOption(in.string()) }
       val compilerVersion = in.string()
-      val compileOrder = CompileOrder.values()(in.byte().toInt)
+      val compileOrder = compileOrderValues(in.byte().toInt)
       val skipApiStoring = in.bool()
       val extra = in.readArray(2) { InterfaceUtil.t2(in.string() -> in.string()) }
       val outputPath = in.string()
@@ -434,12 +434,7 @@ class ConsistentAnalysisFormat(val mappers: ReadWriteMappers, reproducible: Bool
   private def writeUsedNameSet(out: Serializer, uns: scala.collection.Set[UsedName]): Unit = {
     out.writeBlock("UsedName") {
       val groups0 = uns.iterator.map { un =>
-        val sc = un.scopes
-        var i = 0
-        if (sc.contains(UseScope.Default)) i += 1
-        if (sc.contains(UseScope.Implicit)) i += 2
-        if (sc.contains(UseScope.PatMatTarget)) i += 4
-        (un.name, i.toByte)
+        (un.name, AnalysisInterner.scopeBits(un.scopes).toByte)
       }.toArray.groupBy(_._2)
       val groups = if (reproducible) groups0.toVector.sortBy(_._1) else groups0
       out.writeColl("groups", groups, 2) { case (g, gNames) =>
@@ -452,12 +447,14 @@ class ConsistentAnalysisFormat(val mappers: ReadWriteMappers, reproducible: Bool
   }
 
   private def readUsedNameSet(in: Deserializer): Set[UsedName] = {
-    import scala.jdk.CollectionConverters.*
     in.readBlock {
+      // The name and the scope bits fully determine a UsedName, so the interner
+      // can return the pooled instance without constructing a candidate first.
       val data = in.readColl[Vector[UsedName], Vector[Vector[UsedName]]](Vector, 2) {
-        val i = in.byte().toInt
-        val names = in.readStringSeq()
-        names.iterator.map { n => UsedName(n, useScopes(i).asScala) }.toVector
+        val scopeBits = in.byte().toInt
+        in.readColl[UsedName, Vector[UsedName]](Vector) {
+          AnalysisInterner.usedName(in.string(), scopeBits)
+        }
       }
       data.flatten.toSet
     }
@@ -542,14 +539,14 @@ class ConsistentAnalysisFormat(val mappers: ReadWriteMappers, reproducible: Bool
   private def readAnnotation(in: Deserializer): Annotation = in.readBlock {
     val base = readType(in)
     val args = in.readArray(2)(AnnotationArgument.of(in.string(), in.string()))
-    Annotation.of(base, args)
+    internNode(in, Annotation.of(base, args))
   }
 
   private def writeDefinitionType(out: Serializer, dt: DefinitionType): Unit =
     out.byte(dt.ordinal().toByte)
 
   private def readDefinitionType(in: Deserializer): DefinitionType =
-    DefinitionType.values()(in.byte().toInt)
+    definitionTypeValues(in.byte().toInt)
 
   private def writeTypeParameter(out: Serializer, tp: TypeParameter): Unit =
     out.writeBlock("TypeParameter") {
@@ -562,13 +559,16 @@ class ConsistentAnalysisFormat(val mappers: ReadWriteMappers, reproducible: Bool
     }
 
   private def readTypeParameter(in: Deserializer): TypeParameter = in.readBlock {
-    TypeParameter.of(
-      in.string(),
-      in.readArray[Annotation]()(readAnnotation(in)),
-      in.readArray[TypeParameter]()(readTypeParameter(in)),
-      Variance.values()(in.byte().toInt),
-      readType(in),
-      readType(in)
+    internNode(
+      in,
+      TypeParameter.of(
+        in.string(),
+        in.readArray[Annotation]()(readAnnotation(in)),
+        in.readArray[TypeParameter]()(readTypeParameter(in)),
+        varianceValues(in.byte().toInt),
+        readType(in),
+        readType(in)
+      )
     )
   }
 
@@ -612,16 +612,21 @@ class ConsistentAnalysisFormat(val mappers: ReadWriteMappers, reproducible: Bool
   }
 
   private def readType(in: Deserializer): Type = in.readBlock {
+    // Structure (case 2) uses identity equality (lazy members), so dedup
+    // cannot canonicalize it; every other variant has value equality.
+    def i(t: Type): Type = internNode(in, t)
     in.byte() match {
-      case 0 => ParameterRef.of(in.string())
-      case 1 => Parameterized.of(readType(in), in.readArray[Type]()(readType(in)))
+      case 0 => i(ParameterRef.of(in.string()))
+      case 1 => i(Parameterized.of(readType(in), in.readArray[Type]()(readType(in))))
       case 2 => readStructure(in)
-      case 3 => Polymorphic.of(readType(in), in.readArray[TypeParameter]()(readTypeParameter(in)))
-      case 4 => Constant.of(readType(in), in.string())
-      case 5 => Existential.of(readType(in), in.readArray[TypeParameter]()(readTypeParameter(in)))
-      case 6 => Singleton.of(readPath(in))
-      case 7 => Projection.of(readType(in), in.string())
-      case 8 => Annotated.of(readType(in), in.readArray[Annotation]()(readAnnotation(in)))
+      case 3 =>
+        i(Polymorphic.of(readType(in), in.readArray[TypeParameter]()(readTypeParameter(in))))
+      case 4 => i(Constant.of(readType(in), in.string()))
+      case 5 =>
+        i(Existential.of(readType(in), in.readArray[TypeParameter]()(readTypeParameter(in))))
+      case 6 => i(Singleton.of(readPath(in)))
+      case 7 => i(Projection.of(readType(in), in.string()))
+      case 8 => i(Annotated.of(readType(in), in.readArray[Annotation]()(readAnnotation(in))))
       case 9 => EmptyTypeSingleton
     }
   }
@@ -740,7 +745,7 @@ class ConsistentAnalysisFormat(val mappers: ReadWriteMappers, reproducible: Bool
           in.string(),
           readType(in),
           in.bool(),
-          ParameterModifier.values()(in.byte().toInt)
+          parameterModifierValues(in.byte().toInt)
         )
       },
       in.bool()
@@ -813,21 +818,33 @@ class ConsistentAnalysisFormat(val mappers: ReadWriteMappers, reproducible: Bool
 }
 
 object ConsistentAnalysisFormat {
+
+  /**
+   * Dedups a value-equality `xsbti.api` tree node against the current read only.
+   * Nearly all node duplication is within a single analysis, so a plain per-read
+   * map captures it without weak-reference bookkeeping; the cache dies with the
+   * deserializer, so it cannot leak.
+   */
+  private[consistent] def internNode[A <: AnyRef](in: Deserializer, a: A): A = {
+    val prev = in.nodeCache.putIfAbsent(a, a)
+    if (prev == null) a else prev.asInstanceOf[A]
+  }
+
   private final val EmptyTypeSingleton = EmptyType.of()
   private final val ThisSingleton = This.of()
   private final val ThisQualifierSingleton = ThisQualifier.of()
   private final val UnqualifiedSingleton = Unqualified.of()
   private final val PublicSingleton = Public.of()
-  private final val DefaultCompilationTimestamp: Long = 1262304042000L // 2010-01-01T00:00:42Z
 
-  private final val useScopes: Array[EnumSet[UseScope]] =
-    Array.tabulate(8) { i =>
-      val e = EnumSet.noneOf(classOf[UseScope])
-      if ((i & 1) != 0) e.add(UseScope.Default)
-      if ((i & 2) != 0) e.add(UseScope.Implicit)
-      if ((i & 4) != 0) e.add(UseScope.PatMatTarget)
-      e
-    }
+  // Enum `values()` clones the backing array on every call; these are on per-node
+  // read paths, so cache one copy of each.
+  private final val useScopeValues = UseScope.values()
+  private final val severityValues = Severity.values()
+  private final val compileOrderValues = CompileOrder.values()
+  private final val definitionTypeValues = DefinitionType.values()
+  private final val varianceValues = Variance.values()
+  private final val parameterModifierValues = ParameterModifier.values()
+  private final val DefaultCompilationTimestamp: Long = 1262304042000L // 2010-01-01T00:00:42Z
 
   private final val nameHashComparator: Comparator[NameHash] = new Comparator[NameHash] {
     def compare(o1: NameHash, o2: NameHash): Int = {

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/consistent/Serializer.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/consistent/Serializer.scala
@@ -30,6 +30,8 @@ import scala.collection.mutable
 import scala.reflect.ClassTag
 import scala.collection.Factory
 
+import sbt.internal.inc.AnalysisInterner
+
 /** Structural serialization for text and binary formats. */
 abstract class Serializer {
   private final val dedupMap: mutable.Map[AnyRef, Int] = mutable.Map.empty
@@ -115,6 +117,11 @@ abstract class Serializer {
 /** Derialization for text and binary formats produced by Serializer. */
 abstract class Deserializer {
   private final val dedupBuffer: ArrayBuffer[AnyRef] = ArrayBuffer.empty
+
+  // Per-read dedup state for value-equality `xsbti.api` tree nodes (used by
+  // ConsistentAnalysisFormat.internNode): dies with the deserializer, so it
+  // cannot leak.
+  private[consistent] final val nodeCache = new java.util.HashMap[AnyRef, AnyRef]()
 
   def startBlock(): Unit
   def startArray(): Int
@@ -467,7 +474,7 @@ class BinaryDeserializer(_in: InputStream) extends Deserializer {
     case -1 => null
     case 0  => ""
     case len if len > 0 =>
-      val s = if (len <= buffer.length) {
+      val raw = if (len <= buffer.length) {
         ensure(len)
         val s = new String(buffer, pos, len, StandardCharsets.UTF_8)
         pos += len
@@ -478,6 +485,9 @@ class BinaryDeserializer(_in: InputStream) extends Deserializer {
         assert(read == len)
         new String(a, StandardCharsets.UTF_8)
       }
+      // Canonicalize the freshly decoded string so the per-read table and all its
+      // back-references hold the cross-analysis-shared instance.
+      val s = AnalysisInterner.internString(raw)
       strings += s
       s
     case idx =>

--- a/internal/zinc-persist/src/test/scala/sbt/inc/consistent/ConsistentAnalysisFormatInternerSuite.scala
+++ b/internal/zinc-persist/src/test/scala/sbt/inc/consistent/ConsistentAnalysisFormatInternerSuite.scala
@@ -1,0 +1,100 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package sbt.internal.inc.consistent
+
+import org.scalatest.funsuite.AnyFunSuite
+import sbt.internal.inc.{ Analysis, FileAnalysisStore, UsedName }
+import sbt.io.IO
+import xsbti.api.{ ParameterRef, Projection }
+import xsbti.compile.AnalysisContents
+import xsbti.compile.analysis.ReadWriteMappers
+import java.io.*
+
+/**
+ * Verifies that the consistent binary format dedups inline while deserializing:
+ * strings and `UsedName`s are shared across independently-read analyses via the
+ * process-wide interner, and value-equality api tree nodes are shared within one
+ * read via the per-read node cache.
+ */
+class ConsistentAnalysisFormatInternerSuite extends AnyFunSuite {
+
+  /** Serialize a single string, then read it back through a fresh deserializer. */
+  private def roundTripString(s: String): String = {
+    val out = new ByteArrayOutputStream()
+    val ser = SerializerFactory.binary.serializerFor(out)
+    ser.string(s)
+    ser.end()
+    val deser = SerializerFactory.binary.deserializerFor(new ByteArrayInputStream(out.toByteArray))
+    deser.string()
+  }
+
+  test("strings are canonicalized across independent reads (cross-analysis)") {
+    val a = roundTripString(new String("com.example.CrossAnalysis"))
+    val b = roundTripString(new String("com.example.CrossAnalysis"))
+    assert(a == b)
+    assert(a `eq` b) // two separate reads share one canonical instance
+  }
+
+  test("api tree nodes are deduped within one read (per-read node cache)") {
+    val deser =
+      SerializerFactory.binary.deserializerFor(new ByteArrayInputStream(Array.empty[Byte]))
+    val t1 = ConsistentAnalysisFormat.internNode(deser, Projection.of(ParameterRef.of("P"), "x"))
+    val t2 = ConsistentAnalysisFormat.internNode(deser, Projection.of(ParameterRef.of("P"), "x"))
+    assert(t1 `eq` t2)
+  }
+
+  private val mappers = ReadWriteMappers.getEmptyMappers()
+
+  private def writeConsistentBinary(contents: AnalysisContents): File = {
+    val out = File.createTempFile("interner-node", ".zip")
+    out.deleteOnExit()
+    if (out.exists()) IO.delete(out)
+    ConsistentFileAnalysisStore.binary(out, mappers).set(contents)
+    out
+  }
+
+  private def readAnalysis(file: File): Analysis =
+    ConsistentFileAnalysisStore.binary(file, mappers).unsafeGet().getAnalysis.asInstanceOf[Analysis]
+
+  /** First used name under the alphabetically-first class -- deterministic across reads. */
+  private def firstUsedName(a: Analysis): UsedName =
+    a.relations.names.toMultiMap.toSeq
+      .sortBy(_._1)
+      .iterator
+      .flatMap(_._2.toSeq.sortBy(_.name))
+      .next()
+
+  test("UsedNames are canonicalized across independent reads (cross-analysis)") {
+    val d = new File("../../../test-data", "library.zip")
+    assert(d.exists())
+    val bin = writeConsistentBinary(FileAnalysisStore.text(d).unsafeGet())
+
+    val a = readAnalysis(bin) // two independent deserializations of the same analysis
+    val b = readAnalysis(bin)
+    val ua = firstUsedName(a)
+    val ub = firstUsedName(b)
+    assert(ua == ub) // same value (same analysis read twice)
+    assert(ua `eq` ub) // shared canonical instance across the two reads
+  }
+
+  test("interning preserves apiHash (transparent to change detection)") {
+    val d = new File("../../../test-data", "library.zip")
+    assert(d.exists())
+    val original = FileAnalysisStore.text(d).unsafeGet().getAnalysis.asInstanceOf[Analysis]
+    val interned = readAnalysis(writeConsistentBinary(FileAnalysisStore.text(d).unsafeGet()))
+
+    val originalHashes = original.apis.internal.view.mapValues(_.apiHash()).toMap
+    val internedHashes = interned.apis.internal.view.mapValues(_.apiHash()).toMap
+    assert(originalHashes.nonEmpty)
+    assert(originalHashes == internedHashes) // interning changes nothing change-detection observes
+  }
+}


### PR DESCRIPTION
**Disclaimer**: Developed with Claude Code and human review in the loop

Fixes https://github.com/sbt/zinc/issues/1753

## Changes

- **Global weak string pool** — interned inline in `BinaryDeserializer.string()`, so the per-read string table and all of its back-references hold the cross-analysis-shared instance.
- **`UsedName` pools** — 8 weak-valued `name → UsedName` pools, one per `UseScope` combination. A `UsedName` is fully determined by its (already canonical) name and 3 scope bits, so probing is keyed by the name string and a pool hit allocates **nothing**; a candidate is constructed only on a miss. `UsedName` also gains a cached `hashCode` (it is re-hashed into a per-class `Set` on every read) which fits in existing object padding.
- **Both pool types are hand-rolled** in `zinc-core/WeakPools.scala` on `ConcurrentHashMap` + `ReferenceQueue`, so this adds **no dependency**. `WeakInterner` keys its map by a weak reference that hashes and compares by its referent's *value*; `WeakValuePool` keeps strong equals-keyed keys with weakly-held values, which is what makes probe-before-construct possible.
- **Per-read node cache** — a plain `HashMap` on `Deserializer`, used through `ConsistentAnalysisFormat.internNode`, dedups value-equality `xsbti.api` nodes within a single read. ~95% of `Type`/`TypeParameter`/`Annotation` duplication is intra-analysis, so this captures nearly all of it with no weak-reference bookkeeping, and it is leak-free by construction: the cache dies with the read. `Structure` and `EmptyType` are excluded (identity equality / singleton).
- **Shared scope `EnumSet`s** — the 8 possible `UseScope` sets are allocated once and shared instead of copied per `UsedName`. Worth 251 MB by itself, independent of interning.
- **Cached `enum.values()`** — `values()` clones its backing array on every call and sits on per-node read paths (`UseScope`, `Severity`, `CompileOrder`, `DefinitionType`, `Variance`, `ParameterModifier`).
- **`readUsedNameSet` interns per name** instead of materializing a `Seq[String]` per scope group and mapping it into fresh `UsedName`s; `writeUsedNameSet` shares the same scope-bit encoding instead of repeating it.
- **The fresh-compilation path interns too** (`AnalysisCallback.usedName`), so compiler-produced names are canonical, not only deserialized ones.

## Leak-freedom

A build server runs for days, so pooling must not retain. Both pools hold their canonical values **weakly**: once the last analysis referencing a value is dropped the value becomes collectable, and every pool operation drains the reference queue so the entry goes with it.

`WeakInterner` (strings) keys the map by a weak reference that hashes and compares by the *value* of its referent, so nothing in the pool strongly references an interned string. `WeakValuePool` (`UsedName`) is keyed strongly by the name and holds the value weakly; the entry remembers its key so that expunging a dead value releases the key too. (Keying that pool weakly instead would leak — the value references its key, pinning it.) `WeakPoolSpec` asserts, for both pools, that values *and* keys are released once unreachable; `AnalysisInternerSpec` asserts the same end to end, plus retention while a reference is held.

Thread safety: the pools are `ConcurrentHashMap`s, and the fresh-compile path interns from many threads at once; a 16-thread test asserts every thread converges on one canonical instance without deadlock.

Transparency: a test asserts api hashes are identical before and after a round trip, so nothing incremental compilation observes changes.

## Why `NameHash` is deliberately not interned

It is the highest-volume type (15.7 M instances, 424 MB incl. arrays) and the obvious candidate, but the shape is wrong: its internal side has **zero** within-analysis duplication (5,999,323 occurrences = 5,999,323 distinct values) and the corpus-wide distinct population is 6.7 M, so a weak pool would need ~6.7 M entries at ~40 B each — more than the duplicates it removes. Measured directly, interning it *increased* retained heap (+12 MB at 100 analyses) and cost 15.6% of read CPU. Unlike `UsedName` there is also no probe-before-construct trick, because identity includes the api hash int, so all 15.7 M reads would have to allocate a candidate first.

It remains the largest analysis-side consumer and is the next thing worth attacking, but it needs a representation change (parallel `String[]`/`int[]` instead of 15.7 M wrappers, or sharing whole `nameHashes` arrays per `(className, apiHash)`) — both breaking changes to a public `xsbti` type, so out of scope here.

## Benchmark results

All numbers below are from one session on one machine, each measurement paired against a stock `develop` worktree running the identical harness back to back.

### Heap: all 582 analyses co-resident

4 GB fixed heap, loading every analysis in the corpus and holding strong references to all of them. Both heap figures come from the same run: first sampled with no explicit GC (what the process actually occupies right after loading, floating garbage included), then after four forced GCs with every analysis still held (the live set — the steady-state floor a long-lived build server sits at).

| metric | stock `develop` | this PR | Δ |
|---|---|---|---|
| used heap after load, **before GC** | 2335 MB | 1738 MB | −597 MB (−26%) |
| **retained heap after GC** | 1906 MB | **1237 MB** | **−669 MB (−35%)** |
| garbage in the pre-GC sample | 429 MB | 501 MB | |
| histogram total bytes (incl. garbage) | 2343 MiB | 1296 MiB | −1047 MiB (−45%) |
| histogram total objects (incl. garbage) | 82.28 M | 43.61 M | −38.7 M (−47%) |

**Judge this by the retained row.** It is stable: stock measured 1906 MB in two sessions a day apart, and a second harness reports 1904 MB (1 thread) / 1901 MB (8 threads) for stock against 1244 / 1238 MB for this PR — agreement to within 0.6%. The pre-GC row is that same live set plus whatever floating garbage the loader happened to leave behind, which depends entirely on when G1 last collected: across repeat runs stock landed between 2233 and 2536 MB and this PR between 1460 and 1738 MB, i.e. a delta anywhere from −26% to −39%. Of the 669 MB retained saving, roughly 256 MB comes from the format-level fixes alone (measured with interning disabled while it was still switchable) and the rest from the pools.

Where the heap goes, class by class (pre-GC histogram, same pair of runs):

| class | stock | this PR | Δ | cause |
|---|---|---|---|---|
| `java.util.RegularEnumSet` | 8,224,311 / 251.0 MiB | **absent** (< 1.7 MiB) | −251 MiB | shared scope sets |
| `sbt.internal.inc.UsedName` | 8,224,298 / 188.2 MiB | **396,197 / 9.1 MiB** | −179 MiB | UsedName pools |
| `byte[]` (string bodies) | 3.33 M / 208.5 MiB | 1.05 M / 80.7 MiB | −128 MiB | string pool |
| `xsbti.api.Projection` | 4,120,137 / 94.3 MiB | 509,459 / 11.7 MiB | −83 MiB | per-read node cache |
| `xsbti.api.Singleton` | 4,092,961 / 62.5 MiB | **absent** | −62 MiB | per-read node cache |
| `readUsedNameSet` wrappers (`JSetWrapper`, `SetHasAsScala`, lambda) | 3.22 M / 57.3 MiB | **absent** | −57 MiB | no `EnumSet.asScala` per name |
| `[Lxsbti.UseScope;` | 1,543,366 / 52.6 MiB | **absent** | −53 MiB | cached `values()` |
| `java.lang.String` | 3,119,293 / 71.4 MiB | 1,042,455 / 23.9 MiB | −48 MiB | string pool |
| `xsbti.api.Annotation` + args + arrays | 960,212 / 22.0 MiB | 210,975 / 4.8 MiB | −17 MiB | per-read node cache |
| `xsbti.api.NameHash` | 15,727,923 / 360.0 MiB | 15,727,923 / 360.0 MiB | 0 | not interned, by design |
| `[Lxsbti.api.NameHash;` | 241,470 / 64.1 MiB | 241,470 / 64.1 MiB | 0 | not interned, by design |
| pool bookkeeping (`WeakValue`, `KeyedWeakValue`, their map nodes) | 0 | 2.81 M / ~85.6 MiB | **+86 MiB** | cost side |

`NameHash` and its arrays are byte-identical between the two columns (15,727,923 instances, 377,470,152 bytes), which is the clearest confirmation that this PR leaves it untouched.

The interned `UsedName` count equals the corpus-global distinct population exactly (396,197) — the pools are perfect. Bookkeeping is what interning costs: one weak reference plus one map node per canonical value — 1,007,113 strings (30.7 MiB of `WeakValue`) and 396,197 `UsedName`s (12.1 MiB of `KeyedWeakValue`), plus ~42.8 MiB of `ConcurrentHashMap` nodes.

### CPU: zinc's own `AnalysisFormatBenchmark`

Read path, the only one that interns, with enough iterations to settle (`-f1 -wi 5 -i 10 …readConsistentBinary`):

| build | `readConsistentBinary` | vs stock |
|---|---|---|
| stock `develop` | 95.546 ± 0.627 ms | — |
| this PR | **99.038 ± 2.274 ms** | **+3.7%** |
| earlier revision of this PR, Guava pools | 102.919 ± 3.540 ms | +7.7% |

The whole benchmark class as a control (`-f1 -wi 3 -i 5 xsbt.AnalysisFormatBenchmark`, same session):

| benchmark | stock `develop` | this PR | Δ |
|---|---|---|---|
| `readConsistentBinary` | 94.332 ± 3.947 ms | 95.571 ± 5.328 ms | +1.3% |
| `writeConsistentBinary` | 136.822 ± 3.699 ms | 134.833 ± 1.539 ms | −1.5% |
| `writeConsistentBinaryNoSort` | 63.941 ± 3.090 ms | 61.687 ± 0.371 ms | −3.5% |
| `writeNull` | 122.548 ± 9.534 ms | 111.511 ± 0.151 ms | −9.0% |
| `writeNullNoSort` | 51.364 ± 0.589 ms | 46.341 ± 0.564 ms | −9.8% |

This PR barely touches serialization, so the four write benchmarks are a control — and they come out *faster* here, which is the point: at five iterations the run-to-run drift on this machine is several percent in either direction, so read cost should be read off the tighter run above (+3.7%), not from this table.

### CPU: loading the whole corpus

582 analyses in a 4 GB heap, median of three runs each:

| workload | stock `develop` | this PR | Δ |
|---|---|---|---|
| sequential | 4110 ms | 4857 ms | +18% |
| 8 threads | 2032 ms | 2383 ms | +17% |

Both builds scale identically from 1 to 8 threads — stock 2.02×, this PR 2.04× — so the pools add per-call work, not lock contention: `ReferenceQueue.poll()` returns on a plain volatile read while the queue is empty, and the maps are `ConcurrentHashMap`s. (The Guava-based revision measured 2387 ms at 8 threads, indistinguishable from the hand-rolled 2383 ms.)

### End to end in a real build

Published this branch as zinc `2.0.0-intern-SNAPSHOT`, built sbt against it, and ran `Test / compileIncremental` over a 303-module monorepo (603 analyses). This run predates the switch from Guava to the hand-rolled pools; the pooled populations it reports are a property of the pooling scheme, which is unchanged.

- **`[success]`, 710 s**, no errors.
- Peak heap 16914 MB, retained after forced GC 4761 MB (project's own `-Xmx20G -Xms8G`, G1).
- In the live server, `UsedName` held **400,158 instances / 9.2 MiB** — within 1% of the corpus-global distinct population — while compiling new modules *and* holding 600+ analyses. So the pools stay canonical under a real parallel compile, not only when reading files.
- `RegularEnumSet` was **absent from the entire histogram**.
- `NameHash` was 704 MiB / 30.8 M instances (+125 MiB of arrays), again the dominant analysis-side cost and untouched here.
- Pool bookkeeping totalled 54.5 MiB (Guava entries at the time; the hand-rolled pools cost about a third more per entry).

## Compatibility

- Analysis format version unchanged (**1100029**) — existing analysis files stay readable, and files written by this build are readable by stock zinc. Verified against released zinc 2.0.0.
- No public API change; `AnalysisInterner` is `sbt.internal.inc`.
- Api hashes unchanged (asserted by test), so incremental invalidation behaves identically.
- No new dependency: the weak pools are hand-rolled on the JDK's `ConcurrentHashMap` and `ReferenceQueue`.

## Testing

- `WeakPoolSpec` — canonicalization and separation of unequal values; 16-thread convergence; release of values once unreachable; for the weak-valued pool, `get`/`putIfAbsent` semantics and release of the *key* along with its dead value.
- `AnalysisInternerSpec` — string canonicalization; one `UsedName` per (name, scope) with probe-before-construct; scope-combination distinction; control-character names pooled under their escaped form; 16-thread convergence; release once unreachable; retention while referenced.
- `ConsistentAnalysisFormatInternerSuite` — strings shared across independent reads; node cache within one read; `UsedName`s shared across independent reads; api hashes preserved.
- Full build green: `zincRoot/testFull` — 221 scalatest tests + 78 property checks, 0 failures, including the e2e `IncrementalCompilerSpec`/`MultiProjectIncrementalSpec` suites that exercise fresh compilation. `scalafmtCheckAll`, `scalafmtSbtCheck`, `headerCheck` and `Test/headerCheck` clean.
