### PR TITLE
fix: pass Java sources to scalac when pipelining

### DIFF
--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -65,7 +65,8 @@ final case class Project(
     name: String,
     dependsOn: Option[Vector[String]] = None,
     in: Option[Path] = None,
-    scalaVersion: Option[String] = None
+    scalaVersion: Option[String] = None,
+    compileOrder: Option[String] = None
 )
 
 final case class Build(projects: Seq[Project])
@@ -125,6 +126,7 @@ class IncHandler(directory: Path, cacheDir: Path, scriptedLog: ManagedLogger, co
       val in: Path = p.in.getOrElse(directory / p.name)
       val version = switchScalaVersion(p.scalaVersion)
       val deps = p.dependsOn.toVector.flatten
+      val order = p.compileOrder.fold(CompileOrder.Mixed)(CompileOrder.valueOf)
       val project = ProjectStructure(
         p.name,
         deps,
@@ -134,7 +136,8 @@ class IncHandler(directory: Path, cacheDir: Path, scriptedLog: ManagedLogger, co
         lookupProject,
         version,
         compileToJar,
-        incrementalCompiler
+        incrementalCompiler,
+        order
       )
       buildStructure(p.name) = project
     }
@@ -149,11 +152,15 @@ class IncHandler(directory: Path, cacheDir: Path, scriptedLog: ManagedLogger, co
       given pathISOString: IsoString[Path] = IsoString.iso[Path](_.toString, Paths.get(_))
       given pathFormat: JsonFormat[Path] = isoStringFormat[Path](using pathISOString)
       given projectFormat: JsonFormat[Project] =
-        caseClass4(Project.apply, p => Some(p.name, p.dependsOn, p.in, p.scalaVersion))(
+        caseClass5(
+          Project.apply,
+          p => Some(p.name, p.dependsOn, p.in, p.scalaVersion, p.compileOrder)
+        )(
           "name",
           "dependsOn",
           "in",
           "scalaVersion",
+          "compileOrder",
         )
       given buildFormat: JsonFormat[Build] =
         caseClass1(Build.apply, b => Some(b.projects))("projects")
@@ -311,7 +318,8 @@ case class ProjectStructure(
     lookupProject: String => ProjectStructure,
     scalaVersion: String,
     compileToJar: Boolean,
-    incrementalCompiler: IncrementalCompilerImpl
+    incrementalCompiler: IncrementalCompilerImpl,
+    compileOrder: CompileOrder = CompileOrder.Mixed
 ) extends BridgeProviderSpecification {
   import scala.concurrent.ExecutionContext.Implicits._
   // This will test pipelining unless incOptions.properties overrides it
@@ -759,7 +767,7 @@ case class ProjectStructure(
       javacOptions = Array(),
       maxErrors,
       sourcePositionMappers = Array(),
-      CompileOrder.Mixed,
+      compileOrder,
       cs,
       setup,
       previousResult,

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -177,8 +177,11 @@ final class MixedAnalyzingCompiler(
           case _ => scalacOpts1
         }
         JarUtils.withPreviousJar(output) { (extraClasspath: Seq[Path]) =>
+          // Under pipelining javac is deferred, so its output is not on the classpath
+          // yet. Java sources must reach scalac regardless of the configured order,
+          // otherwise Scala sources cannot resolve symbols defined in Java.
           val sources =
-            if (config.currentSetup.order == Mixed) incSrc
+            if (config.currentSetup.order == Mixed || config.incOptions.pipelining) incSrc
             else scalaSrcs
 
           val cp0: Vector[VirtualFile] =

--- a/zinc/src/sbt-test/pipelining/java-then-scala-order/build.json
+++ b/zinc/src/sbt-test/pipelining/java-then-scala-order/build.json
@@ -1,0 +1,9 @@
+{
+  "projects": [
+    {
+      "name": "use",
+      "scalaVersion": "2.13.x",
+      "compileOrder": "JavaThenScala"
+    }
+  ]
+}

--- a/zinc/src/sbt-test/pipelining/java-then-scala-order/test
+++ b/zinc/src/sbt-test/pipelining/java-then-scala-order/test
@@ -1,0 +1,7 @@
+# https://github.com/sbt/sbt/issues/9707
+# Under pipelining javac is deferred, so Java sources must still be handed to
+# scalac even when compileOrder is not Mixed. Otherwise Scala sources in the
+# same project cannot resolve symbols defined in Java.
+> use/compile
+$ exists use/target/classes/ByteArrayAccess.class
+$ exists use/target/classes/Main.class

--- a/zinc/src/sbt-test/pipelining/java-then-scala-order/use/ByteArrayAccess.java
+++ b/zinc/src/sbt-test/pipelining/java-then-scala-order/use/ByteArrayAccess.java
@@ -1,0 +1,5 @@
+public class ByteArrayAccess {
+  public static int getInt(byte[] buf, int pos) {
+    return buf[pos];
+  }
+}

--- a/zinc/src/sbt-test/pipelining/java-then-scala-order/use/Main.scala
+++ b/zinc/src/sbt-test/pipelining/java-then-scala-order/use/Main.scala
@@ -1,0 +1,3 @@
+object Main {
+  def value: Int = ByteArrayAccess.getInt(Array[Byte](1, 2, 3), 0)
+}

--- a/zinc/src/sbt-test/pipelining/java-then-scala-order/use/incOptions.properties
+++ b/zinc/src/sbt-test/pipelining/java-then-scala-order/use/incOptions.properties
@@ -1,0 +1,1 @@
+pipelining = true


### PR DESCRIPTION
Fixes sbt/sbt#9707.

With pipelining javac is deferred, so its output is not on the classpath yet. But MixedAnalyzingCompiler only hands Java sources to scalac when compileOrder is Mixed, so JavaThenScala and ScalaThenJava fail to resolve Java symbols from the same project.

The scripted test needed a compileOrder field in build.json.