### PR TITLE
fix(persistence): prevent quadratic API node interning

### DIFF
--- a/internal/zinc-benchmarks/src/test/scala/sbt/internal/inc/consistent/NodeCacheBenchmark.scala
+++ b/internal/zinc-benchmarks/src/test/scala/sbt/internal/inc/consistent/NodeCacheBenchmark.scala
@@ -1,0 +1,95 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package sbt.internal.inc.consistent
+
+import java.util.HashMap
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import org.openjdk.jmh.infra.Blackhole
+import xsbti.api.ParameterRef
+import xsbti.api.Projection
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(1)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+class NodeCacheBenchmark {
+  @Param(Array("1024"))
+  var size: Int = 0
+
+  var first: Array[Projection] = compiletime.uninitialized
+  var second: Array[Projection] = compiletime.uninitialized
+
+  @Setup
+  def setup(): Unit = {
+    require(size > 0 && (size & (size - 1)) == 0)
+    val bits = Integer.numberOfTrailingZeros(size)
+    val prefix = ParameterRef.of("P")
+    val names = Array.tabulate(size) { value =>
+      val name = new StringBuilder(bits * 2)
+      var bit = 0
+      while (bit < bits) {
+        name.append(if (((value >>> bit) & 1) == 0) "Aa" else "BB")
+        bit += 1
+      }
+      name.result()
+    }
+    require(names.distinct.length == size)
+    require(names.iterator.map(_.hashCode).toSet.size == 1)
+    first = names.map(Projection.of(prefix, _))
+    second = names.map(Projection.of(prefix, _))
+    require(first.iterator.map(_.hashCode).toSet.size == 1)
+  }
+
+  @Benchmark
+  def legacyHashMap(bh: Blackhole): Unit = {
+    val cache = new HashMap[AnyRef, AnyRef]()
+    var i = 0
+    while (i < size) {
+      bh.consume(cache.putIfAbsent(first(i), first(i)))
+      i += 1
+    }
+    i = 0
+    while (i < size) {
+      bh.consume(cache.putIfAbsent(second(i), second(i)))
+      i += 1
+    }
+  }
+
+  @Benchmark
+  def zincNodeCache(bh: Blackhole): Unit = {
+    val cache = new NodeCache
+    var i = 0
+    while (i < size) {
+      bh.consume(cache.intern(first(i)))
+      i += 1
+    }
+    i = 0
+    while (i < size) {
+      bh.consume(cache.intern(second(i)))
+      i += 1
+    }
+  }
+}

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/consistent/ConsistentAnalysisFormat.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/consistent/ConsistentAnalysisFormat.scala
@@ -826,8 +826,7 @@ object ConsistentAnalysisFormat {
    * deserializer, so it cannot leak.
    */
   private[consistent] def internNode[A <: AnyRef](in: Deserializer, a: A): A = {
-    val prev = in.nodeCache.putIfAbsent(a, a)
-    if (prev == null) a else prev.asInstanceOf[A]
+    in.nodeCache.intern(a)
   }
 
   private final val EmptyTypeSingleton = EmptyType.of()

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/consistent/NodeCache.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/consistent/NodeCache.scala
@@ -70,10 +70,26 @@ private[consistent] final class NodeCache {
 }
 
 private[consistent] object NodeCache {
-  private final val Offset = -3750763034362895579L
-  private final val Prime = 1099511628211L
+  private final val ParameterRefTag = 1L
+  private final val ParameterizedTag = 2L
+  private final val PolymorphicTag = 3L
+  private final val ConstantTag = 4L
+  private final val ExistentialTag = 5L
+  private final val SingletonTag = 6L
+  private final val ProjectionTag = 7L
+  private final val AnnotatedTag = 8L
+  private final val TypeParameterTag = 9L
+  private final val AnnotationTag = 10L
 
-  private def mix(hash: Long, value: Long): Long = (hash ^ value) * Prime
+  // FNV-1a 64-bit offset basis and prime.
+  private final val Fnv1a64OffsetBasis = -3750763034362895579L
+  private final val Fnv1a64Prime = 1099511628211L
+
+  // MurmurHash3 fmix64 multipliers.
+  private final val MurmurHash3Fmix64Multiplier1 = -49064778989728563L
+  private final val MurmurHash3Fmix64Multiplier2 = -4265267296055464877L
+
+  private def mix(hash: Long, value: Long): Long = (hash ^ value) * Fnv1a64Prime
 
   private def mixReference(hash: Long, value: AnyRef): Long =
     mix(hash, if (value == null) 0L else Integer.toUnsignedLong(System.identityHashCode(value)))
@@ -107,35 +123,56 @@ private[consistent] object NodeCache {
   }
 
   private[consistent] def fingerprint(value: AnyRef): Long = value match {
-    case node: ParameterRef => mixReference(mix(Offset, 1L), node.id())
+    case node: ParameterRef => mixReference(mix(Fnv1a64OffsetBasis, ParameterRefTag), node.id())
     case node: Parameterized =>
-      mixReferences(mixReference(mix(Offset, 2L), node.baseType()), node.typeArguments())
+      mixReferences(
+        mixReference(mix(Fnv1a64OffsetBasis, ParameterizedTag), node.baseType()),
+        node.typeArguments()
+      )
     case node: Polymorphic =>
-      mixReferences(mixReference(mix(Offset, 3L), node.baseType()), node.parameters())
+      mixReferences(
+        mixReference(mix(Fnv1a64OffsetBasis, PolymorphicTag), node.baseType()),
+        node.parameters()
+      )
     case node: Constant =>
-      mixReference(mixReference(mix(Offset, 4L), node.baseType()), node.value())
+      mixReference(
+        mixReference(mix(Fnv1a64OffsetBasis, ConstantTag), node.baseType()),
+        node.value()
+      )
     case node: Existential =>
-      mixReferences(mixReference(mix(Offset, 5L), node.baseType()), node.clause())
-    case node: Singleton => mixReference(mix(Offset, 6L), node.path())
+      mixReferences(
+        mixReference(mix(Fnv1a64OffsetBasis, ExistentialTag), node.baseType()),
+        node.clause()
+      )
+    case node: Singleton => mixReference(mix(Fnv1a64OffsetBasis, SingletonTag), node.path())
     case node: Projection =>
-      mixReference(mixReference(mix(Offset, 7L), node.prefix()), node.id())
+      mixReference(
+        mixReference(mix(Fnv1a64OffsetBasis, ProjectionTag), node.prefix()),
+        node.id()
+      )
     case node: Annotated =>
-      mixReferences(mixReference(mix(Offset, 8L), node.baseType()), node.annotations())
+      mixReferences(
+        mixReference(mix(Fnv1a64OffsetBasis, AnnotatedTag), node.baseType()),
+        node.annotations()
+      )
     case node: TypeParameter =>
-      val withId = mixReference(mix(Offset, 9L), node.id())
+      val withId = mixReference(mix(Fnv1a64OffsetBasis, TypeParameterTag), node.id())
       val withAnnotations = mixReferences(withId, node.annotations())
       val withParameters = mixReferences(withAnnotations, node.typeParameters())
       val withVariance = mix(withParameters, node.variance().ordinal().toLong)
       mixReference(mixReference(withVariance, node.lowerBound()), node.upperBound())
     case node: Annotation =>
-      mixArguments(mixReference(mix(Offset, 10L), node.base()), node.arguments())
-    case node => mix(Offset, Integer.toUnsignedLong(node.hashCode()))
+      mixArguments(
+        mixReference(mix(Fnv1a64OffsetBasis, AnnotationTag), node.base()),
+        node.arguments()
+      )
+    case node => mix(Fnv1a64OffsetBasis, Integer.toUnsignedLong(node.hashCode()))
   }
 
   private def index(hash: Long, length: Int): Int = {
     var mixed = hash
-    mixed = (mixed ^ (mixed >>> 33)) * -49064778989728563L
-    mixed = (mixed ^ (mixed >>> 33)) * -4265267296055464877L
+    mixed = (mixed ^ (mixed >>> 33)) * MurmurHash3Fmix64Multiplier1
+    mixed = (mixed ^ (mixed >>> 33)) * MurmurHash3Fmix64Multiplier2
     ((mixed ^ (mixed >>> 33)).toInt & Int.MaxValue) & (length - 1)
   }
 }

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/consistent/NodeCache.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/consistent/NodeCache.scala
@@ -1,0 +1,141 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package sbt.internal.inc.consistent
+
+import xsbti.api.Annotated
+import xsbti.api.Annotation
+import xsbti.api.AnnotationArgument
+import xsbti.api.Constant
+import xsbti.api.Existential
+import xsbti.api.ParameterRef
+import xsbti.api.Parameterized
+import xsbti.api.Polymorphic
+import xsbti.api.Projection
+import xsbti.api.Singleton
+import xsbti.api.TypeParameter
+
+private[consistent] final class NodeCache {
+  private var hashes = new Array[Long](16)
+  private var values = new Array[AnyRef](16)
+  private var entries = 0
+
+  def intern[A <: AnyRef](value: A): A = {
+    val hash = NodeCache.fingerprint(value)
+    var index = NodeCache.index(hash, values.length)
+    var existing = values(index)
+    while (existing != null && (hashes(index) != hash || !value.equals(existing))) {
+      index = (index + 1) & (values.length - 1)
+      existing = values(index)
+    }
+    if (existing == null) {
+      if (entries * 2 >= values.length) {
+        grow()
+        index = NodeCache.index(hash, values.length)
+        while (values(index) != null) index = (index + 1) & (values.length - 1)
+      }
+      hashes(index) = hash
+      values(index) = value
+      entries += 1
+      value
+    } else existing.asInstanceOf[A]
+  }
+
+  private def grow(): Unit = {
+    val oldHashes = hashes
+    val oldValues = values
+    hashes = new Array[Long](oldHashes.length * 2)
+    values = new Array[AnyRef](oldValues.length * 2)
+    var oldIndex = 0
+    while (oldIndex < oldValues.length) {
+      val value = oldValues(oldIndex)
+      if (value != null) {
+        val hash = oldHashes(oldIndex)
+        var index = NodeCache.index(hash, values.length)
+        while (values(index) != null) index = (index + 1) & (values.length - 1)
+        hashes(index) = hash
+        values(index) = value
+      }
+      oldIndex += 1
+    }
+  }
+}
+
+private[consistent] object NodeCache {
+  private final val Offset = -3750763034362895579L
+  private final val Prime = 1099511628211L
+
+  private def mix(hash: Long, value: Long): Long = (hash ^ value) * Prime
+
+  private def mixReference(hash: Long, value: AnyRef): Long =
+    mix(hash, if (value == null) 0L else Integer.toUnsignedLong(System.identityHashCode(value)))
+
+  private def mixReferences(hash: Long, entries: Array[? <: AnyRef]): Long = {
+    if (entries == null) mix(hash, -1L)
+    else {
+      var result = mix(hash, entries.length.toLong)
+      var index = 0
+      while (index < entries.length) {
+        result = mixReference(result, entries(index))
+        index += 1
+      }
+      result
+    }
+  }
+
+  private def mixArguments(hash: Long, entries: Array[AnnotationArgument]): Long = {
+    if (entries == null) mix(hash, -1L)
+    else {
+      var result = mix(hash, entries.length.toLong)
+      var index = 0
+      while (index < entries.length) {
+        val argument = entries(index)
+        result = mixReference(result, argument.name())
+        result = mixReference(result, argument.value())
+        index += 1
+      }
+      result
+    }
+  }
+
+  private[consistent] def fingerprint(value: AnyRef): Long = value match {
+    case node: ParameterRef => mixReference(mix(Offset, 1L), node.id())
+    case node: Parameterized =>
+      mixReferences(mixReference(mix(Offset, 2L), node.baseType()), node.typeArguments())
+    case node: Polymorphic =>
+      mixReferences(mixReference(mix(Offset, 3L), node.baseType()), node.parameters())
+    case node: Constant =>
+      mixReference(mixReference(mix(Offset, 4L), node.baseType()), node.value())
+    case node: Existential =>
+      mixReferences(mixReference(mix(Offset, 5L), node.baseType()), node.clause())
+    case node: Singleton => mixReference(mix(Offset, 6L), node.path())
+    case node: Projection =>
+      mixReference(mixReference(mix(Offset, 7L), node.prefix()), node.id())
+    case node: Annotated =>
+      mixReferences(mixReference(mix(Offset, 8L), node.baseType()), node.annotations())
+    case node: TypeParameter =>
+      val withId = mixReference(mix(Offset, 9L), node.id())
+      val withAnnotations = mixReferences(withId, node.annotations())
+      val withParameters = mixReferences(withAnnotations, node.typeParameters())
+      val withVariance = mix(withParameters, node.variance().ordinal().toLong)
+      mixReference(mixReference(withVariance, node.lowerBound()), node.upperBound())
+    case node: Annotation =>
+      mixArguments(mixReference(mix(Offset, 10L), node.base()), node.arguments())
+    case node => mix(Offset, Integer.toUnsignedLong(node.hashCode()))
+  }
+
+  private def index(hash: Long, length: Int): Int = {
+    var mixed = hash
+    mixed = (mixed ^ (mixed >>> 33)) * -49064778989728563L
+    mixed = (mixed ^ (mixed >>> 33)) * -4265267296055464877L
+    ((mixed ^ (mixed >>> 33)).toInt & Int.MaxValue) & (length - 1)
+  }
+}

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/consistent/Serializer.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/consistent/Serializer.scala
@@ -121,7 +121,7 @@ abstract class Deserializer {
   // Per-read dedup state for value-equality `xsbti.api` tree nodes (used by
   // ConsistentAnalysisFormat.internNode): dies with the deserializer, so it
   // cannot leak.
-  private[consistent] final val nodeCache = new java.util.HashMap[AnyRef, AnyRef]()
+  private[consistent] final val nodeCache = new NodeCache
 
   def startBlock(): Unit
   def startArray(): Int
@@ -326,7 +326,7 @@ class TextDeserializer(in: BufferedReader) extends Deserializer {
       }
       i += 1
     }
-    b.result()
+    AnalysisInterner.internString(b.result())
   }
   def bool(): Boolean = long() == 1L
   def int(): Int = long().toInt

