### PR TITLE
[2.x] perf: Defer `MappedDirectory` listing to first access

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/MappedVirtualFile.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/MappedVirtualFile.scala
@@ -53,10 +53,16 @@ object MappedVirtualFile {
 class MappedDirectory(
     encodedPath: String,
     rootPathsMap: Map[String, Path],
-    val items: List[VirtualFile]
+    items0: => List[VirtualFile]
 ) extends BasicVirtualFileRef(encodedPath)
     with PathBasedFile {
   private def path: Path = MappedVirtualFile.toPath(encodedPath, rootPathsMap)
+
+  // Only the hashes below read `items`; most consumers of a directory entry want just `toPath` or
+  // `definesClass`, so listing eagerly statted every classpath directory for nothing. The hashes
+  // therefore describe the directory as of first access.
+  lazy val items: List[VirtualFile] = items0
+
   override lazy val contentHash: Long = {
     val buffer = ByteBuffer.allocate(java.lang.Long.BYTES * items.size)
     items.foreach { item =>
@@ -81,7 +87,7 @@ object MappedDirectory {
   def apply(
       encodedPath: String,
       rootPaths: Map[String, Path],
-      items: List[VirtualFile]
+      items: => List[VirtualFile]
   ): MappedDirectory =
     new MappedDirectory(encodedPath, rootPaths, items)
 }
@@ -169,12 +175,15 @@ class MappedFileConverter(val rootPaths: Map[String, Path], allowMachinePath: Bo
       }
     } catch { case _: IOException => toVirtualFileForRegularFile(path) }
 
-  def toDirectory(path: Path, encodedPath: String) = {
-    val list = view.list(Glob(path, RecursiveGlob), IsRegularFile && IsNotHidden)
+  def toDirectory(path: Path, encodedPath: String): MappedDirectory = {
+    // Passed by name, so the walk runs on first access to items rather than here
+    def items = view
+      .list(Glob(path, RecursiveGlob), IsRegularFile && IsNotHidden)
       .map(_._1)
       .sorted
-    val items = list.map(toItem)
-    MappedDirectory(encodedPath, rootPaths, items.toList)
+      .map(toItem)
+      .toList
+    MappedDirectory(encodedPath, rootPaths, items)
   }
 }
 

--- a/internal/zinc-core/src/test/scala/sbt/internal/inc/MappedFileConverterInterningSpec.scala
+++ b/internal/zinc-core/src/test/scala/sbt/internal/inc/MappedFileConverterInterningSpec.scala
@@ -52,10 +52,20 @@ class MappedFileConverterInterningSpec extends UnitSpec {
     Files.write(classes.resolve("A.class"), "a".getBytes("UTF-8"))
     val converter = MappedFileConverter.empty
     val first = directory(converter.toVirtualFile(classes))
+    first.items should have size 1 // forces the listing `first` memoizes
     Files.write(classes.resolve("B.class"), "bb".getBytes("UTF-8"))
     val second = directory(converter.toVirtualFile(classes))
     first.items should have size 1
     second.items should have size 2
+  }
+
+  it should "list the directory on first access to items, not at conversion" in withTempDir { dir =>
+    val classes = Files.createDirectories(dir.resolve("classes"))
+    Files.write(classes.resolve("A.class"), "a".getBytes("UTF-8"))
+    val converter = MappedFileConverter.empty
+    val vf = directory(converter.toVirtualFile(classes))
+    Files.write(classes.resolve("B.class"), "bb".getBytes("UTF-8"))
+    vf.items should have size 2 // B.class landed after the conversion
   }
 
   it should "convert fresh once a missing path exists" in withTempDir { dir =>


### PR DESCRIPTION
**Disclaimer**: Developed with Claude Code and human review in the loop

Follow-up to #1751.

## Problem

`MappedFileConverter.toDirectory` builds a `MappedDirectory` by recursively listing the directory and converting every contained file, eagerly, at conversion time:

```scala
def toDirectory(path: Path, encodedPath: String) = {
  val list = view.list(Glob(path, RecursiveGlob), IsRegularFile && IsNotHidden)
    .map(_._1)
    .sorted
  val items = list.map(toItem)
  MappedDirectory(encodedPath, rootPaths, items.toList)
}
```

That listing exists only to feed `MappedDirectory`'s `contentHash`, `contentHashStr` and `sizeBytes` — and those are the exception rather than the rule for a directory classpath entry:

- the usual consumer wants `toPath`, to build the compiler's `-classpath`;
- `definesClass` resolves a class by path (`Locate.DirectoryDefinesClass` → `Files.isRegularFile`) and never enumerates the entry;
- stamping doesn't force it either — `Stamper.forHashInRootPaths` hashes the converted `Path` (`FarmHash.ofPath`), not the virtual file. In zinc, the only consumer of `VirtualFile.contentHash` is `FarmHash.ofFile`, used by the *source* stamper, which directories never reach.

Since every consumer converts its classpath independently and the `FileConverter` is shared build-wide, a directory on many classpaths is walked and `stat`ed once per consumer — to produce a list that is then discarded. #1751 stopped the resulting `MappedVirtualFile`s from *accumulating*; it did not stop them from being *built*.

## Change

Make the `items` constructor parameter by-name and memoize it:

```scala
class MappedDirectory(
    encodedPath: String,
    rootPathsMap: Map[String, Path],
    items0: => List[VirtualFile]
) extends BasicVirtualFileRef(encodedPath)
    with PathBasedFile {
  lazy val items: List[VirtualFile] = items0
```

and pass the walk unevaluated:

```scala
def toDirectory(path: Path, encodedPath: String): MappedDirectory = {
  // Passed by name, so the walk runs on first access to items rather than here
  def items = view
    .list(Glob(path, RecursiveGlob), IsRegularFile && IsNotHidden)
    .map(_._1)
    .sorted
    .map(toItem)
    .toList
  MappedDirectory(encodedPath, rootPaths, items)
}
```

## Why it's safe

- **Each conversion still gets its own fresh listing**, so #1751's contract holds: directory membership is always current, and each item is still revalidated against its `(lastModified, size)` by `toItem` before reuse.
- **Change detection is unaffected.** Classpath/library stamping goes through `forHashInRootPaths` → `FarmHash.ofPath`, which re-resolves by path and never reads `MappedDirectory.items`; source stamping (`FarmHash.ofFile`) only ever sees top-level source files, which are `MappedVirtualFile`, not `MappedDirectory`.
- **Behaviour change worth naming:** the derived hashes now describe the directory as of first access rather than as of conversion. This aligns `MappedDirectory` with `MappedVirtualFile`, whose `contentHash`/`contentHashStr` already read content lazily at first access. A consumer that converts an output directory, compiles into it, and *then* asks for `contentHashStr` would now hash the post-compile content. Nothing in zinc does this; downstream callers using a directory entry's hash as a cache key should be aware of the ordering.

## Tests

`MappedFileConverterInterningSpec` gains coverage for the new timing, alongside #1751's cases:

- *"list the directory on first access to items, not at conversion"* — a file written after conversion but before the first `items` read is picked up, which is only possible if nothing was listed at conversion time;
- *"reflect directory content changes in a fresh conversion"* — forces `first.items` before mutating the directory, pinning that each conversion memoizes its own listing independently (a later conversion sees the added file; the earlier one does not).
