### PR TITLE
Analyze class files javac rewrote over untracked ones as products

### DIFF
--- a/zinc/src/main/scala/sbt/internal/inc/javac/AnalyzingJavaCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/javac/AnalyzingJavaCompiler.scala
@@ -141,12 +141,16 @@ final class AnalyzingJavaCompiler private[sbt] (
         log.error(InterfaceUtil.toSupplier(s"No output directory mapped for: $culpritPaths"))
       }
 
-      // Memoize the known class files in the Javac output location
-      val memo = for { case (Some(outputPath), srcs) <- chunks } yield {
+      // Snapshot the class files and their stamps in each Javac output location. This has to
+      // happen before javac runs: the stamps are what tells its products apart afterwards.
+      val snapshots = for { case (Some(outputPath), srcs) <- chunks } yield {
         val classFinder =
-          if (outputPath.toString.endsWith(".jar")) new JarClassFinder(outputPath)
+          if (outputPath.toString.endsWith(".jar"))
+            // MixedAnalyzingCompiler compiles through JarUtils.withPreviousJar, which moves an
+            // existing output jar aside, so this snapshot is always empty.
+            new JarClassFinder(outputPath)
           else new DirectoryClassFinder(outputPath)
-        (classFinder, classFinder.classes.pathsAndClose(), srcs)
+        new OutputSnapshot(classFinder, outputPath, classFinder.classes.stampsAndClose(), srcs)
       }
 
       // Record progress for java compilation
@@ -229,13 +233,19 @@ final class AnalyzingJavaCompiler private[sbt] (
       )
 
       timed(javaAnalysisPhase, log) {
-        for {
-          (classFinder, oldClasses, srcs) <- memo
-        } {
-          val classes = classFinder.classes
+        for (snapshot <- snapshots) {
+          val classes = snapshot.finder.classes
           try {
-            val newClasses = Set(classes.paths*) -- oldClasses
-            JavaAnalyze(newClasses.toSeq, srcs, log, output, finalJarOutput)(
+            // Class files javac rewrote over pre-existing untracked ones are products of this run
+            // too; a path-only diff would skip them and leave their API unread (sbt/zinc#586).
+            val newClasses = classes.changedSince(snapshot.stampsBefore)
+            val rewritten = newClasses.count(p => snapshot.stampsBefore.contains(p.toString))
+            if (rewritten > 0)
+              log.debug(InterfaceUtil.toSupplier(
+                s"Java analysis: $rewritten of ${newClasses.size} class files in " +
+                  s"${snapshot.path} were rewritten over pre-existing ones"
+              ))
+            JavaAnalyze(newClasses, snapshot.sources, log, output, finalJarOutput)(
               callback,
               loader,
               readAPI,
@@ -283,6 +293,14 @@ final class AnalyzingJavaCompiler private[sbt] (
       reporter: XReporter,
       log: XLogger
   ): Boolean = javac.run(sources, options, output, incToolOptions, reporter, log)
+
+  /** A javac output location, with the class files and stamps it held before javac ran. */
+  private final class OutputSnapshot(
+      val finder: ClassFinder,
+      val path: Path,
+      val stampsBefore: Map[String, ClassStamp],
+      val sources: Seq[VirtualFile]
+  )
 
   /** Time how long it takes to run various compilation tasks. */
   private def timed[T](label: String, log: Logger)(t: => T): T = {

--- a/zinc/src/main/scala/sbt/internal/inc/javac/ClassFinder.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/javac/ClassFinder.scala
@@ -18,17 +18,54 @@ import java.nio.file.FileSystem
 import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.attribute.{ BasicFileAttributes, FileTime }
 
 import sbt.io.PathFinder
 
 import scala.util.control.NonFatal
 
+/**
+ * Cheap identity of a class file. javac rewrites every class file it produces, so a rewritten
+ * file always gets a new time. Unlike `sbt.internal.inc.Stamp` this is never persisted; it is only
+ * compared within one javac run.
+ */
+final case class ClassStamp(lastModified: FileTime, size: Long)
+
+object ClassStamp {
+
+  /** None when the attributes cannot be read, e.g. the file vanished after being listed. */
+  def of(path: Path): Option[ClassStamp] =
+    try {
+      val attrs = Files.readAttributes(path, classOf[BasicFileAttributes])
+      Some(ClassStamp(attrs.lastModifiedTime, attrs.size))
+    } catch {
+      case NonFatal(_) => None
+    }
+}
+
 trait Classes {
   def paths: Seq[Path]
-  final def pathsAndClose(): Seq[Path] = {
-    try paths
+
+  /** Each class file with its stamp, or None when the attributes cannot be read. */
+  private def stamped: Seq[(Path, Option[ClassStamp])] = paths.map(p => p -> ClassStamp.of(p))
+
+  /** Stamps of `paths`, keyed by path string so jar entries compare across filesystem instances. */
+  def stamps: Map[String, ClassStamp] =
+    stamped.collect { case (p, Some(stamp)) => p.toString -> stamp }.toMap
+  final def stampsAndClose(): Map[String, ClassStamp] = {
+    try stamps
     finally close()
   }
+
+  /**
+   * The class files that are new or were rewritten since `old` was taken (sbt/zinc#586). Times are
+   * compared exactly, unlike `Stamp.equivStamp`: a spurious difference only adds a class file that
+   * JavaAnalyze maps to no compiled source and drops. A file whose stamp cannot be read counts as
+   * changed, as every listed file did before stamps existed.
+   */
+  def changedSince(old: Map[String, ClassStamp]): Seq[Path] =
+    stamped.collect { case (p, stamp) if stamp.forall(s => !old.get(p.toString).contains(s)) => p }
+
   def close(): Unit = ()
 }
 object Classes {

--- a/zinc/src/test/scala/sbt/inc/JavaPreexistingClassfileSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/JavaPreexistingClassfileSpec.scala
@@ -1,0 +1,139 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package sbt.inc
+
+import java.nio.file.{ Files, Path }
+import java.nio.file.attribute.FileTime
+import java.util.Optional
+
+import sbt.internal.inc.Analysis
+import sbt.io.IO
+import xsbti.compile.{ IncOptions, Inputs, Output }
+
+import scala.jdk.CollectionConverters.*
+
+/**
+ * sbt/zinc#586: javac products that already exist in the output directory but are not tracked by
+ * the previous analysis (shared output dir, lost analysis, or a run that failed after javac wrote
+ * them) must still be attributed to their source. An anonymous class regenerated alongside such a
+ * top-level class is filed under the top-level class name, so if that class's API is never read
+ * the callback crashes with "Failed to find name hashes".
+ */
+class JavaPreexistingClassfileSpec extends BaseCompilerSpec {
+  private val javaSrc =
+    """public class A {
+      |  public Runnable r() { return new Runnable() { public void run() {} }; }
+      |}
+      |""".stripMargin
+
+  // sbt's default: no pipelining, so no -Ypickle-java and no early output. Under -Ypickle-java
+  // scalac also reports the Java classes' API and products.
+  private val noPickleJava: Inputs => Inputs = in =>
+    in.withOptions(in.options.withScalacOptions(Array()).withEarlyOutput(Optional.empty[Output]()))
+
+  /** Stale class files are old; make sure the test never depends on timestamp resolution. */
+  private def backdate(dir: Path): Unit = {
+    val stream = Files.walk(dir)
+    try
+      stream.iterator.asScala.filter(_.toString.endsWith(".class")).foreach { p =>
+        val tenSecondsAgo = FileTime.fromMillis(Files.getLastModifiedTime(p).toMillis - 10000)
+        Files.setLastModifiedTime(p, tenSecondsAgo)
+      }
+    finally stream.close()
+  }
+
+  private def check(deleteAnonymous: Boolean, newInputs: Inputs => Inputs): Unit =
+    IO.withTemporaryDirectory { tempDir =>
+      val baseDir = tempDir.toPath
+      Files.write(baseDir.resolve("A.java"), javaSrc.getBytes("UTF-8"))
+      val projectSetup = ProjectSetup.simple(baseDir, Seq("A.java"))
+      val comp = projectSetup.createCompiler(scalaVersion, IncOptions.of())
+      try {
+        val classesDir = projectSetup.classesDir
+        val src = comp.sources.find(_.name == "A.java").get
+        // empty previous analysis, fresh output dir
+        val clean = comp.doCompile(newInputs).analysis.asInstanceOf[Analysis]
+        assertExists(classesDir.resolve("A.class"))
+        assertExists(classesDir.resolve("A$1.class"))
+        assert(clean.relations.products(src).size == 2)
+        // A.class stays on disk, untracked by the (again empty) previous analysis
+        if (deleteAnonymous) Files.delete(classesDir.resolve("A$1.class"))
+        backdate(classesDir)
+        val analysis = comp.doCompile(newInputs).analysis.asInstanceOf[Analysis]
+        assert(analysis.relations.products(src).nonEmpty, "A.java has no products")
+        assert(analysis.apis.internal.contains("A"))
+        assert(analysis.relations.products(src) == clean.relations.products(src))
+        assert(analysis.apis.internal.keySet == clean.apis.internal.keySet)
+        assert(analysis.apis.internalAPI("A").apiHash == clean.apis.internalAPI("A").apiHash)
+        assert(analysis.relations.allSources == clean.relations.allSources)
+      } finally comp.close()
+    }
+
+  it should "analyze a Java source whose top-level class file pre-exists untracked" in {
+    check(deleteAnonymous = true, noPickleJava)
+  }
+
+  it should "record products when all class files of a Java source pre-exist untracked" in {
+    check(deleteAnonymous = false, noPickleJava)
+  }
+
+  it should "not analyze the Scala products sharing the output directory" in {
+    IO.withTemporaryDirectory { tempDir =>
+      val baseDir = tempDir.toPath
+      Files.write(baseDir.resolve("A.java"), javaSrc.getBytes("UTF-8"))
+      Files.write(baseDir.resolve("S.scala"), "class S { def a = new A }".getBytes("UTF-8"))
+      val projectSetup = ProjectSetup.simple(baseDir, Seq("A.java", "S.scala"))
+      val comp = projectSetup.createCompiler(scalaVersion, IncOptions.of())
+      try {
+        val clean = comp.doCompile(noPickleJava).analysis.asInstanceOf[Analysis]
+        backdate(projectSetup.classesDir)
+        // scalac rewrites its own products before the javac snapshot is taken, so they must not
+        // be picked up as javac products of A.java.
+        val analysis = comp.doCompile(noPickleJava).analysis.asInstanceOf[Analysis]
+        assert(analysis.relations.allProducts == clean.relations.allProducts)
+        assert(analysis.apis.internal.keySet == clean.apis.internal.keySet)
+        val javaSource = comp.sources.find(_.name == "A.java").get
+        assert(analysis.relations.products(javaSource) == clean.relations.products(javaSource))
+      } finally comp.close()
+    }
+  }
+
+  it should "record products of a Java source compiled straight to a jar" in {
+    IO.withTemporaryDirectory { tempDir =>
+      val baseDir = tempDir.toPath
+      Files.write(baseDir.resolve("A.java"), javaSrc.getBytes("UTF-8"))
+      val projectSetup = ProjectSetup.simple(baseDir, Seq("A.java")).copy(outputToJar = true)
+      val comp = projectSetup.createCompiler(scalaVersion, IncOptions.of())
+      try {
+        val src = comp.sources.find(_.name == "A.java").get
+        val clean = comp.doCompile(noPickleJava).analysis.asInstanceOf[Analysis]
+        assert(clean.relations.products(src).size == 2)
+        assert(clean.apis.internal.contains("A"))
+        // javac writes into the jar itself, so JarClassFinder is what snapshots the output
+        assert(clean.relations.products(src).forall(_.id.contains("output.jar")))
+        // withPreviousJar moves the jar aside, so this snapshot is empty like the first one; the
+        // case guards that path rather than reproducing sbt/zinc#586.
+        val again = comp.doCompile(noPickleJava).analysis.asInstanceOf[Analysis]
+        assert(again.relations.products(src) == clean.relations.products(src))
+        assert(again.apis.internal.contains("A"))
+      } finally comp.close()
+    }
+  }
+
+  it should "analyze a pre-existing top-level Java class under -Ypickle-java" in {
+    check(deleteAnonymous = true, identity)
+  }
+
+  it should "record products of pre-existing Java class files under -Ypickle-java" in {
+    check(deleteAnonymous = false, identity)
+  }
+}

--- a/zinc/src/test/scala/sbt/internal/inc/javac/ClassFinderSpec.scala
+++ b/zinc/src/test/scala/sbt/internal/inc/javac/ClassFinderSpec.scala
@@ -1,0 +1,129 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package sbt.internal.inc.javac
+
+import java.net.URI
+import java.nio.file.{ FileSystems, Files, Path }
+import java.nio.file.attribute.FileTime
+import java.util.Collections
+
+import sbt.internal.inc.UnitSpec
+import sbt.io.IO
+
+class ClassFinderSpec extends UnitSpec {
+  private def write(p: Path, content: String): Path = {
+    Files.createDirectories(p.getParent)
+    Files.write(p, content.getBytes("UTF-8"))
+  }
+
+  /** Files that pre-exist a compile are old; do not depend on timestamp resolution. */
+  private def backdate(p: Path): Unit =
+    Files.setLastModifiedTime(p, FileTime.fromMillis(Files.getLastModifiedTime(p).toMillis - 10000))
+
+  "DirectoryClassFinder" should "report new and rewritten class files since a stamp snapshot" in {
+    IO.withTemporaryDirectory { dir =>
+      val base = dir.toPath
+      val kept = write(base.resolve("p/Kept.class"), "kept")
+      val rewritten = write(base.resolve("p/Rewritten.class"), "old")
+      val deleted = write(base.resolve("p/Deleted.class"), "deleted")
+      Seq(kept, rewritten, deleted).foreach(backdate)
+      val finder = new DirectoryClassFinder(base)
+
+      val before = finder.classes.stampsAndClose()
+      before.keySet shouldBe Set(kept, rewritten, deleted).map(_.toString)
+
+      write(rewritten, "new") // same size, new time
+      Files.delete(deleted)
+      val added = write(base.resolve("p/Added.class"), "added")
+
+      val after = finder.classes
+      try after.changedSince(before).toSet shouldBe Set(rewritten, added)
+      finally after.close()
+    }
+  }
+
+  it should "report every class file against an empty snapshot" in {
+    IO.withTemporaryDirectory { dir =>
+      val base = dir.toPath
+      val a = write(base.resolve("A.class"), "a")
+      val b = write(base.resolve("q/B.class"), "b")
+      write(base.resolve("q/notes.txt"), "not a class file")
+      val classes = new DirectoryClassFinder(base).classes
+      try classes.changedSince(Map.empty).toSet shouldBe Set(a, b)
+      finally classes.close()
+    }
+  }
+
+  it should "report a rewritten class file by size when its time did not change" in {
+    IO.withTemporaryDirectory { dir =>
+      val base = dir.toPath
+      val same = write(base.resolve("Same.class"), "one")
+      val time = FileTime.fromMillis(Files.getLastModifiedTime(same).toMillis - 10000)
+      Files.setLastModifiedTime(same, time)
+      val finder = new DirectoryClassFinder(base)
+      val before = finder.classes.stampsAndClose()
+
+      write(same, "longer content")
+      Files.setLastModifiedTime(same, time) // a coarse filesystem can hand out the same time
+
+      val after = finder.classes
+      try after.changedSince(before) shouldBe Seq(same)
+      finally after.close()
+    }
+  }
+
+  "Classes" should "treat a path whose attributes cannot be read as changed" in {
+    IO.withTemporaryDirectory { dir =>
+      val present = write(dir.toPath.resolve("Present.class"), "p")
+      val missing = dir.toPath.resolve("Missing.class")
+      val classes = new Classes { def paths = Seq(present, missing) }
+      ClassStamp.of(missing) shouldBe None
+      classes.stamps.keySet shouldBe Set(present.toString)
+      classes.changedSince(Map.empty) shouldBe Seq(present, missing)
+      classes.changedSince(classes.stamps) shouldBe Seq(missing)
+    }
+  }
+
+  "JarClassFinder" should "compare entries across separately opened jar filesystems" in {
+    IO.withTemporaryDirectory { dir =>
+      val jar = dir.toPath.resolve("out.jar")
+      val create = FileSystems.newFileSystem(
+        URI.create("jar:" + jar.toUri),
+        Collections.singletonMap("create", "true")
+      )
+      try write(create.getPath("/p/A.class"), "a")
+      finally create.close()
+      val finder = new JarClassFinder(jar)
+
+      val before = finder.classes.stampsAndClose()
+      before.keySet shouldBe Set("/p/A.class")
+
+      val unchanged = finder.classes
+      try unchanged.changedSince(before) shouldBe empty
+      finally unchanged.close()
+
+      val update = FileSystems.newFileSystem(jar, null.asInstanceOf[ClassLoader])
+      try write(update.getPath("/p/B.class"), "b")
+      finally update.close()
+
+      val after = finder.classes
+      try after.changedSince(before).map(_.toString) shouldBe Seq("/p/B.class")
+      finally after.close()
+    }
+  }
+
+  it should "have no stamps for a missing jar" in {
+    IO.withTemporaryDirectory { dir =>
+      new JarClassFinder(dir.toPath.resolve("missing.jar")).classes.stampsAndClose() shouldBe empty
+    }
+  }
+}


### PR DESCRIPTION
Fixes #586. Compiling a Java source whose class files already exist in the output directory but are untracked by the previous analysis crashed with `Failed to find name hashes`, or silently recorded no products at all. `AnalyzingJavaCompiler` analyzed only class files that were absent before javac ran, so the ones javac rewrote were skipped.

Change: snapshot a last-modified-plus-size stamp per class file and analyze every new or rewritten one; jar output is unaffected, as the output jar is moved aside while compiling. Under pipelining nothing is pruned, so every Java class file is now analyzed on each run (~0.4 ms each) and Java APIs become uniformly classfile-derived, which changes their API hashes once. Covered by `JavaPreexistingClassfileSpec` and `ClassFinderSpec`.
