### PR TITLE
Treat a null associatedFile as absent on Scala 2.10

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/LocateClassFile.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/LocateClassFile.scala
@@ -31,7 +31,8 @@ abstract class LocateClassFile extends Compat with ClassName {
     else {
       val file = sym.associatedFile
 
-      if (file == NoAbstractFile) {
+      // Scala 2.10 returns null instead of NoAbstractFile when the file is not set
+      if (file == null || file == NoAbstractFile) {
         if (isTopLevelModule(sym)) {
           val linked = sym.companionClass
           if (linked == NoSymbol)

--- a/zinc/src/sbt-test/source-dependencies/default-arguments-separate-compilation-210/build.json
+++ b/zinc/src/sbt-test/source-dependencies/default-arguments-separate-compilation-210/build.json
@@ -1,0 +1,8 @@
+{
+  "projects": [
+    {
+      "name": "root",
+      "scalaVersion": "2.10.x"
+    }
+  ]
+}

--- a/zinc/src/sbt-test/source-dependencies/default-arguments-separate-compilation-210/changes/a1.scala
+++ b/zinc/src/sbt-test/source-dependencies/default-arguments-separate-compilation-210/changes/a1.scala
@@ -1,0 +1,11 @@
+package foo
+
+trait Foo {
+  def use(bar: Foo.Bar): Any
+}
+
+object Foo {
+  class Bar(a: Int = 0) {
+    override def toString(): String = s"Bar($a)"
+  }
+}

--- a/zinc/src/sbt-test/source-dependencies/default-arguments-separate-compilation-210/changes/a2.scala
+++ b/zinc/src/sbt-test/source-dependencies/default-arguments-separate-compilation-210/changes/a2.scala
@@ -1,0 +1,11 @@
+package foo
+
+trait Foo {
+  def use(bar: Foo.Bar): Any
+}
+
+object Foo {
+  class Bar(a: Int = 1, b: Int = 1) {
+    override def toString(): String = s"Bar($a, $b)"
+  }
+}

--- a/zinc/src/sbt-test/source-dependencies/default-arguments-separate-compilation-210/root/incOptions.properties
+++ b/zinc/src/sbt-test/source-dependencies/default-arguments-separate-compilation-210/root/incOptions.properties
@@ -1,0 +1,2 @@
+pipelining = false
+relationsDebug = true

--- a/zinc/src/sbt-test/source-dependencies/default-arguments-separate-compilation-210/root/test.scala
+++ b/zinc/src/sbt-test/source-dependencies/default-arguments-separate-compilation-210/root/test.scala
@@ -1,0 +1,12 @@
+package foo
+
+class FooImpl extends Foo {
+  def use(bar: Foo.Bar): Any = {
+    println(bar)
+  }
+}
+
+object Main extends App {
+  val user = new FooImpl()
+  user.use(new Foo.Bar(1))
+}

--- a/zinc/src/sbt-test/source-dependencies/default-arguments-separate-compilation-210/test
+++ b/zinc/src/sbt-test/source-dependencies/default-arguments-separate-compilation-210/test
@@ -1,0 +1,12 @@
+# Same scenario as default-arguments-separate-compilation, pinned to Scala 2.10.
+# On 2.10 `Symbol.associatedFile` is null rather than NoAbstractFile, so the bridge used to
+# drop the dependency on Foo.Bar and leave test.scala uncompiled against the new constructor.
+
+$ copy-file changes/a1.scala root/a.scala
+> run
+
+$ copy-file changes/a2.scala root/a.scala
+> run
+
+$ copy-file changes/a1.scala root/a.scala
+> run


### PR DESCRIPTION
Fixes sbt/zinc#604. On 2.10 `Symbol.associatedFile` returns `null` where 2.11+ return `NoAbstractFile`, so `LocateClassFile.classFile` hands back `Some((null, name))` instead of `None`. A null matches none of the typed patterns in `Dependency.processExternalDependency`, so it lands in the empty `case _` and the dependency is dropped: 2.10 never reaches the `findAssociatedFile` recovery added in #591, and #590 is still live there.

Change: treat null like `NoAbstractFile`. On 2.11+ `associatedFile` is never null, so the extra disjunct is dead code and behaviour is unchanged. The new scripted test is the 2.10 version of the #590 scenario and is the first end-to-end incremental coverage 2.10 has in this repo; it fails with `NoSuchMethodError: foo.Foo$Bar$.$lessinit$greater$default$2()` without the fix.

This only restores parity with 2.11+. `findAssociatedFile` tags output-dir hits `true` and classpath hits `false`, and only the `true` ones are registered, so jar-resident deps with an unset `associatedFile` stay dropped on every Scala version. Happy to file that separately.

Not re-enabling the commented-out `reporter.error` in that `case _`, even though this issue's title asks for it: it dereferences `at.getClass`, which is null in exactly this case, and the branch stays reachable for other `AbstractFile` subtypes.

Related to #1078: if you would rather drop 2.10 than carry this, say so there and I will close this instead.
