### PR TITLE
Let scripted check commands see the errors of a failed compile

### DIFF
--- a/contributing-docs/scripted_tests.md
+++ b/contributing-docs/scripted_tests.md
@@ -41,6 +41,32 @@ The full task list is the `commands` map in
 [`IncHandler.scala`](../internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala#L229);
 file commands come from `ZincFileCommands` and sbt's `FileCommands`.
 
+Negative tests (expected compilation errors)
+--------------------------------------------
+
+`-> compile` alone passes on *any* failure, including environmental ones. To assert the failure is
+the expected one, follow it with the check commands: after a failed compile they read the problems
+of that failed attempt (captured from the `CompileFailed` exception, since a failed compile stores
+no analysis).
+
+```
+-> compile
+> checkErrors 1
+> checkError 0 "type mismatch"
+```
+
+`checkError <index> <substring>` is a contains-check on the problem message; quote multi-word
+substrings. `->` composes with the check commands too, so a test can also prove that a wrong
+expectation fails: `-> checkError 0 "nonexistent-message"`.
+
+Caveats: problem order is deterministic within one source file (reporting order) but not across
+files, so index-based `checkError` assertions should stick to single-file scenarios. Avoid file
+paths in substrings (platform-dependent), and remember message wording differs across Scala
+versions (e.g. Scala 3 capitalizes `Required:`). In a multi-project build the problems belong to
+the project whose compile failed: after `-> use/compile` fails because `dep` does not compile,
+assert with `> dep/checkErrors 1`, not `use/`. Examples: `reporter/errors-reported`,
+`reporter/errors-reported-multi`.
+
 Running
 -------
 

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -22,6 +22,7 @@ import sbt.util.Logger
 import sbt.util.InterfaceUtil._
 import xsbt.api.Discovery
 import xsbti.{ FileConverter, Problem, Severity, VirtualFileRef, VirtualFile }
+import xsbti.compile.analysis.ReadSourceInfos
 import xsbti.compile.{
   AnalysisContents,
   AnalysisStore,
@@ -732,9 +733,16 @@ case class ProjectStructure(
       converter,
       stamper
     )
+    lastCompileProblems = None
     val result =
-      if (javaOnly) incrementalCompiler.compileAllJava(in, scriptedLog)
-      else incrementalCompiler.compile(in, scriptedLog)
+      try
+        if (javaOnly) incrementalCompiler.compileAllJava(in, scriptedLog)
+        else incrementalCompiler.compile(in, scriptedLog)
+      catch {
+        case e: CompileFailed =>
+          lastCompileProblems = Some(failedCompileProblems(e))
+          throw e
+      }
     val analysis = result.analysis match { case a: Analysis => a }
     cachedStore.set(AnalysisContents.create(analysis, result.setup))
     val javaOnlyStr = if (javaOnly) "(java-only) " else ""
@@ -849,13 +857,26 @@ case class ProjectStructure(
     (incOptions, scalacOptions.toArray)
   }
 
+  // Problems of the latest compile attempt when it failed. A failed compile stores no
+  // analysis, so this is the only place its errors survive for the check commands.
+  @volatile private var lastCompileProblems: Option[Seq[Problem]] = None
+
+  private def failedCompileProblems(e: CompileFailed): Seq[Problem] =
+    e.sourceInfosOption.map(problemsOf).getOrElse(e.problems.toSeq)
+
+  private def problemsOf(infos: ReadSourceInfos): Seq[Problem] = {
+    import scala.jdk.CollectionConverters._
+    infos.getAllSourceInfos.asScala.values.toSeq
+      .flatMap(i => i.getReportedProblems ++ i.getUnreportedProblems)
+  }
+
   def getProblems(): Seq[Problem] =
-    cachedStore.get.toScala match {
-      case Some(analysisContents) =>
-        val analysis = analysisContents.getAnalysis.asInstanceOf[Analysis]
-        val allInfos = analysis.infos.allInfos.values.toSeq
-        allInfos.flatMap(i => i.getReportedProblems ++ i.getUnreportedProblems)
-      case _ => Nil
+    lastCompileProblems.getOrElse {
+      cachedStore.get.toScala match {
+        case Some(analysisContents) =>
+          problemsOf(analysisContents.getAnalysis.asInstanceOf[Analysis].infos)
+        case _ => Nil
+      }
     }
 
   def checkMessages(expected: Int, severity: Severity): Future[Unit] =

--- a/zinc/src/sbt-test/reporter/errors-reported-multi/A.scala
+++ b/zinc/src/sbt-test/reporter/errors-reported-multi/A.scala
@@ -1,0 +1,4 @@
+class A {
+  val x: String = 0
+  val y: Int = "one"
+}

--- a/zinc/src/sbt-test/reporter/errors-reported-multi/test
+++ b/zinc/src/sbt-test/reporter/errors-reported-multi/test
@@ -1,0 +1,5 @@
+-> compile
+> checkErrors 2
+> checkError 0 "required: String"
+> checkError 1 "required: Int"
+-> checkErrors 1

--- a/zinc/src/sbt-test/reporter/errors-reported/pending
+++ b/zinc/src/sbt-test/reporter/errors-reported/pending
@@ -1,3 +1,0 @@
--> compile
-
-> checkErrors 1

--- a/zinc/src/sbt-test/reporter/errors-reported/test
+++ b/zinc/src/sbt-test/reporter/errors-reported/test
@@ -1,0 +1,5 @@
+-> compile
+> checkErrors 1
+> checkError 0 "type mismatch"
+-> checkError 0 "nonexistent-message"
+-> checkErrors 5


### PR DESCRIPTION
Fixes #432

`-> compile` passes on any failure, and `checkErrors` / `checkError` saw nothing after it because a failed compile stores no analysis. Capture the problems from `CompileFailed` per project and let the check commands read them; the success path is unchanged.

```
-> compile
> checkErrors 1
> checkError 0 "type mismatch"
```

Un-pends `reporter/errors-reported`, adds `reporter/errors-reported-multi`, and documents the pattern in `contributing-docs/scripted_tests.md`. Partest-style `.check` file comparison is left as a follow-up.
