### PR TITLE
fix: Don't record JDK class files as library dependencies

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/Incremental.scala
@@ -806,24 +806,28 @@ private final class AnalysisCallback(
       sourceFile: VirtualFileRef,
       context: DependencyContext
   ): Unit = {
-    // TODO: handle library JARs and rt.jar.
-    val vf = converter.toVirtualFile(classFile)
-    externalAPI(onBinaryName, Some(vf)) match {
-      case Some(api) =>
-        // dependency is a product of a source in another project
-        val targetBinaryClassName = onBinaryName
-        externalSourceDependency(sourceClassName, targetBinaryClassName, api, context)
-      case None =>
-        // dependency is some other binary on the classpath.
-        // exclude dependency tracking with rt.jar, for example java.lang.String -> rt.jar.
-        if (!vf.id.endsWith("rt.jar")) {
-          externalLibraryDependency(
-            vf,
-            onBinaryName,
-            sourceFile,
-            context
-          )
-        }
+    // Classes the JDK itself provides (rt.jar, the jrt:/ image, ct.sym under -release) are never
+    // tracked as library dependencies, whichever FileConverter is in use (sbt/zinc#609).
+    if (!JdkClassFiles.isJdkPath(classFile)) {
+      val vf = converter.toVirtualFile(classFile)
+      externalAPI(onBinaryName, Some(vf)) match {
+        case Some(api) =>
+          // dependency is a product of a source in another project
+          val targetBinaryClassName = onBinaryName
+          externalSourceDependency(sourceClassName, targetBinaryClassName, api, context)
+        case None =>
+          // dependency is some other binary on the classpath. The check below predates the
+          // JDK test above and is kept unchanged for compatibility: it is redundant for JDK
+          // inputs now, and it also matches unrelated jars such as jfxrt.jar.
+          if (!vf.id.endsWith("rt.jar")) {
+            externalLibraryDependency(
+              vf,
+              onBinaryName,
+              sourceFile,
+              context
+            )
+          }
+      }
     }
   }
 

--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/MappedVirtualFile.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/MappedVirtualFile.scala
@@ -115,13 +115,7 @@ class MappedFileConverter(val rootPaths: Map[String, Path], allowMachinePath: Bo
         if (isDirectory) toDirectory(path, encodedPath)
         else MappedVirtualFile(encodedPath, rootPaths)
       case _ =>
-        def isCtSym =
-          path.getFileSystem
-            .provider()
-            .getScheme == "jar" && path.getFileSystem.toString.endsWith("ct.sym")
-        def isJrt = path.getFileSystem.provider().getScheme == "jrt"
-        if (isJrt || path.getFileName.toString == "rt.jar" || isCtSym)
-          DummyVirtualFile("rt.jar", path)
+        if (JdkClassFiles.isJdkPath(path)) DummyVirtualFile("rt.jar", path)
         else if (allowMachinePath) {
           val encodedPath = s"$path".replace('\\', '/')
           if (isDirectory) toDirectory(path, encodedPath)
@@ -184,4 +178,19 @@ object MappedFileConverter {
   def empty: MappedFileConverter = new MappedFileConverter(Map(), true)
   def apply(rootPaths: Map[String, Path], allowMachinePath: Boolean): MappedFileConverter =
     new MappedFileConverter(rootPaths, allowMachinePath)
+}
+
+/**
+ * Class files the JDK itself serves: rt.jar on JDK 8, the jrt:/ runtime image on JDK 9+, and the
+ * ct.sym signatures scalac reads under `-release`. Zinc never tracks them as library dependencies
+ * (sbt/zinc#609), so every FileConverter must treat them alike.
+ */
+private[sbt] object JdkClassFiles {
+  def isJdkPath(path: Path): Boolean = {
+    val fs = path.getFileSystem
+    val scheme = fs.provider().getScheme
+    scheme == "jrt" ||
+    (scheme == "jar" && fs.toString.endsWith("ct.sym")) ||
+    (path.getFileName != null && path.getFileName.toString == "rt.jar")
+  }
 }

--- a/zinc/src/test/scala/sbt/inc/JdkDepSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/JdkDepSpec.scala
@@ -1,0 +1,44 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package sbt.inc
+
+import sbt.internal.inc.{ Analysis, PlainVirtualFileConverter, StringVirtualFile }
+import sbt.io.IO
+
+class JdkDepSpec extends BaseCompilerSpec {
+  private val source =
+    """package pkg
+      |class UsesJdk extends java.util.ArrayList[String] {
+      |  def timestamp: java.sql.Timestamp = null
+      |}
+      |""".stripMargin
+
+  it should "not track JDK class files as library deps" in (IO.withTemporaryDirectory { tmp =>
+    // Unlike MappedFileConverter, this converter has no mapping for the JDK's own class files,
+    // which since JDK 9 are served from the `jrt:` runtime image. See sbt/zinc#609.
+    val converter = PlainVirtualFileConverter.converter
+    val proj = VirtualSubproject(tmp.toPath / "p", converterOverride = Some(converter))
+    val compiler = proj.setup.createCompiler()
+    try {
+      val result = compiler.compile(StringVirtualFile("src/pkg/UsesJdk.scala", source))
+      val analysis = result.analysis.asInstanceOf[Analysis]
+      // One representative class name is recorded per library file, and the JDK serves one
+      // file per class, so a tracked JDK class shows up here under its own name.
+      val libraryClasses = analysis.relations.libraryClassName._2s
+      libraryClasses.filter(_.startsWith("java.")) shouldBe Symbol("empty")
+      assert(
+        libraryClasses.exists(_.startsWith("scala.")),
+        s"expected the Scala library to be tracked, got $libraryClasses"
+      )
+    } finally compiler.close()
+  })
+}

--- a/zinc/src/test/scala/sbt/inc/TestProjectSetup.scala
+++ b/zinc/src/test/scala/sbt/inc/TestProjectSetup.scala
@@ -247,12 +247,14 @@ case class VirtualSubproject(
     baseDir: Path,
     projectDeps: List[VirtualSubproject] = Nil,
     externalDeps: List[Path] = Nil,
+    converterOverride: Option[FileConverter] = None,
 ) {
   private val sbtBoot = Paths.get(sys.props("user.home")).resolve(".sbt/boot")
   private val javaHome = Paths.get(sys.props("java.home"))
   private val rootPaths = Map("BASE" -> baseDir, "SBT_BOOT" -> sbtBoot, "JAVA_HOME" -> javaHome)
 
-  val converter = new MappedFileConverter(rootPaths, allowMachinePath = true)
+  val converter: FileConverter =
+    converterOverride.getOrElse(new MappedFileConverter(rootPaths, allowMachinePath = true))
 
   val classesDir = baseDir.resolve("classes")
   val outputJar = baseDir.resolve("target/output.jar")


### PR DESCRIPTION
Fixes #609.

Since JDK 9 the JDK's class files come from the `jrt:` image (or `ct.sym` under `-release`). `MappedFileConverter` maps them to a dummy `rt.jar` that Zinc drops, but `PlainVirtualFileConverter` (Gradle, Bloop) records them as library dependencies. Any classpath change then invalidates every source touching a JDK class:

    Invalidating '/modules/java.base/java/lang/String.class' because could not find class java.lang.String on the classpath.

**Change:** one predicate for "is this a JDK class file", applied in `AnalysisCallback.externalDependency`, so the rule holds for every `FileConverter`. `MappedFileConverter` behaviour (sbt, Mill) is unchanged.