### PR TITLE
Improve Zinc invalidation debug logs

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -337,7 +337,6 @@ object Incremental {
     val previous = previous0 match { case a: Analysis => a }
     val initialChanges =
       incremental.detectInitialChanges(sources, previous, current, lookup, converter, output)
-    log.debug(s"> initialChanges = $initialChanges")
     val binaryChanges = new DependencyChanges {
       override def modifiedBinaries: Array[File] =
         modifiedLibraries.map(converter.toPath(_).toFile)
@@ -384,15 +383,16 @@ object Incremental {
     val initialInvSources =
       if (pickleJava && hasModified) initialInvSources0 ++ javaSources
       else initialInvSources0
-    if (hasModified) {
-      if (initialInvSources == sources)
-        incremental.log.debug(s"all ${initialInvSources.size} sources are invalidated")
-      else
-        incremental.log.debug(
-          "All initially invalidated classes: " + initialInvClasses + "\n" +
-            "All initially invalidated sources:" + initialInvSources + "\n"
+    if (hasModified)
+      incremental.invalidationLog.debug(
+        InvalidationLog.section(
+          "Initial invalidation outcome",
+          Seq(
+            "classes" -> initialInvClasses,
+            "sources" -> initialInvSources.map(_.id),
+          )
         )
-    }
+      )
 
     val hasSubprojectChange = initialChanges.external.apiChanges.nonEmpty
     val analysis = withClassfileManager(options, converter, output, outputJarContent) {

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala
@@ -45,8 +45,8 @@ private[inc] abstract class IncrementalCommon(
   private def enableShallowLookup: Boolean =
     java.lang.Boolean.getBoolean("xsbt.skip.cp.lookup")
 
-  private final val wrappedLog = new PrefixingLogger("[inv] ")(log)
-  def debug(s: => String): Unit = if (options.relationsDebug) wrappedLog.debug(s) else ()
+  private[inc] final val invalidationLog = new InvalidationLog(log, options.relationsDebug)
+  def debug(s: => String): Unit = invalidationLog.detail(s)
 
   final def iterations(state0: CycleState): Iterator[CycleState] =
     new Iterator[CycleState] {
@@ -89,10 +89,22 @@ private[inc] abstract class IncrementalCommon(
 
       val invalidatedSources: Set[VirtualFile] = invalidatedRefs.map(toVf)
 
+      invalidationLog.debug(
+        InvalidationLog.section(
+          s"Cycle $cycleNum",
+          Seq(
+            "invalidated classes" -> invalidatedClasses,
+            "package-object invalidations" -> invalidatedByPackageObjects,
+            "initially changed sources" -> initialChangedSources.map(_.id),
+            "sources selected for recompilation" -> invalidatedSources.map(_.id),
+          )
+        )
+      )
+
       val pruned = IncrementalCommon
         .pruneClassFilesOfInvalidations(invalidatedSources, previous, classfileManager, converter)
 
-      debug(s"********* Pruned: \n${pruned.relations}\n*********")
+      invalidationLog.detail(s"Cycle $cycleNum pruned relations:\n${pruned.relations}")
 
       val handler = new IncrementalCallbackImpl(
         invalidatedSources,
@@ -112,7 +124,6 @@ private[inc] abstract class IncrementalCommon(
       )
 
       // Actual compilation takes place here
-      log.debug(s"compilation cycle $cycleNum")
       val result = doCompile.run(invalidatedSources, binaryChanges, handler)
       val CompileCycleResult(continue, nextInvalidations, current) = result
 
@@ -173,7 +184,13 @@ private[inc] abstract class IncrementalCommon(
 
         val newApiChanges =
           detectAPIChanges(recompiledClasses, previous.apis.internalAPI, analysis.apis.internalAPI)
-        debug(s"\nChanges:\n$newApiChanges")
+        if (!isFullCompilation && newApiChanges.apiChanges.nonEmpty)
+          invalidationLog.debug(
+            InvalidationLog.section(
+              s"Cycle $cycleNum API changes",
+              Seq("detected" -> newApiChanges.apiChanges.map(InvalidationLog.formatApiChange))
+            )
+          )
 
         val nextInvalidations =
           if (isFullCompilation) Set.empty[String]
@@ -190,6 +207,10 @@ private[inc] abstract class IncrementalCommon(
         // continue if there are no invalidations.
         val continue = nextInvalidations.nonEmpty &&
           lookup.shouldDoIncrementalCompilation(nextInvalidations, analysis)
+
+        invalidationLog.debug(
+          InvalidationLog.cycleOutcome(cycleNum, nextInvalidations, continue, isFullCompilation)
+        )
 
         if (shouldRegisterCycle) {
           registerCycle(recompiledClasses, newApiChanges, nextInvalidations, continue)
@@ -282,7 +303,7 @@ private[inc] abstract class IncrementalCommon(
       if (countRelevant(invalidated) <= countRelevant(allSources) * recompileAllFraction)
         invalidated
       else {
-        log.debug(
+        invalidationLog.debug(
           s"Recompiling all sources: number of invalidated sources > ${recompileAllFraction * 100.00} percent of all sources"
         )
         allSources ++ invalidated // Union because `all` doesn't contain removed sources
@@ -373,8 +394,10 @@ private[inc] abstract class IncrementalCommon(
     val sourceChanges: Changes[VirtualFileRef] = lookup.changedSources(previousAnalysis).getOrElse {
       val previousSources = previous.allSources
 
-      log.debug(s"previous = $previous")
-      log.debug(s"current source = $sources")
+      invalidationLog.detail(s"Previous stamps:\n$previous")
+      invalidationLog.detail(
+        InvalidationLog.section("Current sources", Seq("sources" -> sources.map(_.id)))
+      )
 
       new UnderlyingChanges[VirtualFileRef] {
         val sourceIds = sources.map(_.id)
@@ -472,12 +495,23 @@ private[inc] abstract class IncrementalCommon(
         changes.apiChanges.flatMap(invalidateClassesInternally(relations, _, isScalaClass)).toSet
       includeTransitiveInitialInvalidations(initial, invalidated, dependsOnClass)
     }
-    log.debug("Final step, transitive dependencies:\n\t" + firstClassInvalidation)
+    if (firstClassInvalidation.nonEmpty)
+      invalidationLog.detail(
+        InvalidationLog.section(
+          "Transitive invalidation result",
+          Seq("classes" -> firstClassInvalidation)
+        )
+      )
 
     // Invalidate classes linked with a class file that is produced by more than one source file
     val secondClassInvalidation = IncrementalCommon.invalidateNamesProducingSameClassFile(relations)
     if (secondClassInvalidation.nonEmpty)
-      log.debug(s"Invalidated due to generated class file collision: ${secondClassInvalidation}")
+      invalidationLog.debug(
+        InvalidationLog.section(
+          "Generated class-file collision",
+          Seq("invalidated classes" -> secondClassInvalidation)
+        )
+      )
 
     // Invalidate macro classes that transitively depend on any of the recompiled classes
     //
@@ -494,29 +528,43 @@ private[inc] abstract class IncrementalCommon(
     // API, and if it changed, which is insufficient, and upstream projects have no other way than
     // their API to signal to downstream.
     val thirdClassInvalidation = {
-      val transitive = IncrementalCommon.transitiveDeps(recompiledClasses, log)(dependsOnClass)
+      val transitive =
+        IncrementalCommon.transitiveDeps(recompiledClasses, invalidationLog.detailLogger)(
+          dependsOnClass
+        )
       (transitive -- recompiledClasses).filter(analysis.apis.internalAPI(_).hasMacro)
     }
-    log.debug(s"Invalidated macros due to upstream dependencies change: ${thirdClassInvalidation}")
+    if (thirdClassInvalidation.nonEmpty)
+      invalidationLog.debug(
+        InvalidationLog.section(
+          "Upstream changes affecting macros",
+          Seq("invalidated classes" -> thirdClassInvalidation)
+        )
+      )
 
     val newInvalidations =
       (firstClassInvalidation -- recompiledClasses) ++ secondClassInvalidation ++ thirdClassInvalidation
-    if (newInvalidations.isEmpty) {
-      log.debug("No classes were invalidated.")
-      Set.empty
-    } else {
-      if (invalidateTransitively) {
+    val nextInvalidations =
+      if (newInvalidations.isEmpty) Set.empty[String]
+      else if (invalidateTransitively) {
         // NOTE: As member reference relations do not include local relations, this invalidation will fully propagate
         // thus we can't rely solely on `firstClassTransitiveInvalidation`. Better bet is to try to find transitive
         // dependencies from result of `firstClassInvalidation`
         val firstClassTransitiveInvalidation =
-          IncrementalCommon.transitiveDeps(firstClassInvalidation, log)(dependsOnClass)
-        log.debug("Invalidate by brute force:\n\t" + firstClassTransitiveInvalidation)
+          IncrementalCommon.transitiveDeps(firstClassInvalidation, invalidationLog.detailLogger)(
+            dependsOnClass
+          )
+        invalidationLog.detail(
+          InvalidationLog.section(
+            "Brute-force transitive invalidation",
+            Seq("classes" -> firstClassTransitiveInvalidation),
+            Some("no classes")
+          )
+        )
         firstClassTransitiveInvalidation ++ secondClassInvalidation ++ thirdClassInvalidation ++ recompiledClasses
-      } else {
-        firstClassInvalidation ++ secondClassInvalidation ++ thirdClassInvalidation
-      }
-    }
+      } else firstClassInvalidation ++ secondClassInvalidation ++ thirdClassInvalidation
+
+    nextInvalidations
   }
 
   /** Invalidates classes and sources based on initially detected 'changes' to the sources, products, and dependencies.*/
@@ -555,23 +603,31 @@ private[inc] abstract class IncrementalCommon(
     val allInvalidatedSourcefiles = addedSrcs ++ modifiedSrcs ++ byProduct ++ byLibraryDep
 
     if (previous.allSources.isEmpty)
-      log.debug("Full compilation, no sources in previous analysis.")
+      invalidationLog.debug(
+        InvalidationLog.section("Initial changes", Nil, Some("full compilation"))
+      )
     else if (allInvalidatedClasses.isEmpty && allInvalidatedSourcefiles.isEmpty)
-      log.debug("No changes")
+      invalidationLog.debug(InvalidationLog.section("Initial changes", Nil, Some("no changes")))
     else
-      log.debug(s"""
-        |Initial source changes:
-        |	removed: $removedSrcs
-        |	added: $addedSrcs
-        |	modified: $modifiedSrcs
-        |Invalidated products: ${changes.removedProducts}
-        |External API changes: ${changes.external}
-        |Modified binary dependencies: ${changes.libraryDeps}
-        |Initial directly invalidated classes: $invalidatedClasses
-        |Sources indirectly invalidated by:
-        |	product: $byProduct
-        |	binary dep: $byLibraryDep
-        |	external source: $byExtSrcDep""".stripMargin)
+      invalidationLog.debug(
+        InvalidationLog.section(
+          "Initial changes",
+          Seq(
+            "removed sources" -> removedSrcs.map(_.id),
+            "added sources" -> addedSrcs.map(_.id),
+            "modified sources" -> modifiedSrcs.map(_.id),
+            "removed products" -> changes.removedProducts.map(_.id),
+            "external API changes" -> changes.external.apiChanges.map(
+              InvalidationLog.formatApiChange
+            ),
+            "modified binary dependencies" -> changes.libraryDeps.map(_.id),
+            "directly invalidated classes" -> invalidatedClasses,
+            "sources invalidated by products" -> byProduct.map(_.id),
+            "sources invalidated by binary dependencies" -> byLibraryDep.map(_.id),
+            "classes invalidated by external sources" -> byExtSrcDep,
+          )
+        )
+      )
 
     (allInvalidatedClasses, allInvalidatedSourcefiles)
   }
@@ -595,20 +651,30 @@ private[inc] abstract class IncrementalCommon(
       findClassDependencies: String => Set[String]
   ): Set[String] = {
     val newInvalidations = currentInvalidations -- previousInvalidations
-    log.debug(s"New invalidations:${ppxs(newInvalidations)}")
+    if (newInvalidations.nonEmpty)
+      invalidationLog.detail(
+        InvalidationLog.section(
+          "New invalidations",
+          Seq("classes" -> newInvalidations)
+        )
+      )
 
     val newTransitiveInvalidations =
-      IncrementalCommon.transitiveDeps(newInvalidations, log)(findClassDependencies)
+      IncrementalCommon.transitiveDeps(newInvalidations, invalidationLog.detailLogger)(
+        findClassDependencies
+      )
     // Include the initial invalidations that are present in the transitive new invalidations
     val reInvalidated = previousInvalidations.intersect(newTransitiveInvalidations)
 
-    log.debug(
-      s"Previously invalidated, but (transitively) depend on new invalidations:${ppxs(reInvalidated)}"
-    )
+    if (reInvalidated.nonEmpty)
+      invalidationLog.detail(
+        InvalidationLog.section(
+          "Previously invalidated classes depending on new invalidations",
+          Seq("classes" -> reInvalidated)
+        )
+      )
     newInvalidations ++ reInvalidated
   }
-
-  def ppxs[A](xs: Iterable[A]) = xs.iterator.map(x => s"\n\t$x").mkString
 
   /**
    * Logs API changes using debug-level logging. The API are obtained using the APIDiff class.
@@ -770,10 +836,12 @@ object IncrementalCommon {
       previousRelations: Relations,
       converter: FileConverter,
       log: Logger
-  )(implicit equivS: Equiv[XStamp]): VirtualFileRef => Boolean = { (binaryFile: VirtualFileRef) =>
-    {
+  )(implicit equivS: Equiv[XStamp]): VirtualFileRef => Boolean = {
+    val invalidationLog = new InvalidationLog(log, relationsDebug = false)
+    (binaryFile: VirtualFileRef) => {
       def invalidateBinary(reason: String): Boolean = {
-        log.debug(s"Invalidating '$binaryFile' because $reason"); true
+        invalidationLog.debug(s"Invalidating '$binaryFile' because $reason")
+        true
       }
 
       def compareStamps(previousFile: VirtualFileRef, currentFile: VirtualFileRef): Boolean = {
@@ -826,13 +894,19 @@ object IncrementalCommon {
     def all(from: T, tos: Iterable[T]): Unit = tos.foreach(to => visit(from, to))
     def visit(from: T, to: T): Unit = {
       if (!visited.contains(to)) {
-        if (logging) log.debug(s"Including $to by $from")
+        if (logging) log.debug(s"Transitive dependency traversal: including $to from $from")
         visited += to
         all(to, dependencies(to))
       }
     }
 
-    if (logging) log.debug(s"Initial set of included nodes: ${nodes.mkString(", ")}")
+    if (logging && nodes.nonEmpty)
+      log.debug(
+        InvalidationLog.section(
+          "Transitive dependency traversal",
+          Seq("initial nodes" -> nodes.iterator.map(_.toString).toVector)
+        )
+      )
     nodes.foreach { start =>
       visited += start
       all(start, dependencies(start))

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalNameHashing.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalNameHashing.scala
@@ -35,7 +35,8 @@ private[inc] class IncrementalNameHashingCommon(
 ) extends IncrementalCommon(log, options, profiler) {
   import IncrementalCommon.transitiveDeps
 
-  private val memberRefInvalidator = new MemberRefInvalidator(log, options.logRecompileOnMacro())
+  private val memberRefInvalidator =
+    new MemberRefInvalidator(log, invalidationLog, options.logRecompileOnMacro())
 
   /** @inheritdoc */
   protected def invalidatedPackageObjects(
@@ -50,11 +51,18 @@ private[inc] class IncrementalNameHashingCommon(
       cls1 <- relations.classNames(file)
     } yield cls1
 
-    debug("Invalidate package objects by inheritance only...")
     val invalidatedPackageObjects =
-      transitiveDeps(invalidatedClassesAndCodefinedClasses.toSet, log)(findSubclasses)
+      transitiveDeps(invalidatedClassesAndCodefinedClasses.toSet, invalidationLog.detailLogger)(
+        findSubclasses
+      )
         .filter(_.endsWith(".package"))
-    debug(s"Package object invalidations: ${invalidatedPackageObjects.mkString(", ")}")
+    debug(
+      InvalidationLog.section(
+        "Package-object invalidations",
+        Seq("classes" -> invalidatedPackageObjects),
+        Some("no classes")
+      )
+    )
     invalidatedPackageObjects
   }
 
@@ -97,54 +105,95 @@ private[inc] class IncrementalNameHashingCommon(
       isScalaClass: String => Boolean
   ): Set[String] = {
     val modifiedBinaryClassName = externalAPIChange.modifiedClass
-    log.debug(memberRefInvalidator.invalidationReason(externalAPIChange))
-    log.debug("All member reference dependencies will be considered within this context.")
+    invalidationLog.detail(memberRefInvalidator.invalidationReason(externalAPIChange))
+    invalidationLog.detail(
+      "All member reference dependencies will be considered within this context."
+    )
     val memberRefInv = memberRefInvalidator.get(_, relations.names, externalAPIChange, isScalaClass)
 
     // Propagate inheritance dependencies transitively.
     // This differs from normal because we need the initial crossing from externals to classes in this project.
     val byExternalInheritance = relations.inheritance.external.reverse(modifiedBinaryClassName)
-    log.debug(
-      s"Files invalidated by inheriting from (external) $modifiedBinaryClassName: $byExternalInheritance"
+    invalidationLog.detail(
+      InvalidationLog.section(
+        s"Direct inheritance from external class $modifiedBinaryClassName",
+        Seq("invalidated classes" -> byExternalInheritance),
+        Some("no classes")
+      )
     )
-    log.debug("Now invalidating by inheritance (internally).")
+    invalidationLog.detail("Now invalidating by inheritance (internally).")
     val transitiveInheritance = byExternalInheritance.flatMap(invalidateByInheritance(relations, _))
 
     val localInheritance = relations.localInheritance.external.reverse(modifiedBinaryClassName)
 
     // Get the member reference dependencies of all classes transitively invalidated by inheritance
-    log.debug("Getting direct dependencies of all classes transitively invalidated by inheritance.")
+    invalidationLog.detail(
+      "Getting direct dependencies of all classes transitively invalidated by inheritance."
+    )
     val memberRefA = transitiveInheritance.flatMap(memberRefInv(relations.memberRef.internal))
 
     // Get the classes that depend on externals by member reference.
     // This includes non-inheritance dependencies and is not transitive.
-    log.debug(s"Getting classes that directly depend on (external) $modifiedBinaryClassName.")
+    invalidationLog.detail(
+      s"Getting classes that directly depend on (external) $modifiedBinaryClassName."
+    )
     val memberRefB = memberRefInv(relations.memberRef.external)(modifiedBinaryClassName)
 
     val macroExpansion = relations.macroExpansion.external.reverse(modifiedBinaryClassName)
 
-    transitiveInheritance ++ localInheritance ++ memberRefA ++ memberRefB ++ macroExpansion
+    val invalidated =
+      transitiveInheritance ++ localInheritance ++ memberRefA ++ memberRefB ++ macroExpansion
+    invalidationLog.debug(
+      InvalidationLog.section(
+        s"External API change: ${InvalidationLog.formatApiChange(externalAPIChange)}",
+        Seq(
+          "transitive inheritance" -> transitiveInheritance,
+          "local inheritance" -> localInheritance,
+          "member reference" -> (memberRefA ++ memberRefB),
+          "macro expansion" -> macroExpansion,
+        ),
+        Some("no classes invalidated")
+      )
+    )
+    invalidated
   }
 
   private def invalidateByInheritance(relations: Relations, modified: String): Set[String] = {
     val inheritanceDeps = relations.inheritance.internal.reverse
-    log.debug(s"Invalidating (transitively) by inheritance from $modified...")
-    val transitiveInheritance = transitiveDeps(Set(modified), log)(inheritanceDeps)
-    log.debug("Invalidated by transitive inheritance dependency: " + transitiveInheritance)
+    invalidationLog.detail(s"Invalidating transitively by inheritance from $modified.")
+    val transitiveInheritance =
+      transitiveDeps(Set(modified), invalidationLog.detailLogger)(inheritanceDeps)
+    invalidationLog.detail(
+      InvalidationLog.section(
+        s"Inheritance invalidation from $modified",
+        Seq("invalidated classes" -> transitiveInheritance),
+        Some("no classes")
+      )
+    )
     transitiveInheritance
   }
 
   private def invalidateByLocalInheritance(relations: Relations, modified: String): Set[String] = {
     val localInheritanceDeps = relations.localInheritance.internal.reverse(modified)
     if (localInheritanceDeps.nonEmpty)
-      log.debug(s"Invalidate by local inheritance: $modified -> $localInheritanceDeps")
+      invalidationLog.detail(
+        InvalidationLog.section(
+          s"Local-inheritance invalidation from $modified",
+          Seq("invalidated classes" -> localInheritanceDeps)
+        )
+      )
     localInheritanceDeps
   }
 
   private def invalidateByMacroExpansion(relations: Relations, modified: String): Set[String] = {
     val macroExpansionDeps = relations.macroExpansion.internal.reverse(modified)
     if (macroExpansionDeps.nonEmpty)
-      log.debug(s"Invalidate by macro expansion: $modified -> $macroExpansionDeps")
+      invalidationLog.detail(
+        InvalidationLog.section(
+          s"Macro-expansion invalidation from $modified",
+          Seq("invalidated classes" -> macroExpansionDeps)
+        )
+      )
     macroExpansionDeps
   }
 
@@ -175,19 +224,18 @@ private[inc] class IncrementalNameHashingCommon(
     profiler.registerEvent(MacroExpansionKind, List(modifiedClass), macroExpansion, reason4)
 
     val all = transitiveInheritance ++ localInheritance ++ memberRef ++ macroExpansion
-    log.debug {
-      if (all.isEmpty) s"Change $change does not affect any class."
-      else {
-        val reason = memberRefInvalidator.invalidationReason(change)
-        def ppxs(s: String, xs: Set[String]) = if (xs.isEmpty) "" else s"$s: $xs"
-        s"""Change $change invalidates ${all.size} classes due to $reason
-           |  > ${ppxs("by transitive inheritance", transitiveInheritance)}
-           |  > ${ppxs("by local inheritance", localInheritance)}
-           |  > ${ppxs("by member reference", memberRef)}
-           |  > ${ppxs("by macro expansion", macroExpansion)}
-        """.stripMargin
-      }
-    }
+    invalidationLog.debug(
+      InvalidationLog.section(
+        s"API change: ${InvalidationLog.formatApiChange(change)}",
+        Seq(
+          "transitive inheritance" -> transitiveInheritance,
+          "local inheritance" -> localInheritance,
+          "member reference" -> memberRef,
+          "macro expansion" -> macroExpansion,
+        ),
+        Some("no classes invalidated")
+      )
+    )
     all
   }
 

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/InvalidationLog.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/InvalidationLog.scala
@@ -1,0 +1,101 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package sbt.internal.inc
+
+import scala.jdk.CollectionConverters._
+import sbt.util.Logger
+import xsbti.UseScope
+
+private[inc] final class InvalidationLog(log: Logger, relationsDebug: Boolean) {
+  private val prefixed = new Incremental.PrefixingLogger("[inv] ")(log)
+  private[inc] val detailLogger: Logger = if (relationsDebug) prefixed else Logger.Null
+
+  def debug(message: => String): Unit = prefixed.debug(message)
+
+  def detail(message: => String): Unit =
+    if (relationsDebug) prefixed.debug(message)
+}
+
+private[inc] object InvalidationLog {
+
+  /**
+   * Renders a section, omitting empty groups. Returns an empty string when every group is empty
+   * and `whenEmpty` is absent, so callers must either guard the log call or provide a fallback.
+   */
+  def section(
+      title: String,
+      groups: Iterable[(String, Iterable[String])],
+      whenEmpty: Option[String] = None,
+  ): String = {
+    val renderedGroups = groups.iterator.flatMap { case (label, values) =>
+      val sortedValues = values.iterator.toVector.sorted
+      if (sortedValues.isEmpty) None
+      else {
+        val renderedValues = sortedValues.iterator
+          .flatMap(_.linesIterator)
+          .map(line => s"    $line")
+          .mkString("\n")
+        Some(s"  $label:\n$renderedValues")
+      }
+    }.toVector
+    val body = renderedGroups ++ (if (renderedGroups.isEmpty) whenEmpty.map(s => s"  $s") else None)
+    if (body.isEmpty) "" else (title +: body).mkString("\n")
+  }
+
+  def cycleOutcome(
+      cycleNum: Int,
+      nextInvalidations: Set[String],
+      continue: Boolean,
+      isFullCompilation: Boolean,
+  ): String =
+    if (continue)
+      section(
+        s"Cycle $cycleNum outcome",
+        Seq("next-cycle invalidations" -> nextInvalidations)
+      )
+    else if (nextInvalidations.nonEmpty)
+      section(
+        s"Cycle $cycleNum outcome",
+        Seq("invalidations not scheduled for another cycle" -> nextInvalidations)
+      )
+    else
+      section(
+        s"Cycle $cycleNum outcome",
+        Nil,
+        Some(if (isFullCompilation) "full compilation complete" else "no further invalidations")
+      )
+
+  def formatUsedName(usedName: UsedName): String = {
+    val nonDefaultScopes = usedName.scopes.asScala.iterator
+      .filterNot(_ == UseScope.Default)
+      .map(_.toString)
+      .toVector
+      .sorted
+    if (nonDefaultScopes.isEmpty) usedName.name
+    else s"${usedName.name} [${nonDefaultScopes.mkString(", ")}]"
+  }
+
+  def formatUsedNames(usedNames: Iterable[UsedName]): Vector[String] =
+    usedNames.iterator.map(formatUsedName).toVector.sorted
+
+  def formatApiChange(change: APIChange): String = change match {
+    case NamesChange(modifiedClass, modifiedNames) =>
+      val names = modifiedNames.names.iterator.map(formatUsedName).toVector.sorted.mkString(", ")
+      s"$modifiedClass: modified names $names"
+    case APIChangeDueToMacroDefinition(modifiedClass) =>
+      s"$modifiedClass: macro definition changed"
+    case APIChangeDueToAnnotationDefinition(modifiedClass) =>
+      s"$modifiedClass: annotation definition changed"
+    case TraitPrivateMembersModified(modifiedClass) =>
+      s"$modifiedClass: private members changed"
+  }
+}

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/MemberRefInvalidator.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/MemberRefInvalidator.scala
@@ -54,7 +54,11 @@ import xsbti.UseScope
  * dependencies unconditionally. On the other hand, if api change is due to modified name hashes
  * of regular members then we'll invalidate sources that use those names.
  */
-private[inc] class MemberRefInvalidator(log: Logger, logRecompileOnMacro: Boolean) {
+private[inc] class MemberRefInvalidator(
+    log: Logger,
+    invalidationLog: InvalidationLog,
+    logRecompileOnMacro: Boolean
+) {
   private final val NoInvalidation = (_: String) => Set.empty[String]
   def get(
       memberRef: Relation[String, String],
@@ -83,11 +87,9 @@ private[inc] class MemberRefInvalidator(log: Logger, logRecompileOnMacro: Boolea
     case NamesChange(modifiedClass, modifiedNames) =>
       modifiedNames.in(UseScope.Implicit) match {
         case changedImplicits if changedImplicits.isEmpty =>
-          s"""|The $modifiedClass has the following regular definitions changed:
-              |\t${modifiedNames.names.mkString(", ")}.""".stripMargin
+          s"The $modifiedClass has changed definitions: ${InvalidationLog.formatUsedNames(modifiedNames.names).mkString(", ")}."
         case changedImplicits =>
-          s"""|The $modifiedClass has the following implicit definitions changed:
-              |\t${changedImplicits.mkString(", ")}.""".stripMargin
+          s"The $modifiedClass has changed implicit definitions: ${InvalidationLog.formatUsedNames(changedImplicits).mkString(", ")}."
       }
   }
 
@@ -111,9 +113,11 @@ private[inc] class MemberRefInvalidator(log: Logger, logRecompileOnMacro: Boolea
     def apply(from: String): Set[String] = {
       val invalidated = memberRef.reverse(from)
       if (invalidated.nonEmpty)
-        log.debug(
-          s"The following member ref dependencies of $from are invalidated:\n" +
-            formatInvalidated(invalidated)
+        invalidationLog.detail(
+          InvalidationLog.section(
+            s"Unconditional member-reference invalidation from $from",
+            Seq("invalidated classes" -> invalidated)
+          )
         )
       invalidated
     }
@@ -140,17 +144,27 @@ private[inc] class MemberRefInvalidator(log: Logger, logRecompileOnMacro: Boolea
       dependent.filter {
         case from if isScalaClass(from) =>
           if (!usedNames.hasAffectedNames(modifiedNames, from)) {
-            log.debug(
+            invalidationLog.detail(
               s"None of the modified names appears in source file of $from. This dependency is not being considered for invalidation."
             )
             false
           } else {
-            val affectedNames = usedNames.affectedNames(modifiedNames, from)
-            log.debug(s"The following modified names cause invalidation of $from: [$affectedNames]")
+            invalidationLog.debug(
+              InvalidationLog.section(
+                s"Member-reference invalidation of $from",
+                Seq(
+                  "modified names used by the class" -> Seq(
+                    usedNames.affectedNames(modifiedNames, from)
+                  )
+                )
+              )
+            )
             true
           }
         case from =>
-          log.debug(s"Name hashing optimization doesn't apply to non-Scala dependency: $from")
+          invalidationLog.detail(
+            s"Name hashing optimization doesn't apply to non-Scala dependency: $from"
+          )
           true
       }
     }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Relations.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Relations.scala
@@ -689,16 +689,16 @@ private class MRelationsNameHashing(
     }
     def field(name: String, value: String): String =
       if (value == "none") s"$name: none" else s"$name:$value"
-    s"""
-    |Relations:
-    |  ${field("products", relation_s(srcProd))}
-    |  ${field("library deps", relation_s(libraryDep))}
-    |  ${field("library class names", relation_s(libraryClassName))}
-    |  ${field("internalDependencies", deps_s(internalDependencies.dependencies))}
-    |  ${field("externalDependencies", deps_s(externalDependencies.dependencies))}
-    |  ${field("class names", relation_s(classes))}
-    |  ${field("used names", usedNames_s(names))}
-    |  ${field("product class names", relation_s(productClassName))}
-    """.trim.stripMargin
+    // Joined with explicit "\n" so the rendering never inherits the source checkout's line endings.
+    Vector(
+      field("products", relation_s(srcProd)),
+      field("library deps", relation_s(libraryDep)),
+      field("library class names", relation_s(libraryClassName)),
+      field("internalDependencies", deps_s(internalDependencies.dependencies)),
+      field("externalDependencies", deps_s(externalDependencies.dependencies)),
+      field("class names", relation_s(classes)),
+      field("used names", usedNames_s(names)),
+      field("product class names", relation_s(productClassName)),
+    ).mkString("Relations:\n  ", "\n  ", "")
   }
 }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Relations.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Relations.scala
@@ -662,34 +662,43 @@ private class MRelationsNameHashing(
   /** Making large Relations a little readable. */
   private val userDir = sys.props("user.dir").stripSuffix("/") + "/"
   private def nocwd(s: String) = s.stripPrefix(userDir)
-  private def line_s(k: Any, v: Any) = s"    ${nocwd(s"$k")} -> ${nocwd(s"$v")}\n"
-  def relation_s(r: Relation[?, ?]) = {
-    if (r.forwardMap.isEmpty) "Relation [ ]"
-    else r.all.toSeq.map(kv => line_s(kv._1, kv._2)).sorted.mkString("Relation [\n", "", "]")
+  private def renderPairs(entries: Iterable[(String, String)], indentation: String): String = {
+    val sorted = entries.iterator.toVector.sortBy(identity)
+    if (sorted.isEmpty) "none"
+    else sorted.iterator.map { case (key, value) => s"\n$indentation$key -> $value" }.mkString
   }
+  def relation_s(r: Relation[?, ?], indentation: String = "    ") =
+    renderPairs(
+      r.all.iterator.map(kv => nocwd(s"${kv._1}") -> nocwd(s"${kv._2}")).toVector,
+      indentation
+    )
   def usedNames_s(r: Relations.UsedNames) = {
-    if (r.isEmpty) "UsedNames [ ]"
-    else {
-      val all = r.iterator.flatMap { case (a, bs) => bs.iterator.map(b => (a, b)) }
-      all.map(kv => line_s(kv._1, kv._2)).toSeq.sorted.mkString("UsedNames [\n", "", "]")
+    val all = r.iterator.flatMap { case (className, usedNames) =>
+      usedNames.iterator.map(usedName => className -> InvalidationLog.formatUsedName(usedName))
     }
+    renderPairs(all.toVector, "    ")
   }
 
   override def toString: String = {
-    def deps_s(m: Map[?, Relation[?, ?]]) =
-      m.iterator.map {
-        case (k, vs) => s"\n    $k ${relation_s(vs)}"
-      }.mkString
+    def deps_s(m: Map[?, Relation[?, ?]]) = {
+      val rendered = m.iterator.toVector.sortBy(_._1.toString).map { case (kind, relation) =>
+        val values = relation_s(relation, "        ")
+        if (values == "none") s"\n    $kind: none" else s"\n    $kind:$values"
+      }
+      if (rendered.isEmpty) "none" else rendered.mkString
+    }
+    def field(name: String, value: String): String =
+      if (value == "none") s"$name: none" else s"$name:$value"
     s"""
     |Relations:
-    |  products: ${relation_s(srcProd)}
-    |  library deps: ${relation_s(libraryDep)}
-    |  library class names: ${relation_s(libraryClassName)}
-    |  internalDependencies: ${deps_s(internalDependencies.dependencies)}
-    |  externalDependencies: ${deps_s(externalDependencies.dependencies)}
-    |  class names: ${relation_s(classes)}
-    |  used names: ${usedNames_s(names)}
-    |  product class names: ${relation_s(productClassName)}
+    |  ${field("products", relation_s(srcProd))}
+    |  ${field("library deps", relation_s(libraryDep))}
+    |  ${field("library class names", relation_s(libraryClassName))}
+    |  ${field("internalDependencies", deps_s(internalDependencies.dependencies))}
+    |  ${field("externalDependencies", deps_s(externalDependencies.dependencies))}
+    |  ${field("class names", relation_s(classes))}
+    |  ${field("used names", usedNames_s(names))}
+    |  ${field("product class names", relation_s(productClassName))}
     """.trim.stripMargin
   }
 }

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/UsedName.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/UsedName.scala
@@ -77,6 +77,8 @@ object UsedNames {
     def hasAffectedNames(modifiedNames: ModifiedNames, from: String): Boolean =
       map(from).iterator.exists(modifiedNames.isModified)
     def affectedNames(modifiedNames: ModifiedNames, from: String): String =
-      map(from).iterator.filter(modifiedNames.isModified).mkString(", ")
+      InvalidationLog
+        .formatUsedNames(map(from).filter(modifiedNames.isModified))
+        .mkString("\n")
   }
 }

--- a/internal/zinc-core/src/test/scala/sbt/internal/inc/InvalidationLogSpec.scala
+++ b/internal/zinc-core/src/test/scala/sbt/internal/inc/InvalidationLogSpec.scala
@@ -1,0 +1,382 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package sbt.internal.inc
+
+import scala.collection.mutable.ArrayBuffer
+import java.util.Collections
+import sbt.internal.util.Relation
+import sbt.util.{ Level, Logger }
+import xsbti.{ UseScope, VirtualFileRef }
+import xsbti.api.{ DependencyContext, ExternalDependency, InternalDependency }
+import xsbti.compile.{ Changes, IncOptions }
+
+class InvalidationLogSpec extends UnitSpec {
+  behavior of "InvalidationLog"
+
+  it should "render non-empty groups as sorted indented lists" in {
+    val rendered = InvalidationLog.section(
+      "Cycle 2",
+      Seq(
+        "invalidated classes" -> Seq("example.Z", "example.A"),
+        "macro expansion" -> Nil,
+        "invalidated sources" -> Seq("/a/very/long/path/to/Example.scala"),
+      )
+    )
+
+    rendered shouldBe expectedLines(
+      """Cycle 2
+        |  invalidated classes:
+        |    example.A
+        |    example.Z
+        |  invalidated sources:
+        |    /a/very/long/path/to/Example.scala"""
+    )
+  }
+
+  it should "render an explicitly empty result without an empty heading" in {
+    InvalidationLog.section("Cycle outcome", Nil, Some("no further invalidations")) shouldBe
+      expectedLines(
+        """Cycle outcome
+          |  no further invalidations"""
+      )
+  }
+
+  it should "omit a section that has no groups or empty-result text" in {
+    InvalidationLog.section("Current sources", Nil) shouldBe ""
+  }
+
+  it should "indent every line of multiline values" in {
+    InvalidationLog.section("Cause", Seq("reason" -> Seq("first line\nsecond line"))) shouldBe
+      expectedLines(
+        """Cause
+          |  reason:
+          |    first line
+          |    second line"""
+      )
+  }
+
+  it should "hide the default used-name scope but preserve non-default scopes" in {
+    InvalidationLog.formatUsedName(UsedName("member", Seq(UseScope.Default))) shouldBe "member"
+    InvalidationLog.formatUsedName(
+      UsedName("member", Seq(UseScope.Implicit, UseScope.PatMatTarget))
+    ) shouldBe "member [Implicit, PatMatTarget]"
+  }
+
+  it should "describe API changes without raw implementation wrappers" in {
+    val names = ModifiedNames(
+      Set(
+        UsedName("zeta", Seq(UseScope.Default)),
+        UsedName("alpha", Seq(UseScope.Implicit)),
+      )
+    )
+
+    InvalidationLog.formatApiChange(NamesChange("example.A", names)) shouldBe
+      "example.A: modified names alpha [Implicit], zeta"
+    InvalidationLog.formatApiChange(APIChangeDueToMacroDefinition("example.Macro")) shouldBe
+      "example.Macro: macro definition changed"
+    InvalidationLog.formatApiChange(
+      APIChangeDueToAnnotationDefinition("example.Annotation")
+    ) shouldBe
+      "example.Annotation: annotation definition changed"
+    InvalidationLog.formatApiChange(TraitPrivateMembersModified("example.Trait")) shouldBe
+      "example.Trait: private members changed"
+  }
+
+  it should "render relation details deterministically without collection wrappers" in {
+    val relations = Relations.empty.copy(
+      names = UsedNames.fromMultiMap(
+        Map(
+          "B" -> Set(UsedName("zeta", Seq(UseScope.Implicit))),
+          "A" -> Set(UsedName("alpha", Seq(UseScope.Default))),
+        )
+      ),
+      productClassName = Relation.empty + ("B", "B$") + ("A", "A"),
+    )
+
+    relations.toString should include(
+      expectedLines(
+        """  used names:
+          |    A -> alpha
+          |    B -> zeta [Implicit]
+          |  product class names:
+          |    A -> A
+          |    B -> B$"""
+      )
+    )
+    relations.toString should not include "UsedName("
+    relations.toString should not include "Relation ["
+  }
+
+  it should "prefix every emitted line and gate detailed output" in {
+    val concise = new RecordingLogger
+    val conciseLog = new InvalidationLog(concise, relationsDebug = false)
+    var evaluatedDetail = false
+    conciseLog.debug("Cycle 1\n  invalidated classes:\n    A")
+    conciseLog.detail {
+      evaluatedDetail = true
+      "Relations:\n  products: none"
+    }
+
+    concise.messages shouldBe Seq("[inv] Cycle 1\n[inv]   invalidated classes:\n[inv]     A")
+    evaluatedDetail shouldBe false
+
+    val detailed = new RecordingLogger
+    val detailedLog = new InvalidationLog(detailed, relationsDebug = true)
+    detailedLog.detail("Relations:\n  products: none")
+
+    detailed.messages shouldBe Seq("[inv] Relations:\n[inv]   products: none")
+    detailed.messages.mkString should not include "\u001b["
+  }
+
+  it should "keep concise debug rendering lazy when debug output is discarded" in {
+    val invalidationLog = new InvalidationLog(new DiscardingLogger, relationsDebug = false)
+    var evaluated = false
+
+    invalidationLog.debug {
+      evaluated = true
+      InvalidationLog.section("Cycle", Seq("classes" -> Seq("A")))
+    }
+
+    evaluated shouldBe false
+  }
+
+  it should "describe each cycle outcome" in {
+    InvalidationLog.cycleOutcome(2, Set("B", "A"), continue = true, isFullCompilation = false)
+      .shouldBe(
+        expectedLines(
+          """Cycle 2 outcome
+            |  next-cycle invalidations:
+            |    A
+            |    B"""
+        )
+      )
+    InvalidationLog.cycleOutcome(2, Set("A"), continue = false, isFullCompilation = false)
+      .shouldBe(
+        expectedLines(
+          """Cycle 2 outcome
+            |  invalidations not scheduled for another cycle:
+            |    A"""
+        )
+      )
+    InvalidationLog.cycleOutcome(2, Set.empty, continue = false, isFullCompilation = false)
+      .shouldBe(
+        expectedLines(
+          """Cycle 2 outcome
+            |  no further invalidations"""
+        )
+      )
+    InvalidationLog.cycleOutcome(1, Set.empty, continue = false, isFullCompilation = true)
+      .shouldBe(
+        expectedLines(
+          """Cycle 1 outcome
+            |  full compilation complete"""
+        )
+      )
+  }
+
+  it should "log representative internal invalidation reasons through the formatter" in {
+    val logger = new RecordingLogger
+    val incremental = new TestIncremental(logger)
+    val relations = Relations.empty
+      .addInternalSrcDeps(
+        VirtualFileRef.of("Example.scala"),
+        Seq(
+          InternalDependency.of("B", "A", DependencyContext.DependencyByInheritance),
+          InternalDependency.of("C", "B", DependencyContext.DependencyByInheritance),
+          InternalDependency.of("D", "B", DependencyContext.LocalDependencyByInheritance),
+          InternalDependency.of("E", "B", DependencyContext.DependencyByMemberRef),
+          InternalDependency.of("F", "A", DependencyContext.DependencyByMacroExpansion),
+        )
+      )
+      .addUsedNames(
+        UsedNames.fromMultiMap(Map("E" -> Set(UsedName("changed", Seq(UseScope.Default)))))
+      )
+
+    incremental.invalidateInternal(
+      relations,
+      NamesChange("A", ModifiedNames(Set(UsedName("changed", Seq(UseScope.Default)))))
+    ) shouldBe Set("A", "B", "C", "D", "E", "F")
+
+    logger.messages.mkString("\n") should include(
+      expectedLines(
+        """[inv] API change: A: modified names changed
+          |[inv]   transitive inheritance:
+          |[inv]     A
+          |[inv]     B
+          |[inv]     C
+          |[inv]   local inheritance:
+          |[inv]     D
+          |[inv]   member reference:
+          |[inv]     E
+          |[inv]   macro expansion:
+          |[inv]     F"""
+      )
+    )
+    logger.messages.mkString should not include "Set("
+    logger.messages.mkString should not include "UsedName("
+  }
+
+  it should "log representative external and macro invalidations through the formatter" in {
+    val logger = new RecordingLogger
+    val incremental = new TestIncremental(logger)
+    val source = VirtualFileRef.of("Example.scala")
+    val relations = Relations.empty
+      .addInternalSrcDeps(
+        source,
+        Seq(
+          InternalDependency.of("C", "B", DependencyContext.DependencyByInheritance),
+          InternalDependency.of("E", "B", DependencyContext.DependencyByMemberRef),
+        )
+      )
+      .addExternalDeps(
+        source,
+        Seq(
+          ExternalDependency.of("B", "External", null, DependencyContext.DependencyByInheritance),
+          ExternalDependency.of(
+            "D",
+            "External",
+            null,
+            DependencyContext.LocalDependencyByInheritance
+          ),
+          ExternalDependency.of("G", "External", null, DependencyContext.DependencyByMemberRef),
+          ExternalDependency.of(
+            "H",
+            "External",
+            null,
+            DependencyContext.DependencyByMacroExpansion
+          ),
+        )
+      )
+      .addUsedNames(
+        UsedNames.fromMultiMap(
+          Map(
+            "E" -> Set(UsedName("changed", Seq(UseScope.Default))),
+            "G" -> Set(UsedName("changed", Seq(UseScope.Default))),
+          )
+        )
+      )
+
+    incremental.invalidateExternal(
+      relations,
+      NamesChange("External", ModifiedNames(Set(UsedName("changed", Seq(UseScope.Default)))))
+    ) shouldBe Set("B", "C", "D", "E", "G", "H")
+    incremental.invalidateExternal(relations, APIChangeDueToMacroDefinition("External")) shouldBe
+      Set("B", "C", "D", "E", "G", "H")
+
+    val messages = logger.messages.mkString("\n")
+    messages should include("[inv] External API change: External: modified names changed")
+    messages should include("[inv] External API change: External: macro definition changed")
+    messages should include("[inv]   transitive inheritance:")
+    messages should include("[inv]   local inheritance:")
+    messages should include("[inv]   member reference:")
+    messages should include("[inv]   macro expansion:")
+  }
+
+  it should "log class-file collisions and brute-force traversal through the formatter" in {
+    val logger = new RecordingLogger
+    val incremental = new TestIncremental(logger, relationsDebug = true)
+    val sourceA = VirtualFileRef.of("/src/A.scala")
+    val sourceB = VirtualFileRef.of("/src/B.scala")
+    val product = VirtualFileRef.of("/classes/Shared.class")
+    val collisionRelations = Relations.empty
+      .addProducts(sourceA, Seq(product))
+      .addProducts(sourceB, Seq(product))
+      .addClasses(sourceA, Seq("A" -> "Shared"))
+      .addClasses(sourceB, Seq("B" -> "Shared"))
+
+    incremental.invalidateAfterInternalCompilation(
+      Analysis.empty.copy(relations = collisionRelations),
+      new APIChanges(Nil),
+      Set.empty,
+      invalidateTransitively = false,
+      _ => true
+    ) shouldBe Set("A", "B")
+
+    val inheritanceRelations = Relations.empty.addInternalSrcDeps(
+      sourceA,
+      Seq(InternalDependency.of("B", "A", DependencyContext.DependencyByInheritance))
+    )
+    incremental.invalidateAfterInternalCompilation(
+      Analysis.empty.copy(relations = inheritanceRelations),
+      new APIChanges(
+        Seq(NamesChange("A", ModifiedNames(Set(UsedName("changed", Seq(UseScope.Default))))))
+      ),
+      Set("A"),
+      invalidateTransitively = true,
+      _ => true
+    ) shouldBe Set("A", "B")
+
+    val messages = logger.messages.mkString("\n")
+    messages should include("[inv] Generated class-file collision")
+    messages should include("[inv] Brute-force transitive invalidation")
+    logger.messages.foreach(_ should startWith("[inv] "))
+  }
+
+  it should "log full-compilation and no-change initial states" in {
+    val logger = new RecordingLogger
+    val incremental = new TestIncremental(logger)
+    val noChanges = InitialChanges(emptyChanges, Set.empty, Set.empty, new APIChanges(Nil))
+
+    incremental.invalidateInitial(Relations.empty, noChanges) shouldBe (Set.empty, Set.empty)
+
+    val source = VirtualFileRef.of("/src/A.scala")
+    val existingRelations = Relations.empty.addProducts(
+      source,
+      Seq(VirtualFileRef.of("/classes/A.class"))
+    )
+    incremental.invalidateInitial(existingRelations, noChanges) shouldBe (Set.empty, Set.empty)
+
+    logger.messages should contain theSameElementsInOrderAs Seq(
+      "[inv] Initial changes\n[inv]   full compilation",
+      "[inv] Initial changes\n[inv]   no changes",
+    )
+  }
+
+  /** Triple-quoted literals inherit the checkout's line endings (CRLF on Windows CI). */
+  private def expectedLines(s: String): String = s.stripMargin.replace("\r\n", "\n")
+
+  private final class TestIncremental(logger: Logger, relationsDebug: Boolean = false)
+      extends IncrementalNameHashingCommon(
+        logger,
+        IncOptions.of().withRelationsDebug(relationsDebug),
+        RunProfiler.empty
+      ) {
+    def invalidateInternal(relations: Relations, change: APIChange): Set[String] =
+      invalidateClassesInternally(relations, change, _ => true)
+
+    def invalidateExternal(relations: Relations, change: APIChange): Set[String] =
+      invalidateClassesExternally(relations, change, _ => true)
+  }
+
+  private val emptyChanges = new Changes[VirtualFileRef] {
+    override def getAdded = Collections.emptySet[VirtualFileRef]
+    override def getRemoved = Collections.emptySet[VirtualFileRef]
+    override def getChanged = Collections.emptySet[VirtualFileRef]
+    override def getUnmodified = Collections.emptySet[VirtualFileRef]
+    override def isEmpty: java.lang.Boolean = java.lang.Boolean.TRUE
+  }
+
+  private final class RecordingLogger extends Logger {
+    val messages: ArrayBuffer[String] = ArrayBuffer.empty
+
+    override def trace(t: => Throwable): Unit = ()
+    override def success(message: => String): Unit = ()
+    override def log(level: Level.Value, message: => String): Unit =
+      if (level == Level.Debug || level == Level.Info) messages += message
+  }
+
+  private final class DiscardingLogger extends Logger {
+    override def trace(t: => Throwable): Unit = ()
+    override def success(message: => String): Unit = ()
+    override def log(level: Level.Value, message: => String): Unit = ()
+  }
+}

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -17,6 +17,7 @@ import java.io.{ ByteArrayOutputStream, PrintStream }
 import java.nio.file.{ Files, Path, Paths }
 import java.net.URLClassLoader
 import java.util.jar.Manifest
+import java.util.concurrent.ConcurrentLinkedQueue
 
 import sbt.util.Logger
 import sbt.util.InterfaceUtil._
@@ -232,6 +233,9 @@ class IncHandler(directory: Path, cacheDir: Path, scriptedLog: ManagedLogger, co
     onArgs("checkIterations") {
       case (p, x :: Nil, i) => p.checkNumberOfCompilerIterations(i, x.toInt)
     },
+    onArgs("checkInvalidationLog") {
+      case (p, expectedLog :: Nil, _) => p.checkInvalidationLog(expectedLog)
+    },
     onArgs("checkNumberOfLibraries") {
       case (p, x :: Nil, i) => p.checkNumberOfLibraries(i, x.toInt)
     },
@@ -342,6 +346,16 @@ case class ProjectStructure(
   val cachedStore = AnalysisStore.cached(fileStore)
   val earlyCacheFile = baseDirectory / "target" / "early" / "inc_compile.zip"
   val earlyAnalysisStore = FileAnalysisStore.binary(earlyCacheFile.toFile)
+  private val invalidationLines = new ConcurrentLinkedQueue[String]()
+  private val compilerLog = new Logger {
+    override def trace(t: => Throwable): Unit = scriptedLog.trace(t)
+    override def success(message: => String): Unit = scriptedLog.success(message)
+    override def log(level: sbt.util.Level.Value, message: => String): Unit = {
+      val rendered = message
+      rendered.linesIterator.filter(_.startsWith("[inv] ")).foreach(invalidationLines.add)
+      scriptedLog.log(level, rendered)
+    }
+  }
   // val earlyCachedStore = AnalysisStore.cached(fileStore)
   // val profiler = new ZincInvalidationProfiler
 
@@ -417,6 +431,27 @@ case class ProjectStructure(
       assert(count == expected, msg)
       ()
     }
+
+  def checkInvalidationLog(expectedLog: String): Future[Unit] = Future {
+    import scala.jdk.CollectionConverters._
+    val expected = Files
+      .readAllLines(baseDirectory.resolve(expectedLog))
+      .asScala
+      .iterator
+      .filter(_.nonEmpty)
+      .toVector
+    val actual = invalidationLines.iterator.asScala.toVector
+    expected.foldLeft(actual) { (remaining, expectedLine) =>
+      remaining.dropWhile(_ != expectedLine) match {
+        case _ +: tail => tail
+        case _ =>
+          throw new AssertionError(
+            s"Expected invalidation-log line '$expectedLine' in order.\nActual log:\n${actual.mkString("\n")}"
+          )
+      }
+    }
+    ()
+  }
 
   def checkRecompilations(i: IncState, step: Int, expected: List[String]): Future[Unit] =
     compile(i).map { analysis =>
@@ -733,8 +768,8 @@ case class ProjectStructure(
       stamper
     )
     val result =
-      if (javaOnly) incrementalCompiler.compileAllJava(in, scriptedLog)
-      else incrementalCompiler.compile(in, scriptedLog)
+      if (javaOnly) incrementalCompiler.compileAllJava(in, compilerLog)
+      else incrementalCompiler.compile(in, compilerLog)
     val analysis = result.analysis match { case a: Analysis => a }
     cachedStore.set(AnalysisContents.create(analysis, result.setup))
     val javaOnlyStr = if (javaOnly) "(java-only) " else ""

--- a/zinc/src/sbt-test/source-dependencies/value-class-underlying/expected-invalidation-log
+++ b/zinc/src/sbt-test/source-dependencies/value-class-underlying/expected-invalidation-log
@@ -1,0 +1,29 @@
+[inv] Cycle 1 API changes
+[inv]   detected:
+[inv]     A: modified names A, A;init;, x
+[inv] Member-reference invalidation of B
+[inv]   modified names used by the class:
+[inv]     A
+[inv]     A;init;
+[inv] Member-reference invalidation of C
+[inv]   modified names used by the class:
+[inv]     A
+[inv] API change: A: modified names A, A;init;, x
+[inv]   transitive inheritance:
+[inv]     A
+[inv]   member reference:
+[inv]     B
+[inv]     C
+[inv] Cycle 1 outcome
+[inv]   next-cycle invalidations:
+[inv]     B
+[inv]     C
+[inv] Cycle 2
+[inv]   invalidated classes:
+[inv]     B
+[inv]     C
+[inv]   sources selected for recompilation:
+[inv]     ${BASE}/B.scala
+[inv]     ${BASE}/C.scala
+[inv] Cycle 2 outcome
+[inv]   no further invalidations

--- a/zinc/src/sbt-test/source-dependencies/value-class-underlying/test
+++ b/zinc/src/sbt-test/source-dependencies/value-class-underlying/test
@@ -1,3 +1,5 @@
 > run
 $ copy-file changes/A2.scala A.scala
 > run
+> checkInvalidationLog expected-invalidation-log
+> checkIterations 3


### PR DESCRIPTION
## Summary

Make Zinc’s invalidation logs concise, structured, and deterministic.

The new internal formatter consistently applies the `[inv]` prefix, sorts and indents collections, omits empty groups, and replaces raw collection and `UsedName` output with readable sections.

Plain debug logging shows the invalidation narrative. Detailed graph traversal and relation snapshots now require `relationsDebug`. Rendering remains lazy when debug output is disabled.

This does not change invalidation behavior or public APIs. Existing `apiDebug` `[diff]` output is intentionally unchanged and may be addressed separately.

Refs #338