--- a/internal/zinc-persist/src/test/scala/sbt/inc/consistent/ConsistentAnalysisFormatInternerSuite.scala
+++ b/internal/zinc-persist/src/test/scala/sbt/inc/consistent/ConsistentAnalysisFormatInternerSuite.scala
@@ -37,6 +37,15 @@ class ConsistentAnalysisFormatInternerSuite extends AnyFunSuite {
     deser.string()
   }
 
+  private def roundTripTextString(s: String): String = {
+    val out = new ByteArrayOutputStream()
+    val ser = SerializerFactory.text.serializerFor(out)
+    ser.string(s)
+    ser.end()
+    val deser = SerializerFactory.text.deserializerFor(new ByteArrayInputStream(out.toByteArray))
+    deser.string()
+  }
+
   test("strings are canonicalized across independent reads (cross-analysis)") {
     val a = roundTripString(new String("com.example.CrossAnalysis"))
     val b = roundTripString(new String("com.example.CrossAnalysis"))
@@ -44,12 +53,47 @@ class ConsistentAnalysisFormatInternerSuite extends AnyFunSuite {
     assert(a `eq` b) // two separate reads share one canonical instance
   }
 
+  test("text strings are canonicalized across independent reads (cross-analysis)") {
+    val a = roundTripTextString(new String("com.example.CrossAnalysis"))
+    val b = roundTripTextString(new String("com.example.CrossAnalysis"))
+    assert(a == b)
+    assert(a `eq` b)
+  }
+
   test("api tree nodes are deduped within one read (per-read node cache)") {
     val deser =
       SerializerFactory.binary.deserializerFor(new ByteArrayInputStream(Array.empty[Byte]))
-    val t1 = ConsistentAnalysisFormat.internNode(deser, Projection.of(ParameterRef.of("P"), "x"))
-    val t2 = ConsistentAnalysisFormat.internNode(deser, Projection.of(ParameterRef.of("P"), "x"))
+    val p1 = ConsistentAnalysisFormat.internNode(deser, ParameterRef.of("P"))
+    val p2 = ConsistentAnalysisFormat.internNode(deser, ParameterRef.of("P"))
+    val t1 = ConsistentAnalysisFormat.internNode(deser, Projection.of(p1, "x"))
+    val t2 = ConsistentAnalysisFormat.internNode(deser, Projection.of(p2, "x"))
+    assert(p1 `eq` p2)
     assert(t1 `eq` t2)
+  }
+
+  test("api tree nodes with colliding value hashes are deduped without cache hash collisions") {
+    val deser =
+      SerializerFactory.binary.deserializerFor(new ByteArrayInputStream(Array.empty[Byte]))
+    val prefix = ConsistentAnalysisFormat.internNode(deser, ParameterRef.of("P"))
+    val bits = 10
+    val names = Array.tabulate(1 << bits) { value =>
+      val name = new StringBuilder(bits * 2)
+      var bit = 0
+      while (bit < bits) {
+        name.append(if (((value >>> bit) & 1) == 0) "Aa" else "BB")
+        bit += 1
+      }
+      name.result()
+    }
+    val nodes = names.map(Projection.of(prefix, _))
+    assert(nodes.iterator.map(_.hashCode).toSet.size == 1)
+    assert(nodes.iterator.map(NodeCache.fingerprint).toSet.size > nodes.length * 0.95)
+    val canonical = nodes.map(ConsistentAnalysisFormat.internNode(deser, _))
+    names.indices.foreach { index =>
+      val duplicate =
+        ConsistentAnalysisFormat.internNode(deser, Projection.of(prefix, names(index)))
+      assert(duplicate `eq` canonical(index))
+    }
   }
 
   private val mappers = ReadWriteMappers.getEmptyMappers()


### PR DESCRIPTION
Follow-up to #1754.

The per-read API-node cache uses node values directly as `HashMap` keys. Unequal API nodes can share the generated 32-bit hash, causing recursive tree-bin searches because these nodes are not `Comparable`.

This replaces the map with a compact open-addressed cache using shallow 64-bit fingerprints of already-canonical child nodes. Interning behavior and API hashes remain unchanged.

### Results

For 2,048 colliding `Projection` nodes:

| | Before | After |
|---|---:|---:|
| Time | 20.457 ms | 0.036 ms |
| Allocation | 148,078 B | 98,424 B |

The existing analysis-read benchmark remains neutral:

- Before: 98.739 ± 2.906 ms
- After: 97.565 ± 2.732 ms

Added a deterministic collision benchmark and regression coverage. `zincRoot/testFull`, formatting, and header checks pass.