### PR TITLE
Avoid adding a bootclasspath if it already exists

### DIFF
--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala
@@ -186,8 +186,8 @@ final class AnalyzingCompiler(
       cleanupCommands: String,
       log: Logger
   )(loader: Option[ClassLoader] = None, bindings: Seq[(String, Any)] = Nil): Unit = {
-    onArgsHandler(consoleCommandArguments(classpath, converter, options, log))
-    val (classpathString, bootClasspath) = consoleClasspaths(classpath, converter)
+    val (classpathString, bootClasspath) = consoleClasspaths(classpath, converter, options, log)
+    onArgsHandler(consoleCommandArguments(options, bootClasspath, classpathString, log))
     val (names, values0) = bindings.unzip
     val values = values0.toArray[Any].asInstanceOf[Array[AnyRef]]
     // hold reference to compiler bridge class loader to prevent its being evicted
@@ -236,14 +236,24 @@ final class AnalyzingCompiler(
     ()
   }
 
+  /**
+   * The console bridge applies `bootClasspath` on top of the parsed options, so an empty
+   * string is passed when the client already specified one (sbt/zinc#348).
+   */
   private def consoleClasspaths(
       classpath: Seq[VirtualFile],
-      converter: FileConverter
+      converter: FileConverter,
+      options: Seq[String],
+      log: Logger
   ): (String, String) = {
     val cp = classpath map { converter.toPath }
     val classpathString = CompilerArguments.absString(compArgs.finishClasspath(cp))
     val bootClasspath =
-      if (classpathOptions.autoBoot) compArgs.createBootClasspathFor(cp) else ""
+      if (!classpathOptions.autoBoot) ""
+      else if (CompilerArguments.explicitBootClasspath(options).isDefined) {
+        log.warn(CompilerArguments.ExplicitBootClasspathWarning)
+        ""
+      } else compArgs.createBootClasspathFor(cp)
     (classpathString, bootClasspath)
   }
 
@@ -253,7 +263,16 @@ final class AnalyzingCompiler(
       options: Seq[String],
       log: Logger
   ): Seq[String] = {
-    val (classpathString, bootClasspath) = consoleClasspaths(classpath, converter)
+    val (classpathString, bootClasspath) = consoleClasspaths(classpath, converter, options, log)
+    consoleCommandArguments(options, bootClasspath, classpathString, log)
+  }
+
+  private def consoleCommandArguments(
+      options: Seq[String],
+      bootClasspath: String,
+      classpathString: String,
+      log: Logger
+  ): Seq[String] = {
     // hold reference to compiler bridge class loader to prevent its being evicted
     // from the compiler cache (sbt/zinc#914)
     val loader = getCompilerLoader(log)
@@ -284,8 +303,8 @@ final class AnalyzingCompiler(
       loader: Option[ClassLoader] = None,
       bindings: Seq[(String, AnyRef)] = Nil
   ): xsbti.InteractiveConsoleInterface = {
-    onArgsHandler(consoleCommandArguments(classpath, converter, options, log))
-    val (classpathString, bootClasspath) = consoleClasspaths(classpath, converter)
+    val (classpathString, bootClasspath) = consoleClasspaths(classpath, converter, options, log)
+    onArgsHandler(consoleCommandArguments(options, bootClasspath, classpathString, log))
     val (names, values0) = bindings.unzip
     val values = values0.toArray[Any].asInstanceOf[Array[AnyRef]]
     // hold reference to compiler bridge class loader to prevent its being evicted

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/AnalyzingCompiler.scala
@@ -81,7 +81,7 @@ final class AnalyzingCompiler(
   ): Unit = {
     val progress = if (progressOpt.isPresent) progressOpt.get else IgnoreProgress
     val cp = classpath.map(converter.toPath).toIndexedSeq
-    val arguments = compArgs.makeArguments(Nil, cp, options.toIndexedSeq).toArray
+    val arguments = compArgs.makeArguments(Nil, cp, options.toIndexedSeq, log).toArray
     // hold reference to compiler bridge class loader to prevent its being evicted
     // from the compiler cache (sbt/zinc#914)
     val loader = getCompilerLoader(log)
@@ -149,7 +149,7 @@ final class AnalyzingCompiler(
     loadService(classOf[ScaladocInterface2], loader) match {
       case Some(intf) =>
         val arguments =
-          compArgs.makeArguments(Nil, cp, Some(outputDirectory), options)
+          compArgs.makeArguments(Nil, cp, Some(outputDirectory), options, log)
         onArgsHandler(arguments)
         intf.run(sources.toArray, arguments.toArray[String], log, reporter)
       case _ =>
@@ -157,7 +157,7 @@ final class AnalyzingCompiler(
           case Some(intf) =>
             val fileSources: Seq[Path] = sources.map(converter.toPath(_))
             val arguments =
-              compArgs.makeArguments(fileSources, cp, Some(outputDirectory), options)
+              compArgs.makeArguments(fileSources, cp, Some(outputDirectory), options, log)
             onArgsHandler(arguments)
             intf.run(arguments.toArray[String], log, reporter)
           case _ =>
@@ -166,7 +166,7 @@ final class AnalyzingCompiler(
             val (bridge, bridgeClass) = bridgeInstance(scaladocBridgeClassName, loader)
             val fileSources: Seq[Path] = sources.map(converter.toPath(_))
             val arguments =
-              compArgs.makeArguments(fileSources, cp, Some(outputDirectory), options)
+              compArgs.makeArguments(fileSources, cp, Some(outputDirectory), options, log)
             onArgsHandler(arguments)
             invoke(bridge, bridgeClass, "run", log)(
               classOf[Array[String]],

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala
@@ -105,12 +105,8 @@ final class CompilerArguments(
     /* Respect a user-provided -bootclasspath: scalac takes the last occurrence of the
      * flag, so appending Zinc's own would silently override the user's (sbt/zinc#348). */
     val bootClasspath =
-      if (options.contains(BootClasspathOption)) {
-        if (cpOptions.autoBoot)
-          log.warn(() =>
-            s"$BootClasspathOption is already present in compiler options; Zinc will not add " +
-              "its own and assumes the provided boot classpath includes the Scala library."
-          )
+      if (CompilerArguments.explicitBootClasspath(options).isDefined) {
+        if (cpOptions.autoBoot) log.warn(() => CompilerArguments.ExplicitBootClasspathWarning)
         Nil
       } else bootClasspathOption(hasLibrary(classpath))
     options ++ bootClasspath ++ classpathOption ++ abs(sources)
@@ -203,6 +199,31 @@ final class CompilerArguments(
 
 object CompilerArguments {
   val BootClasspathOption = "-bootclasspath"
+
+  /** The GNU-style spelling of `-bootclasspath`, accepted by Scala 2.13 and Scala 3. */
+  val BootClasspathLongOption = "--boot-class-path"
+
+  private val BootClasspathOptions = Seq(BootClasspathOption, BootClasspathLongOption)
+
+  private[inc] val ExplicitBootClasspathWarning: String =
+    "A boot classpath is already set in the compiler options; Zinc will not add its own " +
+      "and assumes the provided boot classpath includes the Scala library."
+
+  /**
+   * Return the boot classpath explicitly set in `options`, if any. Both spellings are
+   * accepted in either `<option> <path>` or `<option>:<path>` form, and as in scalac the
+   * last occurrence wins.
+   */
+  def explicitBootClasspath(options: Seq[String]): Option[String] =
+    options.zipWithIndex.foldLeft(Option.empty[String]) {
+      case (found, (option, index)) =>
+        BootClasspathOptions
+          .collectFirst {
+            case name if option == name               => options.lift(index + 1).getOrElse("")
+            case name if option.startsWith(s"$name:") => option.drop(name.length + 1)
+          }
+          .orElse(found)
+    }
 
   def abs(files: Seq[Path]): List[String] = files.toList.map(_.toAbsolutePath.toString)
 

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerArguments.scala
@@ -50,8 +50,17 @@ final class CompilerArguments(
       output: Option[Path],
       options: Seq[String]
   ): Seq[String] =
+    makeArguments(sources, classpath, output, options, sbt.util.Logger.Null)
+
+  def makeArguments(
+      sources: Seq[Path],
+      classpath: Seq[Path],
+      output: Option[Path],
+      options: Seq[String],
+      log: xsbti.Logger
+  ): Seq[String] =
     CompilerArguments.outputOption(output) ++
-      makeArguments(sources, classpath, options)
+      makeArguments(sources, classpath, options, log)
 
   def makeArguments(
       sources: Seq[Path],
@@ -59,13 +68,30 @@ final class CompilerArguments(
       output: Output,
       options: Seq[String]
   ): Seq[String] =
+    makeArguments(sources, classpath, output, options, sbt.util.Logger.Null)
+
+  def makeArguments(
+      sources: Seq[Path],
+      classpath: Seq[Path],
+      output: Output,
+      options: Seq[String],
+      log: xsbti.Logger
+  ): Seq[String] =
     CompilerArguments.outputOption(output) ++
-      makeArguments(sources, classpath, options)
+      makeArguments(sources, classpath, options, log)
 
   def makeArguments(
       sources: Seq[Path],
       classpath: Seq[Path],
       options: Seq[String]
+  ): Seq[String] =
+    makeArguments(sources, classpath, options, sbt.util.Logger.Null)
+
+  def makeArguments(
+      sources: Seq[Path],
+      classpath: Seq[Path],
+      options: Seq[String],
+      log: xsbti.Logger
   ): Seq[String] = {
     /* Add dummy to avoid Scalac misbehaviour for empty classpath (as of 2.9.1). */
     def dummy: String = "dummy_" + Integer.toHexString(util.Random.nextInt())
@@ -76,7 +102,17 @@ final class CompilerArguments(
       if (compilerClasspath.isEmpty) dummy
       else absString(compilerClasspath)
     val classpathOption = Seq("-classpath", stringClasspath)
-    val bootClasspath = bootClasspathOption(hasLibrary(classpath))
+    /* Respect a user-provided -bootclasspath: scalac takes the last occurrence of the
+     * flag, so appending Zinc's own would silently override the user's (sbt/zinc#348). */
+    val bootClasspath =
+      if (options.contains(BootClasspathOption)) {
+        if (cpOptions.autoBoot)
+          log.warn(() =>
+            s"$BootClasspathOption is already present in compiler options; Zinc will not add " +
+              "its own and assumes the provided boot classpath includes the Scala library."
+          )
+        Nil
+      } else bootClasspathOption(hasLibrary(classpath))
     options ++ bootClasspath ++ classpathOption ++ abs(sources)
   }
 

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/RawCompiler.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/RawCompiler.scala
@@ -63,7 +63,7 @@ class RawCompiler(val scalaInstance: XScalaInstance, cp: ClasspathOptions, log: 
     // import scala.tools.nsc.Main.{ process => _, reporter => _ }
     val uniqueCompilerVersion = scalaInstance.actualVersion
     val compilerOut = Some(outputDirectory)
-    val arguments = compilerArguments.makeArguments(sources, classpath, compilerOut, options)
+    val arguments = compilerArguments.makeArguments(sources, classpath, compilerOut, options, log)
     val args = arguments.toArray
 
     log.debug(

--- a/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/CompilerArgumentsSpec.scala
+++ b/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/CompilerArgumentsSpec.scala
@@ -20,7 +20,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import xsbti.compile.{ ClasspathOptions, ClasspathOptionsUtil }
 
 class CompilerArgumentsSpec extends AnyFlatSpec {
-  import CompilerArguments.BootClasspathOption
+  import CompilerArguments.{ BootClasspathLongOption, BootClasspathOption }
 
   private val scalaLibraryJar = new File("scala-library.jar")
 
@@ -71,6 +71,24 @@ class CompilerArgumentsSpec extends AnyFlatSpec {
     assert(log.warnings.head.contains("Scala library"))
   }
 
+  it should "keep a boot classpath given in the colon form and warn instead of overriding it" in {
+    val log = new RecordingLogger
+    val userOptions = Seq(s"$BootClasspathOption:/custom/rt.jar")
+    val args = makeArguments(autoBootOptions, userOptions, log)
+    assert(!args.contains(BootClasspathOption))
+    assert(args.contains(s"$BootClasspathOption:/custom/rt.jar"))
+    assert(log.warnings.size == 1)
+  }
+
+  it should "keep a boot classpath given with the long option and warn instead of overriding it" in {
+    val log = new RecordingLogger
+    val userOptions = Seq(BootClasspathLongOption, "/custom/rt.jar")
+    val args = makeArguments(autoBootOptions, userOptions, log)
+    assert(!args.contains(BootClasspathOption))
+    assert(args.count(_ == BootClasspathLongOption) == 1)
+    assert(log.warnings.size == 1)
+  }
+
   it should "not add a boot classpath when autoBoot is not set" in {
     val log = new RecordingLogger
     val args = makeArguments(noAutoBootOptions, Seq("-deprecation"), log)
@@ -85,5 +103,39 @@ class CompilerArgumentsSpec extends AnyFlatSpec {
     assert(args.count(_ == BootClasspathOption) == 1)
     assert(args(args.indexOf(BootClasspathOption) + 1) == "/custom/rt.jar")
     assert(log.warnings.isEmpty)
+  }
+
+  "explicitBootClasspath" should "find none when no boot classpath is given" in {
+    assert(CompilerArguments.explicitBootClasspath(Seq("-deprecation")).isEmpty)
+  }
+
+  it should "find a boot classpath in every spelling scalac accepts" in {
+    // Verified against scalac 2.13 and 3: these four are accepted, and the two
+    // near-misses below are rejected by both compilers.
+    val accepted = Seq(
+      Seq(BootClasspathOption, "/a.jar"),
+      Seq(s"$BootClasspathOption:/a.jar"),
+      Seq(BootClasspathLongOption, "/a.jar"),
+      Seq(s"$BootClasspathLongOption:/a.jar"),
+    )
+    accepted.foreach(options =>
+      assert(CompilerArguments.explicitBootClasspath(options) == Some("/a.jar"), options)
+    )
+  }
+
+  it should "ignore spellings that scalac itself rejects" in {
+    val rejected = Seq(Seq("-boot-class-path", "/a.jar"), Seq("--bootclasspath", "/a.jar"))
+    rejected.foreach(options =>
+      assert(CompilerArguments.explicitBootClasspath(options).isEmpty, options)
+    )
+  }
+
+  it should "take the last occurrence, as scalac does" in {
+    val options = Seq(BootClasspathOption, "/first.jar", s"$BootClasspathOption:/second.jar")
+    assert(CompilerArguments.explicitBootClasspath(options) == Some("/second.jar"))
+  }
+
+  it should "not confuse another option that merely starts with the same text" in {
+    assert(CompilerArguments.explicitBootClasspath(Seq("-bootclasspathological")).isEmpty)
   }
 }

--- a/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/CompilerArgumentsSpec.scala
+++ b/internal/zinc-compile-core/src/test/scala/sbt/internal/inc/CompilerArgumentsSpec.scala
@@ -1,0 +1,89 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package sbt
+package internal
+package inc
+
+import java.io.File
+import java.util.function.Supplier
+
+import org.scalatest.flatspec.AnyFlatSpec
+import xsbti.compile.{ ClasspathOptions, ClasspathOptionsUtil }
+
+class CompilerArgumentsSpec extends AnyFlatSpec {
+  import CompilerArguments.BootClasspathOption
+
+  private val scalaLibraryJar = new File("scala-library.jar")
+
+  private object FakeScalaInstance extends xsbti.compile.ScalaInstance {
+    val version = "2.12.20"
+    val actualVersion = version
+    val loader = getClass.getClassLoader
+    val loaderCompilerOnly = loader
+    val loaderLibraryOnly = loader
+    val libraryJars = Array(scalaLibraryJar)
+    val compilerJars = Array.empty[File]
+    val otherJars = Array.empty[File]
+    val allJars = Array(scalaLibraryJar)
+  }
+
+  private class RecordingLogger extends xsbti.Logger {
+    val warnings = collection.mutable.Buffer.empty[String]
+    def warn(msg: Supplier[String]): Unit = warnings += msg.get()
+    def error(msg: Supplier[String]): Unit = ()
+    def info(msg: Supplier[String]): Unit = ()
+    def debug(msg: Supplier[String]): Unit = ()
+    def trace(exception: Supplier[Throwable]): Unit = ()
+  }
+
+  private val autoBootOptions = ClasspathOptionsUtil.boot()
+  private val noAutoBootOptions = ClasspathOptions.of(false, false, false, false, false)
+
+  private def makeArguments(cpOptions: ClasspathOptions, options: Seq[String], log: xsbti.Logger) =
+    new CompilerArguments(FakeScalaInstance, cpOptions)
+      .makeArguments(Nil, Seq(scalaLibraryJar.toPath), options, log)
+
+  "makeArguments" should "add a boot classpath containing the Scala library when autoBoot is set" in {
+    val log = new RecordingLogger
+    val args = makeArguments(autoBootOptions, Seq("-deprecation"), log)
+    assert(args.count(_ == BootClasspathOption) == 1)
+    val value = args(args.indexOf(BootClasspathOption) + 1)
+    assert(value.endsWith(scalaLibraryJar.getName))
+    assert(log.warnings.isEmpty)
+  }
+
+  it should "keep a user-provided boot classpath and warn instead of overriding it" in {
+    val log = new RecordingLogger
+    val userOptions = Seq(BootClasspathOption, "/custom/rt.jar")
+    val args = makeArguments(autoBootOptions, userOptions, log)
+    assert(args.count(_ == BootClasspathOption) == 1)
+    assert(args(args.indexOf(BootClasspathOption) + 1) == "/custom/rt.jar")
+    assert(log.warnings.size == 1)
+    assert(log.warnings.head.contains("Scala library"))
+  }
+
+  it should "not add a boot classpath when autoBoot is not set" in {
+    val log = new RecordingLogger
+    val args = makeArguments(noAutoBootOptions, Seq("-deprecation"), log)
+    assert(!args.contains(BootClasspathOption))
+    assert(log.warnings.isEmpty)
+  }
+
+  it should "not warn about a user-provided boot classpath when autoBoot is not set" in {
+    val log = new RecordingLogger
+    val userOptions = Seq(BootClasspathOption, "/custom/rt.jar")
+    val args = makeArguments(noAutoBootOptions, userOptions, log)
+    assert(args.count(_ == BootClasspathOption) == 1)
+    assert(args(args.indexOf(BootClasspathOption) + 1) == "/custom/rt.jar")
+    assert(log.warnings.isEmpty)
+  }
+}

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -429,15 +429,18 @@ object MixedAnalyzingCompiler {
     val absClasspath = classpath.map(toAbsolute(_))
     val cArgs =
       new CompilerArguments(compiler.scalaInstance, compiler.classpathOptions)
-    val searchClasspath: Seq[VirtualFile] = explicitBootClasspath(
-      scalacOptions.toIndexedSeq,
-      converter
-    ) ++
-      withBootclasspath(
-        cArgs,
-        absClasspath,
-        converter
-      )
+    val options = scalacOptions.toIndexedSeq
+    /* Mirror the compiler: when the client set its own boot classpath, Zinc does not add
+     * one, so analysis must not search one either (sbt/zinc#348). */
+    val clientSetBootClasspath = CompilerArguments.explicitBootClasspath(options).isDefined
+    val searchClasspath: Seq[VirtualFile] =
+      explicitBootClasspathFiles(options, converter) ++
+        withBootclasspath(
+          cArgs,
+          absClasspath,
+          converter,
+          addBootclasspath = !clientSetBootClasspath
+        )
     (searchClasspath, Locate.entry(searchClasspath, perClasspathEntryLookup))
   }
 
@@ -472,21 +475,32 @@ object MixedAnalyzingCompiler {
       args: CompilerArguments,
       classpath: Seq[VirtualFile],
       converter: FileConverter
+  ): Seq[VirtualFile] =
+    withBootclasspath(args, classpath, converter, addBootclasspath = true)
+
+  /** `addBootclasspath` is false when the client supplied its own boot classpath. */
+  def withBootclasspath(
+      args: CompilerArguments,
+      classpath: Seq[VirtualFile],
+      converter: FileConverter,
+      addBootclasspath: Boolean
   ): Seq[VirtualFile] = {
     val cp: Seq[Path] = classpath.map(converter.toPath)
-    args.bootClasspathFor(cp).map(converter.toVirtualFile(_)) ++
+    val bootClasspath =
+      if (addBootclasspath) args.bootClasspathFor(cp).map(converter.toVirtualFile(_))
+      else Nil
+    bootClasspath ++
       args.extClasspath.map(PlainVirtualFile(_)) ++
       args.finishClasspath(cp).map(converter.toVirtualFile(_))
   }
 
-  private def explicitBootClasspath(
+  private def explicitBootClasspathFiles(
       options: Seq[String],
       converter: FileConverter
   ): Seq[VirtualFile] = {
-    options
-      .dropWhile(_ != CompilerArguments.BootClasspathOption)
-      .slice(1, 2)
-      .headOption
+    CompilerArguments
+      .explicitBootClasspath(options)
+      .filter(_.nonEmpty)
       .toList
       .flatMap(IO.parseClasspath)
       .map(_.toPath)

--- a/zinc/src/test/scala/sbt/inc/SearchClasspathSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/SearchClasspathSpec.scala
@@ -24,7 +24,9 @@ import xsbti.compile._
  * universe the compiler sees. See sbt/zinc#348.
  */
 class SearchClasspathSpec extends UnitSpec {
-  private val scalaLibraryJar = new File("/tmp/zinc-test/scala-library.jar")
+  // Absolute so that assertions match the absolutized entries on Windows too,
+  // where "/tmp/..." is only drive-relative.
+  private val scalaLibraryJar = new File("/tmp/zinc-test/scala-library.jar").getAbsoluteFile
   private val userBootJar = "/tmp/zinc-test/custom-library.jar"
   private val converter = PlainVirtualFileConverter.converter
 

--- a/zinc/src/test/scala/sbt/inc/SearchClasspathSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/SearchClasspathSpec.scala
@@ -1,0 +1,95 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package sbt.inc
+
+import java.io.File
+import java.nio.file.Paths
+import java.util.Optional
+
+import sbt.internal.inc.{ MixedAnalyzingCompiler, PlainVirtualFileConverter, UnitSpec }
+import xsbti.VirtualFile
+import xsbti.compile._
+
+/**
+ * The search classpath drives dependency lookup, so it has to describe the same class
+ * universe the compiler sees. See sbt/zinc#348.
+ */
+class SearchClasspathSpec extends UnitSpec {
+  private val scalaLibraryJar = new File("/tmp/zinc-test/scala-library.jar")
+  private val userBootJar = "/tmp/zinc-test/custom-library.jar"
+  private val converter = PlainVirtualFileConverter.converter
+
+  private object FakeScalaInstance extends ScalaInstance {
+    val version = "2.12.20"
+    val actualVersion = version
+    val loader = getClass.getClassLoader
+    val loaderCompilerOnly = loader
+    val loaderLibraryOnly = loader
+    val libraryJars = Array(scalaLibraryJar)
+    val compilerJars = Array.empty[File]
+    val otherJars = Array.empty[File]
+    val allJars = Array(scalaLibraryJar)
+  }
+
+  private object FakeCompiler extends ScalaCompiler {
+    def scalaInstance: ScalaInstance = FakeScalaInstance
+    def classpathOptions: ClasspathOptions = ClasspathOptionsUtil.boot()
+    def compile(
+        sources: Array[VirtualFile],
+        classpath: Array[VirtualFile],
+        converter: xsbti.FileConverter,
+        changes: xsbti.compile.DependencyChanges,
+        options: Array[String],
+        output: Output,
+        callback: xsbti.AnalysisCallback,
+        reporter: xsbti.Reporter,
+        progress: Optional[CompileProgress],
+        log: xsbti.Logger
+    ): Unit = ()
+  }
+
+  private object NoLookup extends PerClasspathEntryLookup {
+    def analysis(classpathEntry: VirtualFile): Optional[CompileAnalysis] = Optional.empty()
+    def definesClass(classpathEntry: VirtualFile): DefinesClass = _ => false
+  }
+
+  private def searchClasspath(scalacOptions: Array[String]): Seq[String] = {
+    val classpath = Seq(converter.toVirtualFile(scalaLibraryJar.toPath))
+    MixedAnalyzingCompiler
+      .searchClasspathAndLookup(converter, classpath, scalacOptions, NoLookup, FakeCompiler)
+      ._1
+      .map(converter.toPath(_).toString)
+  }
+
+  "the search classpath" should "include Zinc's boot classpath when the client sets none" in {
+    val entries = searchClasspath(Array("-deprecation"))
+    assert(entries.contains(scalaLibraryJar.toString))
+  }
+
+  it should "use the client's boot classpath instead of Zinc's when one is set" in {
+    val entries = searchClasspath(Array("-bootclasspath", userBootJar))
+    assert(entries.contains(Paths.get(userBootJar).toString))
+    assert(!entries.contains(scalaLibraryJar.toString))
+  }
+
+  it should "recognize every spelling the compiler accepts" in {
+    val spellings = Seq(
+      Array("-bootclasspath", userBootJar),
+      Array(s"-bootclasspath:$userBootJar"),
+      Array("--boot-class-path", userBootJar),
+      Array(s"--boot-class-path:$userBootJar"),
+    )
+    spellings.foreach { options =>
+      assert(!searchClasspath(options).contains(scalaLibraryJar.toString), options.mkString(" "))
+    }
+  }
+}


### PR DESCRIPTION
Fixes #348.

Zinc appended its own `-bootclasspath` after the client's scalacOptions whenever `autoBoot` was set. scalac takes the last occurrence, so the client's boot classpath was silently discarded. The console and interactive console overrode it as well, by handing the bridge a boot classpath that it applies on top of the parsed options.

Zinc now detects a client-supplied boot classpath in every spelling scalac accepts (`-bootclasspath` and `--boot-class-path`, space or colon form, last occurrence winning), skips adding its own, and warns that it assumes the Scala library is on the provided path. Dependency lookup follows the same decision, so analysis sees the same class universe as the compiler.
