### PR TITLE
Stabilize names of refinement-owned type parameters

### DIFF
--- a/internal/compiler-bridge-test/src/test/scala/sbt/internal/inc/ExtractAPISpecification.scala
+++ b/internal/compiler-bridge-test/src/test/scala/sbt/internal/inc/ExtractAPISpecification.scala
@@ -3,7 +3,7 @@ package internal
 package inc
 
 import xsbti.api._
-import xsbt.api.SameAPI
+import xsbt.api.{ SameAPI, ShowAPI }
 
 class ExtractAPISpecification
     extends UnitSpec
@@ -208,6 +208,58 @@ class ExtractAPISpecification
       SameAPI(macrosClass(macrosFromSource), macrosClass(macrosUnpickled)),
       "Macros API differs between compiling from source and unpickling"
     )
+  }
+
+  // Regression guard for https://github.com/sbt/sbt/issues/1079.
+  // A type parameter of a type alias declared inside a refinement (a type lambda) is named
+  // by `Symbol.fullName`, whose owner chain passes through the anonymous `<refinement>`
+  // class. The pickler rewrites that class's owner (scala/bug#6596), so the parameter is
+  // named `test.<refinement>.a` from source and `test.KleisliMonadReader.<refinement>.a`
+  // when unpickled, flipping the API hash of every class built on the type lambda.
+  it should "give stable names to type parameters owned by a refinement class (sbt/sbt#1079)" in {
+    val monadReader =
+      """|package test
+         |trait MonadReader[F[_], R] {
+         |  def ask: F[R]
+         |  def local[A](f: R => R)(fa: F[A]): F[A]
+         |}
+         |""".stripMargin
+    val kleisli =
+      """|package test
+         |case class Kleisli[F[_], R, A](run: R => F[A])
+         |trait KleisliMonadReader[F[_], R]
+         |    extends MonadReader[({ type l[a] = Kleisli[F, R, a] })#l, R] {
+         |  def ask: Kleisli[F, R, R] = ???
+         |  def local[A](f: R => R)(fa: Kleisli[F, R, A]): Kleisli[F, R, A] = ???
+         |}
+         |""".stripMargin
+    val impl =
+      """|package test
+         |class Impl extends KleisliMonadReader[Option, Int]
+         |""".stripMargin
+    // compile everything together (from source), then recompile `impl` alone,
+    // unpickling the support types from class files.
+    val apis = extractApisFromSrcs(List(monadReader, kleisli, impl), List(impl))
+    val _ :: _ :: implFromSource :: implUnpickled :: Nil = apis.toList: @unchecked
+    def implClass(as: Set[ClassLike]): ClassLike = as.find(_.name == "test.Impl").get
+    // nesting 10: the type lambda sits in a parent's type argument, deeper than
+    // DefaultShowAPI's default of 2 reaches.
+    def render(c: ClassLike): String = ShowAPI.showApi(c)(using 10)
+    val fromSource = implClass(implFromSource)
+    val unpickled = implClass(implUnpickled)
+    val fromSourceText = render(fromSource)
+    val unpickledText = render(unpickled)
+    assert(
+      SameAPI(fromSource, unpickled),
+      s"Impl API differs between compiling from source and unpickling:" +
+        s"\nfrom source:$fromSourceText\nunpickled:$unpickledText"
+    )
+    List("from source" -> fromSourceText, "unpickled" -> unpickledText).foreach {
+      case (label, rendered) =>
+        assert(rendered.contains("<refinement>.a"), s"$label:\n$rendered")
+        // no owner prefix survives; this test has a single, non-nested refinement
+        assert(!rendered.contains(".<refinement>"), s"$label:\n$rendered")
+    }
   }
 
   it should "represent a self type correctly" in {

--- a/internal/compiler-bridge/src/main/scala/xsbt/ExtractAPI.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ExtractAPI.scala
@@ -77,6 +77,9 @@ class ExtractAPI[GlobalType <: Global](
 
   private[this] val emptyStringArray = Array.empty[String]
 
+  // `<refinement>`, matched by refinementRelativeName below.
+  private[this] val refineClassName = tpnme.REFINE_CLASS_NAME.toString
+
   private[this] val allNonLocalClassSymbols = perRunCaches.newSet[Symbol]()
   private[this] val allNonLocalClassesInSrc = perRunCaches.newSet[xsbti.api.ClassLike]()
   private[this] val _mainClasses = perRunCaches.newSet[String]()
@@ -713,8 +716,20 @@ class ExtractAPI[GlobalType <: Global](
         debuglog(s"Renaming existential type variable ${s.fullName} to $rename")
         rename
       case None =>
-        s.fullName
+        refinementRelativeName(s)
     }
+
+  /**
+   * `s.fullName` cut at the outermost refinement class. The pickler rewrites that class's
+   * owner (scala/bug#6596), so the full name of a type parameter declared inside a refinement
+   * differs between typing from source and unpickling, flipping the API hash of every class
+   * built on it (sbt/sbt#1079). Names with no refinement in the owner chain are unchanged.
+   */
+  private def refinementRelativeName(s: Symbol): String = {
+    val full = s.fullName
+    val start = full.indexOf(refineClassName)
+    if (start < 0) full else full.substring(start)
+  }
 
   /* Representation for the self type of a class symbol `s`, or `emptyType` for an *unascribed* self variable (or no self variable at all).
      Only the self variable's explicitly ascribed type is relevant for incremental compilation. */

--- a/zinc/src/sbt-test/source-dependencies/type-lambda-refinement-owner/Consumer.scala
+++ b/zinc/src/sbt-test/source-dependencies/type-lambda-refinement-owner/Consumer.scala
@@ -1,0 +1,5 @@
+package test
+
+object Consumer {
+  def x = new Impl
+}

--- a/zinc/src/sbt-test/source-dependencies/type-lambda-refinement-owner/Impl.scala
+++ b/zinc/src/sbt-test/source-dependencies/type-lambda-refinement-owner/Impl.scala
@@ -1,0 +1,3 @@
+package test
+
+class Impl extends KleisliMonadReader[Option, Int]

--- a/zinc/src/sbt-test/source-dependencies/type-lambda-refinement-owner/Kleisli.scala
+++ b/zinc/src/sbt-test/source-dependencies/type-lambda-refinement-owner/Kleisli.scala
@@ -1,0 +1,9 @@
+package test
+
+case class Kleisli[F[_], R, A](run: R => F[A])
+
+trait KleisliMonadReader[F[_], R]
+    extends MonadReader[({ type l[a] = Kleisli[F, R, a] })#l, R] {
+  def ask: Kleisli[F, R, R] = ???
+  def local[A](f: R => R)(fa: Kleisli[F, R, A]): Kleisli[F, R, A] = ???
+}

--- a/zinc/src/sbt-test/source-dependencies/type-lambda-refinement-owner/MonadReader.scala
+++ b/zinc/src/sbt-test/source-dependencies/type-lambda-refinement-owner/MonadReader.scala
@@ -1,0 +1,6 @@
+package test
+
+trait MonadReader[F[_], R] {
+  def ask: F[R]
+  def local[A](f: R => R)(fa: F[A]): F[A]
+}

--- a/zinc/src/sbt-test/source-dependencies/type-lambda-refinement-owner/changes/Impl.scala
+++ b/zinc/src/sbt-test/source-dependencies/type-lambda-refinement-owner/changes/Impl.scala
@@ -1,0 +1,3 @@
+package test
+
+class Impl extends KleisliMonadReader[Option, Int] // comment-only change

--- a/zinc/src/sbt-test/source-dependencies/type-lambda-refinement-owner/test
+++ b/zinc/src/sbt-test/source-dependencies/type-lambda-refinement-owner/test
@@ -1,0 +1,21 @@
+# Regression guard for https://github.com/sbt/sbt/issues/1079.
+# `Impl` inherits from a trait applied to a type lambda, so its API mentions the
+# type parameter `a` of the alias declared inside the anonymous refinement class.
+# That parameter used to be named by its full owner chain, which the pickler
+# rewrites (scala/bug#6596), so both the name and the API hash differed between
+# compiling `KleisliMonadReader` from source and unpickling it. `Consumer` was
+# then invalidated on every comment-only edit of `Impl.scala`.
+
+> compile
+> checkRecompilations 0 test.MonadReader test.Kleisli test.KleisliMonadReader test.Impl test.Consumer
+
+# a comment-only change to Impl.scala
+
+$ copy-file changes/Impl.scala Impl.scala
+
+> compile
+
+# Impl alone is recompiled: its API is unchanged, so Consumer is not invalidated.
+
+> checkIterations 2
+> checkRecompilations 1 test.Impl


### PR DESCRIPTION
Fixes sbt/sbt#1079. `ExtractAPI.tparamID` names a type parameter by `Symbol.fullName`, so the parameter of a type lambda (`({ type l[a] = Kleisli[F, R, a] })#l`) is named through the anonymous `<refinement>` class, whose owner the pickler rewrites (scala/bug#6596). It comes out `test.<refinement>.a` from source and `test.KleisliMonadReader.<refinement>.a` when unpickled, so every class built on the type lambda re-hashes on each compile and invalidates its dependents.

Change: cut the name at the outermost `<refinement>`. Parameters with no refinement in their owner chain keep byte-identical names, so upgrading forces no full recompile.
